### PR TITLE
feat(frontend): parse RFC 7807 errors in Redux thunks

### DIFF
--- a/inex/ClientApp/src/store/accounts/accounts-actions.ts
+++ b/inex/ClientApp/src/store/accounts/accounts-actions.ts
@@ -1,3 +1,4 @@
+import { parseApiError } from "../../utils/parseApiError";
 import { accountsActions } from "./accounts-slice";
 
 export const fetchAccounts = (mode: string) => {
@@ -6,7 +7,7 @@ export const fetchAccounts = (mode: string) => {
       const response = await fetch(`api/accounts?mode=${mode}`);
 
       if (!response.ok) {
-        throw new Error("Could not fetch accounts");
+        throw new Error(await parseApiError(response, "Could not fetch accounts"));
       }
       const responseJSON = await response.json();
 
@@ -16,7 +17,7 @@ export const fetchAccounts = (mode: string) => {
         })
       );
     } catch (error) {
-      // todo process error
+      dispatch(accountsActions.setError((error as Error).message));
     }
   };
 };

--- a/inex/ClientApp/src/store/accounts/accounts-slice.ts
+++ b/inex/ClientApp/src/store/accounts/accounts-slice.ts
@@ -3,12 +3,17 @@ import { createSlice } from "@reduxjs/toolkit";
 const accountsSlice = createSlice({
   name: "accounts",
   initialState: {
-    items: []
+    items: [],
+    error: null as string | null,
   },
   reducers: {
     setAccounts(state, action) {
       state.items = action.payload.items;
-    }    
+      state.error = null;
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
   },
 });
 

--- a/inex/ClientApp/src/store/budgetReport/budgetReport-actions.ts
+++ b/inex/ClientApp/src/store/budgetReport/budgetReport-actions.ts
@@ -1,3 +1,4 @@
+import { parseApiError } from "../../utils/parseApiError";
 import { budgetReportActions } from "./budgetReport-slice";
 
 export const fetchBudgetReport = (year: number, month: number, currency: string = "USD") => {
@@ -9,7 +10,7 @@ export const fetchBudgetReport = (year: number, month: number, currency: string 
             const response = await fetch(`api/reports/budget/comparison?year=${year}&month=${month}&currency=${currency}`);
 
             if (!response.ok) {
-                throw new Error("Failed to fetch budget report");
+                throw new Error(await parseApiError(response, "Failed to fetch budget report"));
             }
 
             const data = await response.json();

--- a/inex/ClientApp/src/store/budgets/budgets-actions.ts
+++ b/inex/ClientApp/src/store/budgets/budgets-actions.ts
@@ -1,19 +1,7 @@
+import { parseApiError } from "../../utils/parseApiError";
 import { budgetsActions } from "./budgets-slice";
 
 const API_BASE = "api/budgets";
-
-const handleResponseError = async (response: Response, defaultMessage: string) => {
-    try {
-        const errorData = await response.json();
-        if (errorData && errorData.messages && Array.isArray(errorData.messages)) {
-            const messages = errorData.messages.map((m: any) => m.text).join('; ');
-            if (messages) return new Error(messages);
-        }
-    } catch (e) {
-        // If parsing JSON fails, fall back to default message
-    }
-    return new Error(defaultMessage);
-};
 
 export const fetchBudgets = (year?: number, month?: number) => {
     return async (dispatch: any) => {
@@ -29,7 +17,7 @@ export const fetchBudgets = (year?: number, month?: number) => {
             const response = await fetch(url);
 
             if (!response.ok) {
-                throw await handleResponseError(response, "Could not fetch budgets");
+                throw new Error(await parseApiError(response, "Could not fetch budgets"));
             }
             const responseJSON = await response.json();
             
@@ -67,7 +55,7 @@ export const copyBudgets = (
             });
 
             if (!response.ok) {
-                throw await handleResponseError(response, "Could not copy budgets");
+                throw new Error(await parseApiError(response, "Could not copy budgets"));
             }
 
             // Trigger refresh in the view
@@ -103,10 +91,8 @@ export const createBudget = (
             });
 
             if (!response.ok) {
-                throw await handleResponseError(response, "Could not create a budget");
+                throw new Error(await parseApiError(response, "Could not create a budget"));
             }
-
-            const responseJSON = await response.json();
 
             // Trigger refresh in the view
             dispatch(budgetsActions.setLastUpdate());
@@ -142,7 +128,7 @@ export const updateBudget = (
             });
 
             if (!response.ok) {
-                throw await handleResponseError(response, "Could not update a budget");
+                throw new Error(await parseApiError(response, "Could not update a budget"));
             }
 
             // Trigger refresh in the view
@@ -164,7 +150,7 @@ export const deleteBudget = (id: number) => {
             });
 
             if (!response.ok) {
-                throw await handleResponseError(response, "Could not delete a budget");
+                throw new Error(await parseApiError(response, "Could not delete a budget"));
             }
 
             // Trigger refresh in the view

--- a/inex/ClientApp/src/store/categories/categories-actions.ts
+++ b/inex/ClientApp/src/store/categories/categories-actions.ts
@@ -1,3 +1,4 @@
+import { parseApiError } from "../../utils/parseApiError";
 import { categoriesActions } from "./categories-slice";
 
 const API_BASE = "api/categories";
@@ -9,7 +10,7 @@ export const fetchCategories = (mode: string) => {
             const response = await fetch(`${API_BASE}?mode=${mode}`);
 
             if (!response.ok) {
-                throw new Error("Could not fetch accounts");
+                throw new Error(await parseApiError(response, "Could not fetch categories"));
             }
             const responseJSON = await response.json();
 
@@ -38,7 +39,7 @@ export const createCategory = (name: string, description: string, isEnabled: boo
             });
 
             if (!response.ok) {
-                throw new Error("Could not create a transaction");
+                throw new Error(await parseApiError(response, "Could not create a category"));
             }
 
             const responseJSON = await response.json();
@@ -68,7 +69,7 @@ export const updateCategory = (id: number, name: string, description: string, is
             });
 
             if (!response.ok) {
-                throw new Error("Could not update a category");
+                throw new Error(await parseApiError(response, "Could not update a category"));
             }
 
             dispatch(categoriesActions.setLastUpdate());

