### PR TITLE
feat(auth): AuthController, JWT middleware, ICurrentUserAccessor; rename response types

### DIFF
--- a/inex.Services/Models/Records/Auth/AuthResult.cs
+++ b/inex.Services/Models/Records/Auth/AuthResult.cs
@@ -1,0 +1,8 @@
+namespace inex.Services.Models.Records.Auth;
+
+/// <summary>
+/// Internal result returned by AuthService to the controller.
+/// The controller places RefreshToken in an httpOnly cookie and returns
+/// only AccessToken + ExpiresIn to the client.
+/// </summary>
+public record AuthResult(string AccessToken, string RefreshToken, int ExpiresIn);

--- a/inex.Services/Models/Records/Auth/UserProfileDTO.cs
+++ b/inex.Services/Models/Records/Auth/UserProfileDTO.cs
@@ -1,3 +1,3 @@
 namespace inex.Services.Models.Records.Auth;
 
-public record UserProfileDTO(int Id, string Username, string Email);
+public record UserProfile(int Id, string Username, string Email);

--- a/inex.Services/Models/Records/Base/ResponseCreateDTO.cs
+++ b/inex.Services/Models/Records/Base/ResponseCreateDTO.cs
@@ -1,6 +1,3 @@
-﻿namespace inex.Services.Models.Records.Base;
+namespace inex.Services.Models.Records.Base;
 
-public record ResponseCreateDTO : ResponseDTO
-{
-    public int Id { get; init; }
-}
+public record CreatedResponse(int Id);

--- a/inex.Services/Models/Records/Base/ResponseDTO.cs
+++ b/inex.Services/Models/Records/Base/ResponseDTO.cs
@@ -1,3 +1,3 @@
+// This file is intentionally empty — ResponseDTO base class was removed.
+// Types previously inheriting from it: CreatedResponse, ListResponse<T>, ResponseTransferDTO
 namespace inex.Services.Models.Records.Base;
-
-public record ResponseDTO;

--- a/inex.Services/Models/Records/Data/ResponseDataDTO.cs
+++ b/inex.Services/Models/Records/Data/ResponseDataDTO.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
-using inex.Services.Models.Records.Base;
+using System.Collections.Generic;
 
 namespace inex.Services.Models.Records.Data;
 
-public record ResponseDataDTO<T> : ResponseDTO
+public record ListResponse<T>
 {
     public IEnumerable<T> Data { get; init; } = new List<T>();
 }

--- a/inex.Services/Models/Records/Data/ResponseDataExDTO.cs
+++ b/inex.Services/Models/Records/Data/ResponseDataExDTO.cs
@@ -1,6 +1,6 @@
-﻿namespace inex.Services.Models.Records.Data;
+namespace inex.Services.Models.Records.Data;
 
-public record ResponseDataExDTO<T, K> : ResponseDataDTO<T>
+public record PagedResponse<T, TMeta> : ListResponse<T>
 {
-    public K Metadata { get; init; } = default!;
+    public TMeta Metadata { get; init; } = default!;
 }

--- a/inex.Services/Models/Records/Transaction/ResponseTransferDTO.cs
+++ b/inex.Services/Models/Records/Transaction/ResponseTransferDTO.cs
@@ -1,13 +1,6 @@
-﻿using inex.Services.Models.Records.Base;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace inex.Services.Models.Records.Transaction;
 
-public record ResponseTransferDTO : ResponseDTO
+public record ResponseTransferDTO
 {
     public int FromId { get; set; }
     public int ToId { get; set; }

--- a/inex.Services/Services/AccountService.cs
+++ b/inex.Services/Services/AccountService.cs
@@ -34,7 +34,7 @@ public class AccountService : InExService, IAccountService
         return Mapper.Map<AccountDetailsDTO>(account);
     }
 
-    public ResponseDataDTO<AccountDetailsDTO> Get(int userId, ActivityMode mode)
+    public ListResponse<AccountDetailsDTO> Get(int userId, ActivityMode mode)
     {
         IQueryable<Account> items = DbInEx.AccountRepository.Get(false, null, i => i.Currency).Where(i => i.UserId == userId).OrderBy(i => i.Name);
         return mode switch
@@ -46,11 +46,11 @@ public class AccountService : InExService, IAccountService
         };
     }
 
-    public ResponseDataDTO<AccountListDetailsDTO> GetDetails(int userId, IEnumerable<int> ids)
+    public ListResponse<AccountListDetailsDTO> GetDetails(int userId, IEnumerable<int> ids)
     {
         IQueryable<Account> items = DbInEx.AccountRepository.Get(false, null, i => i.Currency).Where(i => i.UserId == userId && ids.Contains(i.Id)).OrderBy(i => i.Name);
         var accountDetails = DbInEx.TransactionRepository.Get(true).Where(i => ids.Contains(i.AccountId)).GroupBy(i => i.AccountId).Select(i => new { AccountId = i.Key, Value = i.Sum(j => j.Value) });
-        ResponseDataDTO<AccountListDetailsDTO> resultDTO = BuildDataResponse<Account, AccountListDetailsDTO>(items);
+        ListResponse<AccountListDetailsDTO> resultDTO = BuildDataResponse<Account, AccountListDetailsDTO>(items);
         var values = accountDetails.ToDictionary(i => i.AccountId, i => i.Value);
         return resultDTO with
         {
@@ -58,9 +58,8 @@ public class AccountService : InExService, IAccountService
         };
     }
 
-    public async Task<ResponseCreateDTO> CreateAsync(AccountCreateDTO itemDTO, int userId)
+    public async Task<CreatedResponse> CreateAsync(AccountCreateDTO itemDTO, int userId)
     {
-        ResponseCreateDTO resultDTO = new ResponseCreateDTO();
         // create an item
         Account account = Mapper.Map<Account>(itemDTO);
         account.UserId = userId;
@@ -70,7 +69,7 @@ public class AccountService : InExService, IAccountService
         // apply changes to the database
         await DbInEx.SaveAsync();
 
-        return resultDTO with { Id = result.Entity.Id };
+        return new CreatedResponse(result.Entity.Id);
     }
 
     public async Task<AccountDetailsDTO> UpdateAsync(int id, AccountUpdateDTO itemDTO, int userId)

--- a/inex.Services/Services/Auth/AuthService.cs
+++ b/inex.Services/Services/Auth/AuthService.cs
@@ -28,7 +28,7 @@ public class AuthService : IAuthService
         _jwt = jwtOptions.Value;
     }
 
