### PR TITLE
PR-1: Centralize API error handling with RFC 7807 Problem Details baseline

### DIFF
--- a/inex/Exceptions/DomainExceptionTypes.cs
+++ b/inex/Exceptions/DomainExceptionTypes.cs
@@ -1,0 +1,142 @@
+namespace inex.Exceptions;
+
+/// <summary>
+/// Generic mapping abstraction: Any exception can define how it maps to HTTP.
+/// This decouples the handler from knowing specific exception types.
+/// 
+/// LEARNING: Strategy pattern allows exceptions to be responsible for their own mapping.
+/// </summary>
+public record HttpErrorMapping
+{
+    public int StatusCode { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string TypeUri { get; init; } = string.Empty;
+    public string? Detail { get; init; }
+    public Dictionary<string, object>? Extensions { get; init; }
+}
+
+/// <summary>
+/// Contract: Any exception can implement this to define its HTTP error mapping.
+/// The handler calls this without needing to know the specific exception type.
+/// </summary>
+public interface IHttpMappable
+{
+    /// <summary>
+    /// Convert this exception into its HTTP Problem Details representation.
+    /// </summary>
+    HttpErrorMapping ToHttpErrorMapping(bool isDevelopment);
+}
+
+/// <summary>
+/// Base class for domain exceptions that can be mapped to HTTP responses.
+/// Simpler than InExException if you want a fresh start with fewer dependencies.
+/// </summary>
+public abstract class DomainException : Exception, IHttpMappable
+{
+    protected DomainException(string message) : base(message) { }
+    protected DomainException(string message, Exception? inner) : base(message, inner) { }
+
+    public abstract HttpErrorMapping ToHttpErrorMapping(bool isDevelopment);
+}
+
+/// <summary>
+/// Example: Concrete domain exceptions that don't need MessageCode enum.
+/// Each exception type knows its own HTTP semantics.
+/// </summary>
+/// 
+public class ResourceNotFoundException : DomainException
+{
+    public string? ResourceType { get; }
+    public object? ResourceId { get; }
+
+    public ResourceNotFoundException(string message, string? resourceType = null, object? resourceId = null)
+        : base(message)
+    {
+        ResourceType = resourceType;
+        ResourceId = resourceId;
+    }
+
+    public override HttpErrorMapping ToHttpErrorMapping(bool isDevelopment) => new()
+    {
+        StatusCode = StatusCodes.Status404NotFound,
+        Title = "Resource Not Found",
+        TypeUri = "/errors/not-found",
+        Detail = Message,
+        Extensions = new()
+        {
+            { "resourceType", ResourceType ?? "Unknown" },
+            { "resourceId", ResourceId ?? string.Empty }
+        }
+    };
+}
+
+public class ValidationFailedException : DomainException
+{
+    public IList<string> Errors { get; }
+
+    public ValidationFailedException(string message, IList<string> errors)
+        : base(message)
+    {
+        Errors = errors;
+    }
+
+    public override HttpErrorMapping ToHttpErrorMapping(bool isDevelopment) => new()
+    {
+        StatusCode = StatusCodes.Status422UnprocessableEntity,
+        Title = "Validation Failed",
+        TypeUri = "/errors/validation-failed",
+        Detail = Message,
+        Extensions = new()
+        {
+            { "errors", Errors }
+        }
+    };
+}
+
+public class AccessDeniedException : DomainException
+{
+    public string? Reason { get; }
+
+    public AccessDeniedException(string message, string? reason = null)
+        : base(message)
+    {
+        Reason = reason;
+    }
+
+    public override HttpErrorMapping ToHttpErrorMapping(bool isDevelopment) => new()
+    {
+        StatusCode = StatusCodes.Status403Forbidden,
+        Title = "Access Denied",
+        TypeUri = "/errors/access-denied",
+        Detail = Message,
+        Extensions = Reason != null ? new() { { "reason", Reason } } : null
+    };
+}
+
+public class OperationNotSupportedException : DomainException
+{
+    public OperationNotSupportedException(string message)
+        : base(message) { }
+
+    public override HttpErrorMapping ToHttpErrorMapping(bool isDevelopment) => new()
+    {
+        StatusCode = StatusCodes.Status400BadRequest,
+        Title = "Operation Not Supported",
+        TypeUri = "/errors/not-supported",
+        Detail = Message
+    };
+}
+
+public class InternalServerErrorException : DomainException
+{
+    public InternalServerErrorException(string message, Exception? innerException = null)
+        : base(message, innerException) { }
+
+    public override HttpErrorMapping ToHttpErrorMapping(bool isDevelopment) => new()
+    {
+        StatusCode = StatusCodes.Status500InternalServerError,
+        Title = "Internal Server Error",
+        TypeUri = "/errors/internal-error",
+        Detail = isDevelopment ? Message : "An error occurred processing your request."
+    };
+}

--- a/inex/Exceptions/GlobalExceptionsHandler.cs
+++ b/inex/Exceptions/GlobalExceptionsHandler.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
+
+namespace inex.Exceptions;
+
+/// <summary>
+/// Generic global exception handler that converts all unhandled exceptions to RFC 7807 Problem Details.
+/// 
+/// SIMPLIFIED DESIGN: Handler is now decoupled from specific exception types.
+/// - Exceptions implement IHttpMappable to define their own mapping
+/// - Handler just orchestrates: log → map → serialize → respond
+/// - No dependency on InExException, MessageCode, or domain-specific classes
+/// 
+/// LEARNING: Strategy pattern (IHttpMappable) is more flexible than type-checking with switch.
+/// </summary>
+public class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+    private readonly IHostEnvironment _env;
+
+    public GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger, IHostEnvironment env)
+    {
+        _logger = logger;
+        _env = env;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        // Check if response has already started (cannot modify headers after body begins)
+        if (httpContext.Response.HasStarted)
+        {
+            _logger.LogWarning("Response has already started; cannot handle exception: {Message}", exception.Message);
+            return false;
+        }
+
+        // Log the full exception details using Serilog
+        _logger.LogError(exception, "Unhandled exception occurred");
+
+        // Get HTTP mapping: either from IHttpMappable or default
+        var errorMapping = GetErrorMapping(exception);
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = errorMapping.StatusCode,
+            Title = errorMapping.Title,
+            Type = errorMapping.TypeUri,
+            Detail = errorMapping.Detail,
+            Instance = httpContext.Request.Path
+        };
+
+        // Add standard correlation extension
+        problemDetails.Extensions["traceId"] = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+
+        // Add any domain-specific extensions
+        if (errorMapping.Extensions != null)
+        {
+            foreach (var ext in errorMapping.Extensions)
+            {
+                problemDetails.Extensions[ext.Key] = ext.Value;
+            }
+        }
+
+        // Include stack trace only in development
+        if (_env.IsDevelopment())
+        {
+            problemDetails.Extensions["stackTrace"] = exception.StackTrace;
+        }
+
+        // Set response headers
+        httpContext.Response.StatusCode = errorMapping.StatusCode;
+        httpContext.Response.ContentType = "application/problem+json";
+
+        // Write Problem Details as JSON
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Get HTTP error mapping from exception.
+    /// Priority:
+    /// 1. If exception is IHttpMappable, use its mapping
+    /// 2. Otherwise, use default mapping for unknown exception
+    /// </summary>
+    private HttpErrorMapping GetErrorMapping(Exception exception)
+    {
+        // If exception knows how to map itself, use that
+        if (exception is IHttpMappable mappable)
+        {
+            return mappable.ToHttpErrorMapping(_env.IsDevelopment());
+        }
+
+        // Default fallback for unknown exceptions
+        return new HttpErrorMapping
+        {
+            StatusCode = StatusCodes.Status500InternalServerError,
+            Title = "Internal Server Error",
+            TypeUri = "/errors/internal-error",
+            Detail = _env.IsDevelopment()
+                ? exception.Message
+                : "An unexpected error occurred. Please try again later."
+        };
+    }
+}

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -7,6 +7,8 @@ using inex.Services.Extensions;
 using System.Security.Cryptography;
 using System.Text;
 using Serilog;