--- a/inex/ClientApp/src/store/rates/rates-action.ts
+++ b/inex/ClientApp/src/store/rates/rates-action.ts
@@ -1,3 +1,4 @@
+import { parseApiError } from "../../utils/parseApiError";
 import { ratesActions } from "./rates-slice";
 
 export const fetchRatesForDate = (date: Date) => {
@@ -6,18 +7,18 @@ export const fetchRatesForDate = (date: Date) => {
       const response = await fetch(`api/exchange/rates/${date.toISOString().slice(0, 10)}`);
 
       if (!response.ok) {
-        throw new Error("Could not fetch transactions summary");
+        throw new Error(await parseApiError(response, "Could not fetch exchange rates"));
       }
-      
+
       const responseJSON = await response.json();
 
       dispatch(
         ratesActions.setRates({
           items: responseJSON.data || [],
         })
-      );      
+      );
     } catch (error) {
-      // todo process error
+      dispatch(ratesActions.setError((error as Error).message));
     }
   };
 };

--- a/inex/ClientApp/src/store/rates/rates-slice.ts
+++ b/inex/ClientApp/src/store/rates/rates-slice.ts
@@ -4,10 +4,15 @@ const ratesSlice = createSlice({
   name: "rates",
   initialState: {
     items: [],
+    error: null as string | null,
   },
   reducers: {
     setRates(state, action) {
       state.items = action.payload.items;
+      state.error = null;
+    },
+    setError(state, action) {
+      state.error = action.payload;
     },
   },
 });

--- a/inex/ClientApp/src/store/report/report-actions.ts
+++ b/inex/ClientApp/src/store/report/report-actions.ts
@@ -1,6 +1,6 @@
-import { reportActions } from "./report-slice";
-
 import moment from "moment";
+import { parseApiError } from "../../utils/parseApiError";
+import { reportActions } from "./report-slice";
 
 export const fetchReport = (type: string, filter: any) => {
   return async (dispatch: any) => {
@@ -16,7 +16,7 @@ export const fetchReport = (type: string, filter: any) => {
       const response = await fetch(`api/reports/${type}${filterStr}`);
 
       if (!response.ok) {
-        throw new Error(`Could not fetch ${type} report`);
+        throw new Error(await parseApiError(response, `Could not fetch ${type} report`));
       }
       const responseJSON = await response.json();
 
@@ -27,9 +27,10 @@ export const fetchReport = (type: string, filter: any) => {
           currency: responseJSON.metadata.currency,
         })
       );
-      dispatch(reportActions.setIsLoading({ isLoading: false }));
     } catch (error) {
-      // todo process error
+      dispatch(reportActions.setError((error as Error).message));
+    } finally {
+      dispatch(reportActions.setIsLoading({ isLoading: false }));
     }
   };
 };
@@ -42,7 +43,7 @@ export const fetchHistory = (year: number, currency: string = "USD") => {
       const response = await fetch(`api/reports/history/${year}?currency=${currency}`);
 
       if (!response.ok) {
-        throw new Error(`Could not fetch history report`);
+        throw new Error(await parseApiError(response, "Could not fetch history report"));
       }
       const responseJSON = await response.json();
 
@@ -51,9 +52,10 @@ export const fetchHistory = (year: number, currency: string = "USD") => {
           history: responseJSON.data || [],
         })
       );
-      dispatch(reportActions.setIsLoading({ isLoading: false }));
     } catch (error) {
-      // todo process error
+      dispatch(reportActions.setError((error as Error).message));
+    } finally {
+      dispatch(reportActions.setIsLoading({ isLoading: false }));
     }
   };
 };