-    public async Task<TokenResponse> RegisterAsync(RegisterRequest request)
+    public async Task<AuthResult> RegisterAsync(RegisterRequest request)
     {
         var existing = await _userManager.FindByEmailAsync(request.Email);
         if (existing is not null)
@@ -50,7 +50,7 @@ public class AuthService : IAuthService
         return await IssueTokenPairAsync(user);
     }
 
-    public async Task<TokenResponse> LoginAsync(LoginRequest request)
+    public async Task<AuthResult> LoginAsync(LoginRequest request)
     {
         var user = await _userManager.FindByEmailAsync(request.Email);
         if (user is null || !await _userManager.CheckPasswordAsync(user, request.Password))
@@ -59,7 +59,7 @@ public class AuthService : IAuthService
         return await IssueTokenPairAsync(user);
     }
 
-    public async Task<TokenResponse> RefreshAsync(string refreshToken)
+    public async Task<AuthResult> RefreshAsync(string refreshToken)
     {
         var stored = await _db.RefreshTokens
             .Include(t => t.User)
@@ -76,8 +76,9 @@ public class AuthService : IAuthService
         {
             var withinGraceWindow = DateTime.UtcNow - stored.UsedAt.Value < TimeSpan.FromSeconds(_jwt.RefreshGraceWindowSeconds);
             if (withinGraceWindow && stored.ReplacedByToken is not null)
-                return new TokenResponse(
+                return new AuthResult(
                     _tokenService.GenerateAccessToken(stored.User),
+                    stored.ReplacedByToken,
                     _jwt.AccessTokenExpirySeconds);
 
             // Reuse outside grace window — potential token theft
@@ -99,8 +100,9 @@ public class AuthService : IAuthService
 
         await _db.SaveChangesAsync();
 
-        return new TokenResponse(
+        return new AuthResult(
             _tokenService.GenerateAccessToken(stored.User),
+            newRefreshToken,
             _jwt.AccessTokenExpirySeconds);
     }
 
@@ -118,7 +120,7 @@ public class AuthService : IAuthService
 
     // --- Private helpers ---
 
-    private async Task<TokenResponse> IssueTokenPairAsync(AppUser user)
+    private async Task<AuthResult> IssueTokenPairAsync(AppUser user)
     {
         var refreshToken = _tokenService.GenerateRefreshToken();
 
@@ -131,8 +133,9 @@ public class AuthService : IAuthService
 
         await _db.SaveChangesAsync();
 
-        return new TokenResponse(
+        return new AuthResult(
             _tokenService.GenerateAccessToken(user),
+            refreshToken,
             _jwt.AccessTokenExpirySeconds);
     }
 

--- a/inex.Services/Services/Auth/IAuthService.cs
+++ b/inex.Services/Services/Auth/IAuthService.cs
@@ -4,8 +4,8 @@ namespace inex.Services.Services.Auth;
 
 public interface IAuthService
 {
-    Task<TokenResponse> RegisterAsync(RegisterRequest request);
-    Task<TokenResponse> LoginAsync(LoginRequest request);
-    Task<TokenResponse> RefreshAsync(string refreshToken);
+    Task<AuthResult> RegisterAsync(RegisterRequest request);
+    Task<AuthResult> LoginAsync(LoginRequest request);
+    Task<AuthResult> RefreshAsync(string refreshToken);
     Task RevokeAsync(string refreshToken);
 }

--- a/inex.Services/Services/Auth/TokenService.cs
+++ b/inex.Services/Services/Auth/TokenService.cs
@@ -27,6 +27,7 @@ public class TokenService : ITokenService
         {
             new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
             new Claim(JwtRegisteredClaimNames.Email, user.Email!),
+            new Claim(JwtRegisteredClaimNames.Name, user.UserName!),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
         };

--- a/inex.Services/Services/Base/IAccountService.cs
+++ b/inex.Services/Services/Base/IAccountService.cs
@@ -10,8 +10,8 @@ namespace inex.Services.Services.Base;
 public interface IAccountService : IInExService
 {
     Task<AccountDetailsDTO> GetAsync(int id);
-    ResponseDataDTO<AccountDetailsDTO> Get(int userId, ActivityMode mode);
-    ResponseDataDTO<AccountListDetailsDTO> GetDetails(int userId, IEnumerable<int> ids);
-    Task<ResponseCreateDTO> CreateAsync(AccountCreateDTO itemDTO, int userId);
+    ListResponse<AccountDetailsDTO> Get(int userId, ActivityMode mode);
+    ListResponse<AccountListDetailsDTO> GetDetails(int userId, IEnumerable<int> ids);
+    Task<CreatedResponse> CreateAsync(AccountCreateDTO itemDTO, int userId);
     Task<AccountDetailsDTO> UpdateAsync(int id, AccountUpdateDTO itemDTO, int userId);
 }

--- a/inex.Services/Services/Base/IBudgetReportService.cs
+++ b/inex.Services/Services/Base/IBudgetReportService.cs
@@ -7,5 +7,5 @@ namespace inex.Services.Services.Base;
 
 public interface IBudgetReportService
 {
-    Task<ResponseDataExDTO<BudgetComparisonDTO, ReportMetadataDTO>> GetBudgetComparison(int userId, int year, int month, string currency);
+    Task<PagedResponse<BudgetComparisonDTO, ReportMetadataDTO>> GetBudgetComparison(int userId, int year, int month, string currency);
 }

--- a/inex.Services/Services/Base/IBudgetService.cs
+++ b/inex.Services/Services/Base/IBudgetService.cs
@@ -8,8 +8,8 @@ namespace inex.Services.Services.Base;
 public interface IBudgetService : IInExService
 {
     Task<BudgetDetailsDTO> GetAsync(int id);
-    ResponseDataDTO<BudgetDetailsDTO> Get(int userId, int? year = null, int? month = null);
-    Task<ResponseCreateDTO> CreateAsync(BudgetCreateDTO itemDTO, int userId);
+    ListResponse<BudgetDetailsDTO> Get(int userId, int? year = null, int? month = null);
+    Task<CreatedResponse> CreateAsync(BudgetCreateDTO itemDTO, int userId);
     Task<BudgetDetailsDTO> UpdateAsync(int id, BudgetUpdateDTO itemDTO, int userId);
     Task CopyBudgetsAsync(int userId, int sourceYear, int sourceMonth, int targetYear, int targetMonth);
 }

--- a/inex.Services/Services/Base/ICategoryService.cs
+++ b/inex.Services/Services/Base/ICategoryService.cs
@@ -9,7 +9,7 @@ namespace inex.Services.Services.Base;
 public interface ICategoryService : IInExService
 {
     Task<CategoryDetailsDTO> GetAsync(int id);
-    ResponseDataDTO<CategoryDetailsDTO> Get(int userId, ActivityMode mode);
-    Task<ResponseCreateDTO> CreateAsync(CategoryCreateDTO itemDTO, int userId);
+    ListResponse<CategoryDetailsDTO> Get(int userId, ActivityMode mode);
+    Task<CreatedResponse> CreateAsync(CategoryCreateDTO itemDTO, int userId);
     Task<CategoryDetailsDTO> UpdateAsync(int id, CategoryUpdateDTO itemDTO, int userId);
 }

--- a/inex.Services/Services/Base/IExchangeRateService.cs
+++ b/inex.Services/Services/Base/IExchangeRateService.cs
@@ -7,6 +7,6 @@ namespace inex.Services.Services.Base;
 
 public interface IExchangeRateService
 {
-    Task<ResponseDataDTO<ExchangeRateDTO>> Get(int userId, DateTime date, string baseCurrency = "");
-    Task<ResponseDataDTO<ExchangeRateDTO>> Get(int userId, DateTime start, DateTime end, string baseCurrency = "");
+    Task<ListResponse<ExchangeRateDTO>> Get(int userId, DateTime date, string baseCurrency = "");
+    Task<ListResponse<ExchangeRateDTO>> Get(int userId, DateTime start, DateTime end, string baseCurrency = "");
 }

--- a/inex.Services/Services/Base/IReportService.cs
+++ b/inex.Services/Services/Base/IReportService.cs
@@ -9,6 +9,6 @@ namespace inex.Services.Services.Base;
 
 public interface IReportService : IDisposable
 {
-    Task<ResponseDataExDTO<CategoryListDetailsDTO, ReportMetadataDTO>> GetCategoriesReportData(int userId, string currency, IDictionary<string, string> filters);
-    Task<ResponseDataDTO<MonthlyHistoryDTO>> GetMonthlyHistory(int userId, int year, string currency);
+    Task<PagedResponse<CategoryListDetailsDTO, ReportMetadataDTO>> GetCategoriesReportData(int userId, string currency, IDictionary<string, string> filters);
+    Task<ListResponse<MonthlyHistoryDTO>> GetMonthlyHistory(int userId, int year, string currency);
 }

--- a/inex.Services/Services/Base/ITransactionService.cs
+++ b/inex.Services/Services/Base/ITransactionService.cs
@@ -10,9 +10,9 @@ namespace inex.Services.Services.Base;
 public interface ITransactionService : IInExService
 {
     Task<TransactionDetailsDTO> GetAsync(int id);
-    ResponseDataDTO<TransactionDetailsDTO> Get(int userId, ActivityMode mode, IDictionary<string, string> filters);
-    ResponseDataExDTO<TransactionDetailsDTO, PaginationMetadataDTO> Get(int userId, ActivityMode mode, int pageSize, int pageNumber, IDictionary<string, string> filters);
-    Task<ResponseCreateDTO> CreateAsync(TransactionCreateDTO itemDTO, int userId);
+    ListResponse<TransactionDetailsDTO> Get(int userId, ActivityMode mode, IDictionary<string, string> filters);
+    PagedResponse<TransactionDetailsDTO, PaginationMetadataDTO> Get(int userId, ActivityMode mode, int pageSize, int pageNumber, IDictionary<string, string> filters);
+    Task<CreatedResponse> CreateAsync(TransactionCreateDTO itemDTO, int userId);
     Task<ResponseTransferDTO> CreateAsync(TransferCreateDTO itemDTO, int userId);
     Task<TransactionDetailsDTO> UpdateAsync(int id, TransactionUpdateDTO itemDTO, int userId);
 }

--- a/inex.Services/Services/Base/Service.cs
+++ b/inex.Services/Services/Base/Service.cs
@@ -28,7 +28,7 @@ public abstract class Service : IDisposable
 
     #endregion Properties
 
-    public ResponseDataExDTO<K, PaginationMetadataDTO> BuildPaginatedDataResponse<T, K>(IQueryable<T> items, int pageSize, int pageNumber)
+    public PagedResponse<K, PaginationMetadataDTO> BuildPaginatedDataResponse<T, K>(IQueryable<T> items, int pageSize, int pageNumber)
     {
         int total = items.Count();
 
@@ -38,27 +38,27 @@ public abstract class Service : IDisposable
             items = items.Skip(metadata.SkippedItems).Take(metadata.PerPage);
         }
 
-        return new ResponseDataExDTO<K, PaginationMetadataDTO>
+        return new PagedResponse<K, PaginationMetadataDTO>
         {
             Metadata = metadata,
             Data = Mapper.Map<IEnumerable<K>>(items)
         };
     }
 
-    public ResponseDataExDTO<K, ReportMetadataDTO> BuildReportDataResponse<T, K>(IEnumerable<T> items, string name, string currency, DateTime? start = null, DateTime? end = null)
+    public PagedResponse<K, ReportMetadataDTO> BuildReportDataResponse<T, K>(IEnumerable<T> items, string name, string currency, DateTime? start = null, DateTime? end = null)
     {
         int total = items.Count();
 
-        return new ResponseDataExDTO<K, ReportMetadataDTO>
+        return new PagedResponse<K, ReportMetadataDTO>
         {
             Metadata = new ReportMetadataDTO { Name = name, Currency = currency, Start = start, End = end },
             Data = Mapper.Map<IEnumerable<K>>(items)
         };
     }
 
-    public ResponseDataDTO<K> BuildDataResponse<T, K>(IEnumerable<T> items)
+    public ListResponse<K> BuildDataResponse<T, K>(IEnumerable<T> items)
     {
-        return new ResponseDataDTO<K>
+        return new ListResponse<K>
         {
             Data = Mapper.Map<IEnumerable<K>>(items)
         };

--- a/inex.Services/Services/BudgetReportService.cs
+++ b/inex.Services/Services/BudgetReportService.cs
@@ -35,7 +35,7 @@ public class BudgetReportService : Service, IBudgetReportService
         _categoryService = categoryService;
     }
 
-    public async Task<ResponseDataExDTO<BudgetComparisonDTO, ReportMetadataDTO>> GetBudgetComparison(int userId, int year, int month, string currency)
+    public async Task<PagedResponse<BudgetComparisonDTO, ReportMetadataDTO>> GetBudgetComparison(int userId, int year, int month, string currency)
     {
         // 1. Get Budgets for the month
         var budgetsResponse = _budgetService.Get(userId, year, month);
@@ -175,7 +175,7 @@ public class BudgetReportService : Service, IBudgetReportService
             });
         }
 
-        return new ResponseDataExDTO<BudgetComparisonDTO, ReportMetadataDTO>
+        return new PagedResponse<BudgetComparisonDTO, ReportMetadataDTO>
         {
             Data = comparisonList,
             Metadata = new ReportMetadataDTO

--- a/inex.Services/Services/BudgetService.cs
+++ b/inex.Services/Services/BudgetService.cs
@@ -33,15 +33,14 @@ public class BudgetService : InExService, IBudgetService
         return Mapper.Map<BudgetDetailsDTO>(budget);
     }
 
-    public ResponseDataDTO<BudgetDetailsDTO> Get(int userId, int? year = null, int? month = null)
+    public ListResponse<BudgetDetailsDTO> Get(int userId, int? year = null, int? month = null)
     {
         IQueryable<Budget> items = DbInEx.BudgetRepository.Get(false, i => i.UserId == userId && (!year.HasValue || i.Year == year) && (!month.HasValue || i.Month == month), i => i.BudgetCategories).OrderBy(i => i.Name);
         return BuildDataResponse<Budget, BudgetDetailsDTO>(items.ToList());
     }
 
-    public async Task<ResponseCreateDTO> CreateAsync(BudgetCreateDTO itemDTO, int userId)
+    public async Task<CreatedResponse> CreateAsync(BudgetCreateDTO itemDTO, int userId)
     {
-        ResponseCreateDTO resultDTO = new ResponseCreateDTO();
         // create an item
         Budget budget = Mapper.Map<Budget>(itemDTO);
 
@@ -80,7 +79,7 @@ public class BudgetService : InExService, IBudgetService
             await DbInEx.SaveAsync();
         }
 
-        return resultDTO with { Id = result.Entity.Id };
+        return new CreatedResponse(result.Entity.Id);
     }
 
     public async Task<BudgetDetailsDTO> UpdateAsync(int id, BudgetUpdateDTO itemDTO, int userId)