+using Microsoft.AspNetCore.Mvc;
+using inex.Exceptions;
 
 // ── 1. BUILDER PHASE ──
 
@@ -31,6 +33,36 @@ try
             .Enrich.FromLogContext());
 
     builder.Services.AddInExServices(builder.Configuration);
+
+    // Register the global exception handler
+    builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
+    builder.Services.AddProblemDetails();
+
+    // Configure API behavior to return Problem Details for validation/model-binding errors
+    // This ensures 400 Bad Request for invalid input is also RFC 7807 compliant
+    builder.Services.Configure<ApiBehaviorOptions>(options =>
+    {
+        options.InvalidModelStateResponseFactory = context =>
+        {
+            var problemDetails = new ValidationProblemDetails(context.ModelState)
+            {
+                Type = "/errors/validation-failed",
+                Title = "One or more validation errors occurred.",
+                Status = StatusCodes.Status422UnprocessableEntity,
+                Detail = "See the errors field for details.",
+                Instance = context.HttpContext.Request.Path,
+            };
+
+            // Add trace ID for correlation
+            problemDetails.Extensions["traceId"] = System.Diagnostics.Activity.Current?.Id
+                ?? context.HttpContext.TraceIdentifier;
+
+            return new UnprocessableEntityObjectResult(problemDetails)
+            {
+                ContentTypes = { "application/problem+json" }
+            };
+        };
+    });
 
     var allowedOrigins = builder.Configuration.GetSection("AllowedOrigins").Get<string[]>();
     builder.Services.AddCors(options =>
@@ -74,9 +106,10 @@ try
         };
     });
 
+    app.UseExceptionHandler();
+
     if (app.Environment.IsDevelopment())
     {
-        app.UseDeveloperExceptionPage();
         app.UseInExSwagger();
     }
     else
@@ -85,7 +118,11 @@ try
         app.UseHttpsRedirection();
         app.EnsureDatabaseInitialized();
     }