--- a/inex/ClientApp/src/store/report/report-slice.ts
+++ b/inex/ClientApp/src/store/report/report-slice.ts
@@ -13,6 +13,7 @@ const reportSlice = createSlice({
     currency: "",
     filter: defaultFilter,
     isLoading: false,
+    error: null as string | null,
   },
   reducers: {
     setDetails(state, action) {
@@ -28,6 +29,9 @@ const reportSlice = createSlice({
     },
     setIsLoading(state, action) {
       state.isLoading = action.payload.isLoading;
+    },
+    setError(state, action) {
+      state.error = action.payload;
     },
   },
 });

--- a/inex/ClientApp/src/store/transactions/transactions-actions.ts
+++ b/inex/ClientApp/src/store/transactions/transactions-actions.ts
@@ -1,6 +1,7 @@
 import moment from "moment";
 import { Moment } from "moment";
 
+import { parseApiError } from "../../utils/parseApiError";
 import { transactionsActions } from "./transactions-slice";
 
 const API_BASE = "api/transactions";
@@ -22,7 +23,7 @@ export const fetchTransactions = (pageSize: number, pageNumber: number, filter: 
             const response = await fetch(`${API_BASE}?mode=active&pageSize=${pageSize}&pageNumber=${pageNumber}${filterStr}`);
 
             if (!response.ok) {
-                throw new Error("Could not fetch transactions");
+                throw new Error(await parseApiError(response, "Could not fetch transactions"));
             }
             const responseJSON = await response.json();
 
@@ -49,7 +50,7 @@ export const fetchTransactionsSummaryForAccounts = (ids: number[]) => {
             const response = await fetch(`api/accounts/details?mode=active&${idsStr.join("&")}`);
 
             if (!response.ok) {
-                throw new Error("Could not fetch transactions summary");
+                throw new Error(await parseApiError(response, "Could not fetch transactions summary"));
             }
             const responseJSON = await response.json();
 
@@ -75,12 +76,9 @@ export const createTransaction = (accountId: number, categoryId: number, amount:
             });
 
             if (!response.ok) {
-                throw new Error("Could not create a transaction");
+                throw new Error(await parseApiError(response, "Could not create a transaction"));
             }
 
-            const responseJSON = await response.json();
-            console.log(responseJSON);
-            
             dispatch(transactionsActions.setLastUpdate());
         } catch (error) {
             dispatch(transactionsActions.setError({ error: (error as Error).message }));
@@ -106,11 +104,8 @@ export const createTransfer = (accountFromId: number, accountToId: number, amoun
             });
 
             if (!response.ok) {
-                throw new Error("Could not create a transaction");
+                throw new Error(await parseApiError(response, "Could not create a transfer"));
             }
-
-            const responseJSON = await response.json();
-            console.log(responseJSON);
 
             dispatch(transactionsActions.setLastUpdate());
         } catch (error) {
@@ -137,7 +132,7 @@ export const updateTransaction = (id: number, accountId: number, categoryId: num
             });
 
             if (!response.ok) {
-                throw new Error("Could not update a transaction");
+                throw new Error(await parseApiError(response, "Could not update a transaction"));
             }
 
             dispatch(transactionsActions.setLastUpdate());
@@ -161,7 +156,7 @@ export const removeTransaction = (id: number) => {
             });
 
             if (!response.ok) {
-                throw new Error("Could not delete a transaction");
+                throw new Error(await parseApiError(response, "Could not delete a transaction"));
             }
 
             dispatch(transactionsActions.setLastUpdate());

--- a/inex/ClientApp/src/utils/parseApiError.ts
+++ b/inex/ClientApp/src/utils/parseApiError.ts
@@ -1,0 +1,37 @@
+export interface ProblemDetails {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+  traceId?: string;
+  /** Present on 422 ValidationProblemDetails */
+  errors?: Record<string, string[]>;
+  [key: string]: unknown;
+}
+
+/**
+ * Extracts a human-readable error message from an API error response.
+ * Detects RFC 7807 `application/problem+json` and prefers `detail` over `title`.
+ * Falls back to `defaultMessage` for non-ProblemDetails responses.
+ */
+export async function parseApiError(
+  response: Response,
+  defaultMessage: string
+): Promise<string> {
+  const ct = response.headers.get('content-type') ?? '';
+  if (ct.includes('application/problem+json')) {
+    try {
+      const problem: ProblemDetails = await response.json();
+      // For validation errors, flatten the field errors into the message
+      if (problem.errors) {
+        const fieldErrors = Object.values(problem.errors).flat().join('; ');
+        if (fieldErrors) return fieldErrors;
+      }
+      return problem.detail ?? problem.title ?? defaultMessage;
+    } catch {
+      // JSON parse failed — fall through to default
+    }
+  }
+  return defaultMessage;
+}


### PR DESCRIPTION
Aligns frontend error handling with the new ProblemDetails API contract.

Changes

- Add src/utils/parseApiError.ts — detects application/problem+json, extracts errors (validation field errors) → detail → title → fallback message
- Add error: string | null + setError reducer to 3 slices that were missing it: accounts, rates, report
- Update all 7 Redux action files to use parseApiError instead of generic new Error(...) or silent // todo process error catches
- Remove handleResponseError from budgets-actions (parsed old messages[].text envelope — no longer valid)
- Fix report-actions: move setIsLoading(false) into finally (was in try, so loading state leaked on error)

Ref #11 