--- a/inex.Services/Services/CategoryService.cs
+++ b/inex.Services/Services/CategoryService.cs
@@ -34,7 +34,7 @@ public class CategoryService : InExService, ICategoryService
         return Mapper.Map<CategoryDetailsDTO>(category);
     }
 
-    public ResponseDataDTO<CategoryDetailsDTO> Get(int userId, ActivityMode mode)
+    public ListResponse<CategoryDetailsDTO> Get(int userId, ActivityMode mode)
     {
         IQueryable<Category> items = DbInEx.CategoryRepository.Get(false).Where(i => i.UserId == userId).OrderBy(i => i.Name);
         return mode switch
@@ -46,9 +46,8 @@ public class CategoryService : InExService, ICategoryService
         };
     }
 
-    public async Task<ResponseCreateDTO> CreateAsync(CategoryCreateDTO itemDTO, int userId)
+    public async Task<CreatedResponse> CreateAsync(CategoryCreateDTO itemDTO, int userId)
     {
-        ResponseCreateDTO resultDTO = new ResponseCreateDTO();
         // create an item
         Category category = Mapper.Map<Category>(itemDTO);
         category.UserId = userId;
@@ -58,7 +57,7 @@ public class CategoryService : InExService, ICategoryService
         // apply changes to the database
         await DbInEx.SaveAsync();
 
-        return resultDTO with { Id = result.Entity.Id };
+        return new CreatedResponse(result.Entity.Id);
     }
 
     public async Task<CategoryDetailsDTO> UpdateAsync(int id, CategoryUpdateDTO itemDTO, int userId)