-    app.UseStaticFiles();
+    // Avoid noisy warning when wwwroot is not present in this SPA-hosted setup.
+    if (Directory.Exists(app.Environment.WebRootPath))
+    {
+        app.UseStaticFiles();
+    }
     app.UseSpaStaticFiles();
 
     app.UseRouting();

--- a/inex/inex.xml
+++ b/inex/inex.xml
@@ -239,6 +239,90 @@
             </summary>
             <param name="ids">Transaction ids</param>
         </member>
+        <member name="T:inex.Exceptions.HttpErrorMapping">
+            <summary>
+            Generic mapping abstraction: Any exception can define how it maps to HTTP.
+            This decouples the handler from knowing specific exception types.
+            
+            LEARNING: Strategy pattern allows exceptions to be responsible for their own mapping.
+            </summary>
+        </member>
+        <member name="T:inex.Exceptions.IHttpMappable">
+            <summary>
+            Contract: Any exception can implement this to define its HTTP error mapping.
+            The handler calls this without needing to know the specific exception type.
+            </summary>
+        </member>
+        <member name="M:inex.Exceptions.IHttpMappable.ToHttpErrorMapping(System.Boolean)">
+            <summary>
+            Convert this exception into its HTTP Problem Details representation.
+            </summary>
+        </member>
+        <member name="T:inex.Exceptions.DomainException">
+            <summary>
+            Base class for domain exceptions that can be mapped to HTTP responses.
+            Simpler than InExException if you want a fresh start with fewer dependencies.
+            </summary>
+        </member>
+        <member name="T:inex.Exceptions.ResourceNotFoundException">
+            <summary>
+            Example: Concrete domain exceptions that don't need MessageCode enum.
+            Each exception type knows its own HTTP semantics.
+            </summary>
+            
+        </member>
+        <member name="T:inex.Exceptions.ExceptionMappingPolicy">
+            <summary>
+            Maps domain exceptions and message codes to HTTP status codes and RFC 7807 Problem Details.
+            This class serves as the contract for how errors are translated at the API boundary.
+            </summary>
+        </member>
+        <member name="M:inex.Exceptions.ExceptionMappingPolicy.MapMessageCodeToStatus(inex.Services.Models.Exceptions.MessageCode)">
+            <summary>
+            Mapping policy documentation:
+            - DataInvalid (101) -> 422 Unprocessable Entity (client data failed validation)
+            - NotFound (106) -> 404 Not Found (resource doesn't exist)
+            - AccessDenied (104) -> 403 Forbidden (user lacks permission)
+            - NotSupported (102) -> 400 Bad Request (operation not allowed)
+            - UploadFailed (103) -> 400 Bad Request (file upload issue)
+            - InternalError (105) -> 500 Internal Server Error (runtime/unexpected)
+            </summary>
+        </member>
+        <member name="M:inex.Exceptions.ExceptionMappingPolicy.GetPrimaryMessageCode(inex.Services.Models.Exceptions.InExException)">
+            <summary>
+            Get the primary (first/highest-severity) message code from an InExException.
+            </summary>
+        </member>
+        <member name="M:inex.Exceptions.ExceptionMappingPolicy.ExtractDomainErrors(inex.Services.Models.Exceptions.InExException)">
+            <summary>
+            Extract domain error details for extension field when multiple errors exist.
+            </summary>
+        </member>
+        <member name="M:inex.Exceptions.ExceptionMappingPolicy.MapExceptionTypeToStatus(System.Exception)">
+            <summary>
+            Map other exception types to status and title.
+            </summary>
+        </member>
+        <member name="T:inex.Exceptions.GlobalExceptionHandler">
+            <summary>
+            Generic global exception handler that converts all unhandled exceptions to RFC 7807 Problem Details.
+            
+            SIMPLIFIED DESIGN: Handler is now decoupled from specific exception types.
+            - Exceptions implement IHttpMappable to define their own mapping
+            - Handler just orchestrates: log → map → serialize → respond
+            - No dependency on InExException, MessageCode, or domain-specific classes
+            
+            LEARNING: Strategy pattern (IHttpMappable) is more flexible than type-checking with switch.
+            </summary>
+        </member>
+        <member name="M:inex.Exceptions.GlobalExceptionHandler.GetErrorMapping(System.Exception)">
+            <summary>
+            Get HTTP error mapping from exception.
+            Priority:
+            1. If exception is IHttpMappable, use its mapping
+            2. Otherwise, use default mapping for unknown exception
+            </summary>
+        </member>
         <member name="T:inex.Extensions.DatabaseExtensions">
             <summary>
             Extension methods for database initialization and migration


### PR DESCRIPTION
This PR introduces the foundational error-handling pipeline for the API by moving exception shaping out of controllers and into a centralized global handler path that returns RFC 7807 Problem Details responses.

- register centralized exception handling in Program.cs
- add ProblemDetails service and validation response shaping
- implement GlobalExceptionHandler with traceId extension
- introduce self-mapping domain exceptions via IHttpMappable
- standardize handled errors as application/problem+json
- guard static files middleware when wwwroot is absent

Ref #11 