--- a/inex.Services/Services/ExchangeRateService.cs
+++ b/inex.Services/Services/ExchangeRateService.cs
@@ -40,7 +40,7 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// Future dates are silently skipped.
     /// </summary>
     /// <exception cref="ValidationFailedException">Thrown when <paramref name="end"/> is before <paramref name="start"/>.</exception>
-    public async Task<ResponseDataDTO<ExchangeRateDTO>> Get(int userId, DateTime start, DateTime end, string baseCurrency = "")
+    public async Task<ListResponse<ExchangeRateDTO>> Get(int userId, DateTime start, DateTime end, string baseCurrency = "")
     {
         if (end < start)
         {
@@ -74,7 +74,7 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// Returns exchange rates for a single <paramref name="date"/>.
     /// Delegates to the range overload with <c>start == end == date</c>.
     /// </summary>
-    public Task<ResponseDataDTO<ExchangeRateDTO>> Get(int userId, DateTime date, string baseCurrency = "")
+    public Task<ListResponse<ExchangeRateDTO>> Get(int userId, DateTime date, string baseCurrency = "")
         => Get(userId, date, date, baseCurrency);
 
     #endregion Public Interface

--- a/inex.Services/Services/ReportService.cs
+++ b/inex.Services/Services/ReportService.cs
@@ -32,7 +32,7 @@ public class ReportService : Service, IReportService
 
     #region Public Interface
 
-    public async Task<ResponseDataDTO<MonthlyHistoryDTO>> GetMonthlyHistory(int userId, int year, string currency)
+    public async Task<ListResponse<MonthlyHistoryDTO>> GetMonthlyHistory(int userId, int year, string currency)
     {
         var start = new DateTime(year, 1, 1);
         var end = new DateTime(year, 12, 31);
@@ -93,10 +93,10 @@ public class ReportService : Service, IReportService
             });
         }
 
-        return new ResponseDataDTO<MonthlyHistoryDTO> { Data = result };
+        return new ListResponse<MonthlyHistoryDTO> { Data = result };
     }
 
-    public async Task<ResponseDataExDTO<CategoryListDetailsDTO, ReportMetadataDTO>> GetCategoriesReportData(int userId, string currency, IDictionary<string, string> filters)
+    public async Task<PagedResponse<CategoryListDetailsDTO, ReportMetadataDTO>> GetCategoriesReportData(int userId, string currency, IDictionary<string, string> filters)
     {
         DateTime start = FilterHelper.GetDateTimeFromFilter(filters, nameof(ReportMetadataDTO.Start), new DateTime(2014, 01, 01));
         DateTime end = FilterHelper.GetDateTimeFromFilter(filters, nameof(ReportMetadataDTO.End), new DateTime(2014, 01, 01));
@@ -106,7 +106,7 @@ public class ReportService : Service, IReportService
         IEnumerable<CategoryDetailsDTO> categories = _categoryService.Get(userId, ActivityMode.ACTIVE).Data.Where(i => !i.IsSystem);
         IEnumerable<TransactionDetailsDTO> transactions = _transactionService.Get(userId, ActivityMode.ACTIVE, filters).Data;
 
-        ResponseDataExDTO<CategoryListDetailsDTO, ReportMetadataDTO> resultDTO = BuildReportDataResponse<CategoryDetailsDTO, CategoryListDetailsDTO>(categories, "Расходы по категориям", currency, start, end);
+        PagedResponse<CategoryListDetailsDTO, ReportMetadataDTO> resultDTO = BuildReportDataResponse<CategoryDetailsDTO, CategoryListDetailsDTO>(categories, "Расходы по категориям", currency, start, end);
 
         var categoryValues = new Dictionary<int, decimal>();
         foreach (TransactionDetailsDTO transaction in transactions)

--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -35,21 +35,20 @@ public class TransactionService : InExService, ITransactionService
         return Mapper.Map<TransactionDetailsDTO>(transaction);
     }
 
-    public ResponseDataDTO<TransactionDetailsDTO> Get(int userId, ActivityMode mode, IDictionary<string, string> filters)
+    public ListResponse<TransactionDetailsDTO> Get(int userId, ActivityMode mode, IDictionary<string, string> filters)
     {
         IQueryable<Transaction> items = GetTransactions(userId, mode, filters);
         return BuildDataResponse<Transaction, TransactionDetailsDTO>(items);
     }
 
-    public ResponseDataExDTO<TransactionDetailsDTO, PaginationMetadataDTO> Get(int userId, ActivityMode mode, int pageSize, int pageNumber, IDictionary<string, string> filters)
+    public PagedResponse<TransactionDetailsDTO, PaginationMetadataDTO> Get(int userId, ActivityMode mode, int pageSize, int pageNumber, IDictionary<string, string> filters)
     {
         IQueryable<Transaction> items = GetTransactions(userId, mode, filters);
         return BuildPaginatedDataResponse<Transaction, TransactionDetailsDTO>(items, pageSize, pageNumber);
     }
 
-    public async Task<ResponseCreateDTO> CreateAsync(TransactionCreateDTO itemDTO, int userId)
+    public async Task<CreatedResponse> CreateAsync(TransactionCreateDTO itemDTO, int userId)
     {
-        ResponseCreateDTO resultDTO = new ResponseCreateDTO();
 
         Transaction transaction = Mapper.Map<Transaction>(itemDTO);
         transaction.UserId = userId;
@@ -61,7 +60,7 @@ public class TransactionService : InExService, ITransactionService
 
         await DbInEx.SaveAsync();
 
-        return resultDTO with { Id = result.Entity.Id };
+        return new CreatedResponse(result.Entity.Id);
     }
 
     public async Task<ResponseTransferDTO> CreateAsync(TransferCreateDTO itemDTO, int userId)

--- a/inex/Controllers/AccountsController.cs
+++ b/inex/Controllers/AccountsController.cs
@@ -1,5 +1,6 @@
 using inex.Controllers.Base;
 using inex.Services.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using inex.Services.Models.Enums;
 using inex.Services.Models.Records.Account;
 using inex.Services.Models.Records.Base;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class AccountsController : ApiControllerBase
@@ -60,11 +62,11 @@ public class AccountsController : ApiControllerBase
     /// <returns>List of accounts</returns>
     [HttpGet]
     [Route(GetAllRoute)]
-    [ProducesResponseType(typeof(ResponseDataDTO<AccountDetailsDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ListResponse<AccountDetailsDTO>), StatusCodes.Status200OK)]
     public ActionResult List(string mode)
     {
         ActivityMode activityMode = mode.ToEnum(ActivityMode.ALL);
-        ResponseDataDTO<AccountDetailsDTO> resultsDTO = _accountService.Get(CurrentUserId, activityMode);
+        ListResponse<AccountDetailsDTO> resultsDTO = _accountService.Get(CurrentUserId, activityMode);
         return Ok(resultsDTO);
     }
 
@@ -73,10 +75,10 @@ public class AccountsController : ApiControllerBase
     /// <returns>List of accounts with status</returns>
     [HttpGet]
     [Route(GetStatusRoute)]
-    [ProducesResponseType(typeof(ResponseDataDTO<AccountListDetailsDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ListResponse<AccountListDetailsDTO>), StatusCodes.Status200OK)]
     public ActionResult DetailsForList([FromQuery] IEnumerable<int> ids)
     {
-        ResponseDataDTO<AccountListDetailsDTO> resultsDTO = _accountService.GetDetails(CurrentUserId, ids);
+        ListResponse<AccountListDetailsDTO> resultsDTO = _accountService.GetDetails(CurrentUserId, ids);
         return Ok(resultsDTO);
     }
 
@@ -85,10 +87,10 @@ public class AccountsController : ApiControllerBase
     /// <returns>Id of a new account</returns>
     [HttpPost]
     [Route(PostAddRoute)]
-    [ProducesResponseType(typeof(ResponseCreateDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreatedResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Add(AccountCreateDTO itemDTO)
     {
-        ResponseCreateDTO resultDTO = await _accountService.CreateAsync(itemDTO, CurrentUserId);
+        CreatedResponse resultDTO = await _accountService.CreateAsync(itemDTO, CurrentUserId);
         return Ok(resultDTO);
     }
 

--- a/inex/Controllers/AuthController.cs
+++ b/inex/Controllers/AuthController.cs
@@ -1,0 +1,120 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using inex.Services.Models.Records.Auth;
+using inex.Services.Options;
+using inex.Services.Services.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace inex.Controllers;
+
+[Route("api/auth")]
+[Produces("application/json")]
+[ApiController]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+    private readonly JwtOptions _jwt;
+    private readonly IHostEnvironment _env;
+
+    public AuthController(IAuthService authService, IOptions<JwtOptions> jwtOptions, IHostEnvironment env)
+    {
+        _authService = authService;
+        _jwt = jwtOptions.Value;
+        _env = env;
+    }
+
+    /// <summary>Register a new user account</summary>
+    [HttpPost("register")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<TokenResponse>> Register([FromBody] RegisterRequest request)
+    {
+        var result = await _authService.RegisterAsync(request);
+        SetRefreshTokenCookie(result.RefreshToken);
+        return Ok(new TokenResponse(result.AccessToken, result.ExpiresIn));
+    }
+
+    /// <summary>Authenticate with email and password</summary>
+    [HttpPost("login")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<TokenResponse>> Login([FromBody] LoginRequest request)
+    {
+        var result = await _authService.LoginAsync(request);
+        SetRefreshTokenCookie(result.RefreshToken);
+        return Ok(new TokenResponse(result.AccessToken, result.ExpiresIn));
+    }
+
+    /// <summary>
+    /// Issue a new access token using the httpOnly refresh token cookie.
+    /// Implements token rotation — the old refresh token is invalidated.
+    /// </summary>
+    [HttpPost("refresh")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<TokenResponse>> Refresh()
+    {
+        var refreshToken = Request.Cookies["refreshToken"];
+        if (string.IsNullOrEmpty(refreshToken))
+            return Unauthorized();
+
+        var result = await _authService.RefreshAsync(refreshToken);
+        SetRefreshTokenCookie(result.RefreshToken);
+        return Ok(new TokenResponse(result.AccessToken, result.ExpiresIn));
+    }
+
+    /// <summary>Revoke the current session and clear the refresh token cookie</summary>
+    [HttpPost("logout")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> Logout()
+    {
+        var refreshToken = Request.Cookies["refreshToken"];
+        if (!string.IsNullOrEmpty(refreshToken))
+            await _authService.RevokeAsync(refreshToken);
+
+        ClearRefreshTokenCookie();
+        return NoContent();
+    }
+
+    /// <summary>Return the profile of the currently authenticated user from JWT claims</summary>
+    [HttpGet("me")]
+    [Authorize]
+    [ProducesResponseType(typeof(UserProfile), StatusCodes.Status200OK)]
+    public ActionResult<UserProfile> Me()
+    {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var email = User.FindFirstValue(JwtRegisteredClaimNames.Email)!;
+        var username = User.FindFirstValue(JwtRegisteredClaimNames.Name)!;
+
+        return Ok(new UserProfile(userId, username, email));
+    }
+
+    // ── Private helpers ──
+
+    private void SetRefreshTokenCookie(string token)
+    {
+        Response.Cookies.Append("refreshToken", token, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = !_env.IsDevelopment(),
+            SameSite = SameSiteMode.Strict,
+            Expires = DateTimeOffset.UtcNow.AddDays(_jwt.RefreshTokenExpiryDays),
+            // Scope cookie to auth endpoints — frontend never needs to read it
+            Path = "/api/auth"
+        });
+    }
+
+    private void ClearRefreshTokenCookie()
+    {
+        Response.Cookies.Delete("refreshToken", new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = !_env.IsDevelopment(),
+            SameSite = SameSiteMode.Strict,
+            Path = "/api/auth"
+        });
+    }
+}

--- a/inex/Controllers/Base/ApiControllerBase.cs
+++ b/inex/Controllers/Base/ApiControllerBase.cs
@@ -1,3 +1,4 @@
+using inex.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using inex.Services.Models.Enums;
@@ -18,5 +19,6 @@ public class ApiControllerBase : ControllerBase
         return date.Value;
     }
 
-    protected virtual int CurrentUserId => 1;
+    protected int CurrentUserId =>
+        HttpContext.RequestServices.GetRequiredService<ICurrentUserAccessor>().UserId;
 }

--- a/inex/Controllers/BudgetsController.cs
+++ b/inex/Controllers/BudgetsController.cs
@@ -1,4 +1,5 @@
 using inex.Controllers.Base;
+using Microsoft.AspNetCore.Authorization;
 using inex.Services.Models.Records.Budget;
 using inex.Services.Models.Records.Base;
 using inex.Services.Models.Records.Data;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class BudgetsController : ApiControllerBase
@@ -60,7 +62,7 @@ public class BudgetsController : ApiControllerBase
     [ProducesResponseType(typeof(IEnumerable<BudgetDetailsDTO>), StatusCodes.Status200OK)]
     public ActionResult List(int? year = null, int? month = null)
     {
-        ResponseDataDTO<BudgetDetailsDTO> resultsDTO = _budgetService.Get(CurrentUserId, year, month);
+        ListResponse<BudgetDetailsDTO> resultsDTO = _budgetService.Get(CurrentUserId, year, month);
         return Ok(resultsDTO);
     }
 
@@ -69,10 +71,10 @@ public class BudgetsController : ApiControllerBase
     /// <returns>Id of a new budget</returns>
     [HttpPost]
     [Route(PostAddRoute)]
-    [ProducesResponseType(typeof(ResponseCreateDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreatedResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Add(BudgetCreateDTO itemDTO)
     {
-        ResponseCreateDTO resultDTO = await _budgetService.CreateAsync(itemDTO, CurrentUserId);
+        CreatedResponse resultDTO = await _budgetService.CreateAsync(itemDTO, CurrentUserId);
         return Ok(resultDTO);
     }
 

--- a/inex/Controllers/CategoriesController.cs
+++ b/inex/Controllers/CategoriesController.cs
@@ -1,5 +1,6 @@
 using inex.Controllers.Base;
 using inex.Services.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using inex.Services.Models.Enums;
 using inex.Services.Models.Records.Base;
 using inex.Services.Models.Records.Category;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class CategoriesController : ApiControllerBase
@@ -63,7 +65,7 @@ public class CategoriesController : ApiControllerBase
     public ActionResult List(string mode)
     {
         ActivityMode activityMode = mode.ToEnum(ActivityMode.ALL);
-        ResponseDataDTO<CategoryDetailsDTO> resultsDTO = _categoryService.Get(CurrentUserId, activityMode);
+        ListResponse<CategoryDetailsDTO> resultsDTO = _categoryService.Get(CurrentUserId, activityMode);
         return Ok(resultsDTO);
     }
 
@@ -72,10 +74,10 @@ public class CategoriesController : ApiControllerBase
     /// <returns>Id of a new category</returns>
     [HttpPost]
     [Route(PostAddRoute)]
-    [ProducesResponseType(typeof(ResponseCreateDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreatedResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Add(CategoryCreateDTO itemDTO)
     {
-        ResponseCreateDTO resultDTO = await _categoryService.CreateAsync(itemDTO, CurrentUserId);
+        CreatedResponse resultDTO = await _categoryService.CreateAsync(itemDTO, CurrentUserId);
         return Ok(resultDTO);
     }
 

--- a/inex/Controllers/ExchangeRateController.cs
+++ b/inex/Controllers/ExchangeRateController.cs
@@ -1,4 +1,5 @@
 using inex.Controllers.Base;
+using Microsoft.AspNetCore.Authorization;
 using inex.Services.Models.Records.Data;
 using inex.Services.Models.Records.ExchangeRate;
 using inex.Services.Services.Base;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class ExchangeRateController : ApiControllerBase
@@ -42,7 +44,7 @@ public class ExchangeRateController : ApiControllerBase
     [ProducesResponseType(typeof(IEnumerable<ExchangeRateDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult> Get(DateTime date)
     {
-        ResponseDataDTO<ExchangeRateDTO> resultsDTO = await _exchangeService.Get(CurrentUserId, date);
+        ListResponse<ExchangeRateDTO> resultsDTO = await _exchangeService.Get(CurrentUserId, date);
         return Ok(resultsDTO);
     }
 

--- a/inex/Controllers/ReportBudgetController.cs
+++ b/inex/Controllers/ReportBudgetController.cs
@@ -1,4 +1,5 @@
 using inex.Controllers.Base;
+using Microsoft.AspNetCore.Authorization;
 using inex.Services.Models.Records.Data;
 using inex.Services.Models.Records.Report;
 using inex.Services.Services.Base;
@@ -9,6 +10,7 @@ using System.Threading.Tasks;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class ReportBudgetController : ApiControllerBase
@@ -35,7 +37,7 @@ public class ReportBudgetController : ApiControllerBase
     /// <returns>Budget comparison report</returns>
     [HttpGet]
     [Route(GetComparisonRoute)]
-    [ProducesResponseType(typeof(ResponseDataExDTO<BudgetComparisonDTO, ReportMetadataDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedResponse<BudgetComparisonDTO, ReportMetadataDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult> GetComparison(int year, int month, string currency = "USD")
     {
         var result = await _budgetReportService.GetBudgetComparison(CurrentUserId, year, month, currency);

--- a/inex/Controllers/ReportsController.cs
+++ b/inex/Controllers/ReportsController.cs
@@ -1,5 +1,6 @@
 using inex.Controllers.Base;
 using inex.Services.Helpers;
+using Microsoft.AspNetCore.Authorization;
 using inex.Services.Models.Records.Category;
 using inex.Services.Models.Records.Data;
 using inex.Services.Models.Records.Report;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class ReportsController : ApiControllerBase
@@ -40,11 +42,11 @@ public class ReportsController : ApiControllerBase
     /// <returns>Category report details</returns>
     [HttpGet]
     [Route(GetCategoryReportRoute)]
-    [ProducesResponseType(typeof(ResponseDataExDTO<CategoryListDetailsDTO, ReportMetadataDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedResponse<CategoryListDetailsDTO, ReportMetadataDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult> GetCategoryReport(string currency = "USD", string filter = "")
     {
         IDictionary<string, string> filters = FilterHelper.ParseFilter(filter, ReportMetadataDTO.FieldsList);
-        ResponseDataExDTO<CategoryListDetailsDTO, ReportMetadataDTO> resultsDTO = await _reportService.GetCategoriesReportData(CurrentUserId, currency, filters);
+        PagedResponse<CategoryListDetailsDTO, ReportMetadataDTO> resultsDTO = await _reportService.GetCategoriesReportData(CurrentUserId, currency, filters);
         return Ok(resultsDTO);
     }
 
@@ -54,7 +56,7 @@ public class ReportsController : ApiControllerBase
     /// <returns>Monthly history details</returns>
     [HttpGet]
     [Route(GetMonthlyHistoryRoute)]
-    [ProducesResponseType(typeof(ResponseDataDTO<MonthlyHistoryDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ListResponse<MonthlyHistoryDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult> GetMonthlyHistory(int year, string currency = "USD")
     {
         return Ok(await _reportService.GetMonthlyHistory(CurrentUserId, year, currency));

--- a/inex/Controllers/TransactionsController.cs
+++ b/inex/Controllers/TransactionsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
@@ -15,6 +16,7 @@ using inex.Services.Helpers;
 namespace inex.Controllers;
 
 [Route(RoutePrefix)]
+[Authorize]
 [Produces("application/json")]
 [ApiController]
 public class TransactionsController : ApiControllerBase
@@ -70,7 +72,7 @@ public class TransactionsController : ApiControllerBase
     {
         IDictionary<string, string> filters = FilterHelper.ParseFilter(filter, TransactionDetailsDTO.FieldsList);
         ActivityMode activityMode = mode.ToEnum(ActivityMode.ALL);
-        ResponseDataExDTO<TransactionDetailsDTO, PaginationMetadataDTO> resultsDTO = _transactionService.Get(CurrentUserId, activityMode, pageSize, pageNumber, filters);
+        PagedResponse<TransactionDetailsDTO, PaginationMetadataDTO> resultsDTO = _transactionService.Get(CurrentUserId, activityMode, pageSize, pageNumber, filters);
         return Ok(resultsDTO);
     }
 
@@ -79,10 +81,10 @@ public class TransactionsController : ApiControllerBase
     /// <returns>Id of a new transaction</returns>
     [HttpPost]
     [Route(PostAddRoute)]
-    [ProducesResponseType(typeof(ResponseCreateDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreatedResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Add(TransactionCreateDTO itemDTO)
     {
-        ResponseCreateDTO resultDTO = await _transactionService.CreateAsync(itemDTO, CurrentUserId);
+        CreatedResponse resultDTO = await _transactionService.CreateAsync(itemDTO, CurrentUserId);
         return Ok(resultDTO);
     }
 

--- a/inex/Extensions/SwaggerExtensions.cs
+++ b/inex/Extensions/SwaggerExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
@@ -22,6 +23,32 @@ public static class SwaggerExtensions
             var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
             var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
             options.IncludeXmlComments(xmlPath);
+
+            // Add JWT bearer security definition so Swagger UI has the "Authorize" button
+            options.AddSecurityDefinition(JwtBearerDefaults.AuthenticationScheme, new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = JwtBearerDefaults.AuthenticationScheme,
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Description = "Paste the access token from /api/auth/login"
+            });
+
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = JwtBearerDefaults.AuthenticationScheme
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            });
         });
 
         return services;

--- a/inex/Infrastructure/HttpContextCurrentUserAccessor.cs
+++ b/inex/Infrastructure/HttpContextCurrentUserAccessor.cs
@@ -1,0 +1,20 @@
+using System.Security.Claims;
+
+namespace inex.Infrastructure;
+
+/// <summary>
+/// Reads the current user ID from the JWT claims stored in HttpContext.
+/// Registered as Scoped — one instance per request.
+/// </summary>
+public class HttpContextCurrentUserAccessor : ICurrentUserAccessor
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public HttpContextCurrentUserAccessor(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public int UserId =>
+        int.Parse(_httpContextAccessor.HttpContext!.User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+}

--- a/inex/Infrastructure/ICurrentUserAccessor.cs
+++ b/inex/Infrastructure/ICurrentUserAccessor.cs
@@ -1,0 +1,10 @@
+namespace inex.Infrastructure;
+
+/// <summary>
+/// Abstracts the current user identity so controllers and services
+/// don't depend directly on HttpContext or Claims — easier to test.
+/// </summary>
+public interface ICurrentUserAccessor
+{
+    int UserId { get; }
+}

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -1,15 +1,20 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using inex.Data;
-using inex.Extensions;
-using inex.Services.Extensions;
 using System.Security.Cryptography;
 using System.Text;
-using Serilog;
+using inex.Data;
+using inex.Data.Models;
+using inex.Extensions;
+using inex.Infrastructure;
+using inex.Services.Extensions;
+using inex.Services.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
-using inex.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using inex.Exceptions;
+using Serilog;
 
 // ── 1. BUILDER PHASE ──
 
@@ -34,6 +39,46 @@ try
             .Enrich.FromLogContext());
 
     builder.Services.AddInExServices(builder.Configuration);
+
+    // ── Identity (AddIdentityCore = UserManager + RoleManager only, no Cookie auth scheme) ──
+    builder.Services
+        .AddIdentityCore<AppUser>(options =>
+        {
+            options.Password.RequiredLength = 8;
+            options.Password.RequireUppercase = false;
+            options.Password.RequireNonAlphanumeric = false;
+            options.Password.RequireDigit = true;
+        })
+        .AddRoles<AppRole>()
+        .AddEntityFrameworkStores<InExDbContext>();
+
+    // ── JWT Authentication ──
+    var jwtSection = builder.Configuration.GetSection(JwtOptions.SectionName);
+    var jwtSecret = jwtSection["Secret"] ?? throw new InvalidOperationException("JwtOptions:Secret is not configured.");
+
+    builder.Services
+        .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
+        {
+            options.MapInboundClaims = false;
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = jwtSection["Issuer"],
+                ValidAudience = jwtSection["Audience"],
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
+                ClockSkew = TimeSpan.Zero
+            };
+        });
+
+    builder.Services.AddAuthorization();
+
+    // ── ICurrentUserAccessor ──
+    builder.Services.AddHttpContextAccessor();
+    builder.Services.AddScoped<ICurrentUserAccessor, HttpContextCurrentUserAccessor>();
 
     // Register the global exception handler
     builder.Services.AddExceptionHandler<GlobalExceptionsHandler>();
@@ -166,6 +211,9 @@ try
     app.UseRouting();
 
     app.UseCors("AllowLocalhost");
+
+    app.UseAuthentication();
+    app.UseAuthorization();
 
     app.MapHealthChecks("/health");
     app.MapControllers();

--- a/inex/appsettings.json
+++ b/inex/appsettings.json
@@ -37,6 +37,14 @@
     ]
   },
   "AllowedHosts": "*",
+  "JwtOptions": {
+    "Issuer": "inex-api",
+    "Audience": "inex-client",
+    "Secret": "",
+    "AccessTokenExpiryMinutes": 15,
+    "RefreshTokenExpiryDays": 7,
+    "RefreshGraceWindowSeconds": 30
+  },
   "ConnectionStrings": {
     "InExConnection": ""
   },

--- a/inex/inex.csproj
+++ b/inex/inex.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/inex/inex.xml
+++ b/inex/inex.xml
@@ -38,6 +38,24 @@
             <summary>Delete a list of accounts</summary>
             <param name="ids">Account ids</param>
         </member>
+        <member name="M:inex.Controllers.AuthController.Register(inex.Services.Models.Records.Auth.RegisterRequest)">
+            <summary>Register a new user account</summary>
+        </member>
+        <member name="M:inex.Controllers.AuthController.Login(inex.Services.Models.Records.Auth.LoginRequest)">
+            <summary>Authenticate with email and password</summary>
+        </member>
+        <member name="M:inex.Controllers.AuthController.Refresh">
+            <summary>
+            Issue a new access token using the httpOnly refresh token cookie.
+            Implements token rotation — the old refresh token is invalidated.
+            </summary>
+        </member>
+        <member name="M:inex.Controllers.AuthController.Logout">
+            <summary>Revoke the current session and clear the refresh token cookie</summary>
+        </member>
+        <member name="M:inex.Controllers.AuthController.Me">
+            <summary>Return the profile of the currently authenticated user from JWT claims</summary>
+        </member>
         <member name="M:inex.Controllers.BudgetsController.Single(System.Int32)">
             <summary>Get budget details</summary>
             <param name="id">Budget id</param>
@@ -189,6 +207,18 @@
             <summary>
             Ensures the database is created (for development).
             This does not apply migrations, just ensures the database exists.
+            </summary>
+        </member>
+        <member name="T:inex.Infrastructure.HttpContextCurrentUserAccessor">
+            <summary>
+            Reads the current user ID from the JWT claims stored in HttpContext.
+            Registered as Scoped — one instance per request.
+            </summary>
+        </member>
+        <member name="T:inex.Infrastructure.ICurrentUserAccessor">
+            <summary>
+            Abstracts the current user identity so controllers and services
+            don't depend directly on HttpContext or Claims — easier to test.
             </summary>
         </member>
     </members>


### PR DESCRIPTION
- Add AuthController — POST /api/auth/register|login|refresh|logout, GET /api/auth/me
- Wire up AddIdentityCore + AddAuthentication(JwtBearer) in Program.cs; add UseAuthentication / UseAuthorization to pipeline
- Introduce ICurrentUserAccessor / HttpContextCurrentUserAccessor — abstracts HttpContext.User claims, replaces hardcoded CurrentUserId = 1 in ApiControllerBase
- Add [Authorize] to all existing business controllers
- Add Swagger JWT bearer security definition (Authorize button in /help)
- Add JwtOptions section to appsettings.json; JWT secret stored in User Secrets (dev) / env vars (prod)
- Rename response types for clarity: ResponseCreateDTO → CreatedResponse, ResponseDataDTO<T> → ListResponse<T>, ResponseDataExDTO<T,K> → PagedResponse<T,TMeta>, UserProfileDTO → UserProfile

Ref #26 