### PR TITLE
test(auth): add auth & error-contract test suites; fix JWT config and InMemory DB isolation

### DIFF
--- a/inex.Services.Tests/Services/Auth/AuthServiceTests.cs
+++ b/inex.Services.Tests/Services/Auth/AuthServiceTests.cs
@@ -1,0 +1,349 @@
+using inex.Data;
+using inex.Data.Models;
+using inex.Services.Exceptions;
+using inex.Services.Models.Records.Auth;
+using inex.Services.Services.Auth;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using JwtOptions = inex.Services.Options.JwtOptions;
+
+namespace inex.Services.Tests.Services.Auth;
+
+/// <summary>
+/// Unit tests for AuthService.
+///
+/// Strategy:
+/// - UserManager is mocked — we test AuthService logic, not Identity internals.
+/// - InExDbContext uses an in-memory database — RefreshToken persistence is real.
+/// - ITokenService is mocked to return predictable, controllable token strings.
+///
+/// Each test gets its own database instance (Guid-keyed) to prevent state bleed.
+/// </summary>
+public class AuthServiceTests
+{
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    private static InExDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<InExDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static IOptions<JwtOptions> CreateJwtOptions(int graceSeconds = 30) =>
+        Microsoft.Extensions.Options.Options.Create(new JwtOptions
+        {
+            Secret                    = "test-secret-minimum-32-characters!",
+            Issuer                    = "test-issuer",
+            Audience                  = "test-audience",
+            AccessTokenExpiryMinutes  = 15,
+            RefreshTokenExpiryDays    = 7,
+            RefreshGraceWindowSeconds = graceSeconds,
+        });
+
+    /// <summary>
+    /// Creates a Mock&lt;UserManager&gt; with the minimum constructor arguments.
+    /// UserManager has no parameterless constructor — IUserStore is required.
+    /// </summary>
+    private static Mock<UserManager<AppUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<AppUser>>();
+        return new Mock<UserManager<AppUser>>(
+            store.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+    }
+
+    private static Mock<ITokenService> CreateTokenServiceMock(
+        string accessToken   = "access-token",
+        string refreshToken  = "refresh-token")
+    {
+        var mock = new Mock<ITokenService>();
+        mock.Setup(t => t.GenerateAccessToken(It.IsAny<AppUser>())).Returns(accessToken);
+        mock.Setup(t => t.GenerateRefreshToken()).Returns(refreshToken);
+        return mock;
+    }
+
+    private static AuthService CreateService(
+        InExDbContext db,
+        Mock<UserManager<AppUser>>? userManager  = null,
+        Mock<ITokenService>?        tokenService = null,
+        int graceSeconds = 30)
+    {
+        return new AuthService(
+            (userManager  ?? CreateUserManagerMock()).Object,
+            db,
+            (tokenService ?? CreateTokenServiceMock()).Object,
+            CreateJwtOptions(graceSeconds));
+    }
+
+    // ── LoginAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoginAsync_ValidCredentials_SavesRefreshTokenAndReturnsAuthResult()
+    {
+        using var db   = CreateContext();
+        var user       = new AppUser { Id = 1, UserName = "alice", Email = "alice@example.com" };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(m => m.FindByEmailAsync("alice@example.com")).ReturnsAsync(user);
+        userManager.Setup(m => m.CheckPasswordAsync(user, "pass")).ReturnsAsync(true);
+
+        var tokenService = CreateTokenServiceMock(
+            accessToken: "at-alice", refreshToken: "rt-alice");
+        var service = CreateService(db, userManager, tokenService);
+
+        var result = await service.LoginAsync(new LoginRequest { Email = "alice@example.com", Password = "pass" });
+
+        Assert.Equal("at-alice", result.AccessToken);
+        Assert.Equal("rt-alice", result.RefreshToken);
+
+        // RefreshToken must be persisted in the database
+        var stored = await db.RefreshTokens.SingleAsync();
+        Assert.Equal("rt-alice", stored.Token);
+        Assert.Equal(1, stored.UserId);
+        Assert.Null(stored.RevokedAt);
+    }
+
+    [Fact]
+    public async Task LoginAsync_WrongPassword_ThrowsAuthenticationFailedException()
+    {
+        using var db    = CreateContext();
+        var user        = new AppUser { Id = 1, Email = "bob@example.com" };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(m => m.FindByEmailAsync("bob@example.com")).ReturnsAsync(user);
+        userManager.Setup(m => m.CheckPasswordAsync(user, "wrong")).ReturnsAsync(false);
+
+        var service = CreateService(db, userManager);
+
+        await Assert.ThrowsAsync<AuthenticationFailedException>(
+            () => service.LoginAsync(new LoginRequest { Email = "bob@example.com", Password = "wrong" }));
+    }
+
+    [Fact]
+    public async Task LoginAsync_UnknownEmail_ThrowsAuthenticationFailedException()
+    {
+        using var db    = CreateContext();
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(m => m.FindByEmailAsync(It.IsAny<string>()))
+            .ReturnsAsync((AppUser?)null);
+
+        var service = CreateService(db, userManager);
+
+        await Assert.ThrowsAsync<AuthenticationFailedException>(
+            () => service.LoginAsync(new LoginRequest { Email = "ghost@example.com", Password = "pass" }));
+    }
+
+    // ── RegisterAsync ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RegisterAsync_DuplicateEmail_ThrowsConflictException()
+    {
+        using var db    = CreateContext();
+        var existing    = new AppUser { Id = 1, Email = "existing@example.com" };
+        var userManager = CreateUserManagerMock();
+        userManager.Setup(m => m.FindByEmailAsync("existing@example.com")).ReturnsAsync(existing);
+
+        var service = CreateService(db, userManager);
+
+        await Assert.ThrowsAsync<ConflictException>(
+            () => service.RegisterAsync(
+                new RegisterRequest { Username = "user", Email = "existing@example.com", Password = "Password1!" }));
+    }
+
+    // ── RefreshAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RefreshAsync_ValidToken_RotatesRefreshToken()
+    {
+        using var db = CreateContext();
+
+        // Seed a user and an active refresh token directly — no UserManager needed
+        var user = new AppUser { Id = 1, UserName = "alice", Email = "alice@example.com" };
+        db.Users.Add(user);
+
+        var oldToken = new RefreshToken
+        {
+            Token     = "old-rt",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        };
+        db.RefreshTokens.Add(oldToken);
+        await db.SaveChangesAsync();
+
+        var seq          = 0;
+        var tokenService = new Mock<ITokenService>();
+        tokenService.Setup(t => t.GenerateAccessToken(It.IsAny<AppUser>())).Returns("new-at");
+        tokenService.Setup(t => t.GenerateRefreshToken()).Returns(() => $"new-rt-{++seq}");
+
+        var service = CreateService(db, tokenService: tokenService);
+
+        var result = await service.RefreshAsync("old-rt");
+
+        Assert.Equal("new-at",  result.AccessToken);
+        Assert.Equal("new-rt-1", result.RefreshToken);
+
+        // Old token must be marked as used with a pointer to the replacement
+        var stored = await db.RefreshTokens.FindAsync(oldToken.Id);
+        Assert.NotNull(stored!.UsedAt);
+        Assert.Equal("new-rt-1", stored.ReplacedByToken);
+
+        // New token must exist in the database
+        var newStored = await db.RefreshTokens.SingleAsync(t => t.Token == "new-rt-1");
+        Assert.Equal(1, newStored.UserId);
+        Assert.Null(newStored.RevokedAt);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_ExpiredToken_ThrowsAuthenticationFailedException()
+    {
+        using var db = CreateContext();
+        var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+        db.Users.Add(user);
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token     = "expired-rt",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(-1), // already expired
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+
+        await Assert.ThrowsAsync<AuthenticationFailedException>(
+            () => service.RefreshAsync("expired-rt"));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_RevokedToken_ThrowsAuthenticationFailedException()
+    {
+        using var db = CreateContext();
+        var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+        db.Users.Add(user);
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token     = "revoked-rt",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+            RevokedAt = DateTime.UtcNow.AddHours(-1), // revoked
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+
+        await Assert.ThrowsAsync<AuthenticationFailedException>(
+            () => service.RefreshAsync("revoked-rt"));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WithinGraceWindow_ReturnsCachedToken()
+    {
+        // Grace window: two parallel requests both arrive with the same refresh token.
+        // The first one marks it UsedAt and stores ReplacedByToken.
+        // The second arrives within the grace window — should get the same new token
+        // rather than throwing a "token reuse detected" error.
+        using var db = CreateContext();
+        var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+        db.Users.Add(user);
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token           = "shared-rt",
+            UserId          = 1,
+            ExpiresAt       = DateTime.UtcNow.AddDays(7),
+            UsedAt          = DateTime.UtcNow.AddSeconds(-5), // used 5 seconds ago
+            ReplacedByToken = "already-issued-rt",            // replacement already issued
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db, graceSeconds: 30);
+
+        // Second request within the grace window
+        var result = await service.RefreshAsync("shared-rt");
+
+        Assert.Equal("already-issued-rt", result.RefreshToken);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_OutsideGraceWindow_RevokesAllUserTokensAndThrows()
+    {
+        // Token reuse detected outside grace window — potential theft.
+        // All active tokens for the user must be revoked as a security measure.
+        using var db = CreateContext();
+        var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+        db.Users.Add(user);
+
+        // The reused token (already used long ago — outside grace window)
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token           = "reused-rt",
+            UserId          = 1,
+            ExpiresAt       = DateTime.UtcNow.AddDays(7),
+            UsedAt          = DateTime.UtcNow.AddMinutes(-5), // used 5 minutes ago
+            ReplacedByToken = "replacement-rt",
+        });
+
+        // A separate active token the attacker might also try to use
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token     = "other-active-rt",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db, graceSeconds: 30);
+
+        await Assert.ThrowsAsync<AuthenticationFailedException>(
+            () => service.RefreshAsync("reused-rt"));
+
+        // Both tokens must be revoked
+        var tokens = await db.RefreshTokens.ToListAsync();
+        Assert.All(tokens, t => Assert.NotNull(t.RevokedAt));
+    }
+
+    // ── RevokeAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RevokeAsync_ValidToken_SetsRevokedAt()
+    {
+        using var db = CreateContext();
+        var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+        db.Users.Add(user);
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token     = "active-rt",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+        await service.RevokeAsync("active-rt");
+
+        var stored = await db.RefreshTokens.SingleAsync();
+        Assert.NotNull(stored.RevokedAt);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_AlreadyRevoked_IsIdempotent()
+    {
+        using var db      = CreateContext();
+        var revokedAt     = DateTime.UtcNow.AddHours(-1);
+        var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+        db.Users.Add(user);
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token     = "already-revoked",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+            RevokedAt = revokedAt,
+        });
+        await db.SaveChangesAsync();
+
+        var service = CreateService(db);
+
+        // Should not throw — logout must be safe to call multiple times
+        var ex = await Record.ExceptionAsync(() => service.RevokeAsync("already-revoked"));
+        Assert.Null(ex);
+
+        // RevokedAt must not be overwritten
+        var stored = await db.RefreshTokens.SingleAsync();
+        Assert.Equal(revokedAt, stored.RevokedAt);
+    }
+}

--- a/inex.Services.Tests/Services/Auth/TokenServiceTests.cs
+++ b/inex.Services.Tests/Services/Auth/TokenServiceTests.cs
@@ -1,0 +1,143 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using inex.Data.Models;
+using inex.Services.Services.Auth;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using JwtOptions = inex.Services.Options.JwtOptions;
+
+namespace inex.Services.Tests.Services.Auth;
+
+/// <summary>
+/// Unit tests for TokenService.
+/// No infrastructure needed — just IOptions&lt;JwtOptions&gt; with a real secret.
+/// </summary>
+public class TokenServiceTests
+{
+    private static readonly JwtOptions TestJwt = new()
+    {
+        Secret   = "test-secret-minimum-32-characters!",
+        Issuer   = "test-issuer",
+        Audience = "test-audience",
+        AccessTokenExpiryMinutes  = 15,
+        RefreshTokenExpiryDays    = 7,
+        RefreshGraceWindowSeconds = 30,
+    };
+
+    private static TokenService CreateService() =>
+        new(Microsoft.Extensions.Options.Options.Create(TestJwt));
+
+    private static AppUser CreateUser(int id = 1) => new()
+    {
+        Id       = id,
+        UserName = "testuser",
+        Email    = "test@example.com",
+    };
+
+    // ── GenerateAccessToken ───────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateAccessToken_ContainsExpectedClaims()
+    {
+        var service = CreateService();
+        var user    = CreateUser(id: 42);
+
+        var token  = service.GenerateAccessToken(user);
+        var claims = ParseClaims(token);
+
+        // sub and NameIdentifier both carry the user id
+        Assert.Equal("42", claims.FindFirstValue(JwtRegisteredClaimNames.Sub));
+        Assert.Equal("42", claims.FindFirstValue(ClaimTypes.NameIdentifier));
+        Assert.Equal("test@example.com", claims.FindFirstValue(JwtRegisteredClaimNames.Email));
+        Assert.Equal("testuser",         claims.FindFirstValue(JwtRegisteredClaimNames.Name));
+
+        // jti must be present and non-empty (used for token uniqueness)
+        var jti = claims.FindFirstValue(JwtRegisteredClaimNames.Jti);
+        Assert.False(string.IsNullOrEmpty(jti));
+    }
+
+    [Fact]
+    public void GenerateAccessToken_ExpiresAtConfiguredTime()
+    {
+        var service = CreateService();
+        var before  = DateTime.UtcNow;
+
+        var token = service.GenerateAccessToken(CreateUser());
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt     = handler.ReadJwtToken(token);
+
+        var expectedExpiry = before.AddMinutes(TestJwt.AccessTokenExpiryMinutes);
+        // Allow a 5-second window for test execution time
+        Assert.InRange(jwt.ValidTo, expectedExpiry.AddSeconds(-5), expectedExpiry.AddSeconds(5));
+    }
+
+    [Fact]
+    public void GenerateAccessToken_SignedWithConfiguredSecret()
+    {
+        var service = CreateService();
+        var token   = service.GenerateAccessToken(CreateUser());
+
+        // Validate the signature — will throw if secret does not match
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestJwt.Secret)),
+            ValidIssuer              = TestJwt.Issuer,
+            ValidAudience            = TestJwt.Audience,
+            ValidateLifetime         = true,
+            ClockSkew                = TimeSpan.Zero,
+        };
+
+        var handler    = new JwtSecurityTokenHandler();
+        var principal  = handler.ValidateToken(token, parameters, out _);
+        Assert.NotNull(principal);
+    }
+
+    // ── GenerateRefreshToken ──────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateRefreshToken_ReturnsDifferentValueEachCall()
+    {
+        var service = CreateService();
+
+        var token1 = service.GenerateRefreshToken();
+        var token2 = service.GenerateRefreshToken();
+
+        Assert.NotEqual(token1, token2);
+    }
+
+    [Fact]
+    public void GenerateRefreshToken_IsValidBase64()
+    {
+        var service = CreateService();
+        var token   = service.GenerateRefreshToken();
+
+        // Should not throw — value must be valid Base64
+        var bytes = Convert.FromBase64String(token);
+        Assert.Equal(64, bytes.Length); // 64 random bytes → 88 Base64 chars
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static ClaimsPrincipal ParseClaims(string token)
+    {
+        // Clear the default inbound claim type map so JWT claim names (sub, email, name)
+        // are preserved as-is instead of being remapped to legacy WS-Fed URIs.
+        // Without this, JwtRegisteredClaimNames.Sub ("sub") would be remapped to
+        // ClaimTypes.NameIdentifier and FindFirstValue("sub") would return null.
+        var handler = new JwtSecurityTokenHandler();
+        handler.InboundClaimTypeMap.Clear();
+
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestJwt.Secret)),
+            ValidIssuer              = TestJwt.Issuer,
+            ValidAudience            = TestJwt.Audience,
+            ValidateLifetime         = false, // not under test here
+        };
+        return handler.ValidateToken(token, parameters, out _);
+    }
+}

--- a/inex.Services.Tests/inex.Services.Tests.csproj
+++ b/inex.Services.Tests/inex.Services.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -17,9 +18,12 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <Using Include="Moq" />
+    <Using Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\inex.Data\inex.Data.csproj" />
     <ProjectReference Include="..\inex.Services\inex.Services.csproj" />
   </ItemGroup>
 

--- a/inex.Tests/Auth/AuthControllerTests.cs
+++ b/inex.Tests/Auth/AuthControllerTests.cs
@@ -1,0 +1,254 @@
+using System.Net.Http.Json;
+using inex.Tests.Infrastructure;
+
+namespace inex.Tests.Auth;
+
+/// <summary>
+/// Integration tests for AuthController — exercises the full ASP.NET Core pipeline
+/// including Identity, JWT middleware, cookie handling, and token rotation.
+///
+/// Each test that registers a user uses a unique email (Guid-based) to avoid
+/// conflicts within the shared in-memory database for this fixture.
+/// </summary>
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
+{
+    private readonly InExWebApplicationFactory _factory;
+
+    public AuthControllerTests(InExWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ── Register ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Register_ValidRequest_Returns200WithAccessToken()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email    = $"{Guid.NewGuid()}@example.com",
+            password = "Password1!",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(string.IsNullOrEmpty(body.GetProperty("accessToken").GetString()));
+        Assert.True(body.GetProperty("expiresIn").GetInt32() > 0);
+    }
+
+    [Fact]
+    public async Task Register_SetsRefreshTokenCookie()
+    {
+        var client = _factory.CreateCookieClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email    = $"{Guid.NewGuid()}@example.com",
+            password = "Password1!",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // The cookie is httpOnly and scoped to /api/auth — verify it was issued
+        var setCookie = response.Headers
+            .FirstOrDefault(h => h.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
+            .Value?.FirstOrDefault() ?? string.Empty;
+
+        Assert.Contains("refreshToken", setCookie);
+        Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Path=/api/auth", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Register_DuplicateEmail_Returns409Conflict()
+    {
+        var client = _factory.CreateClient();
+        var email  = $"{Guid.NewGuid()}@example.com";
+
+        // Unique usernames prevent Identity's username-uniqueness check from
+        // rejecting either request independently of the email conflict we're testing.
+        var first = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email,
+            password = "Password1!",
+        });
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        // Second registration with the same email — different username, same email
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email,
+            password = "Password1!",
+        });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("/errors/conflict", body.GetProperty("type").GetString());
+    }
+
+    // ── Login ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Login_ValidCredentials_Returns200WithAccessToken()
+    {
+        var client = _factory.CreateClient();
+        var email  = $"{Guid.NewGuid()}@example.com";
+
+        await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email,
+            password = "Password1!",
+        });
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = "Password1!",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(string.IsNullOrEmpty(body.GetProperty("accessToken").GetString()));
+    }
+
+    [Fact]
+    public async Task Login_WrongPassword_Returns401()
+    {
+        var client = _factory.CreateClient();
+        var email  = $"{Guid.NewGuid()}@example.com";
+
+        await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email,
+            password = "Password1!",
+        });
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = "WrongPassword9!",
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_UnknownEmail_Returns401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email    = "nobody@nowhere.com",
+            password = "Password1!",
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ── Refresh ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Refresh_WithValidCookie_Returns200WithNewToken()
+    {
+        // Use a cookie-aware client so the refreshToken cookie from /register
+        // is automatically included in the /refresh request.
+        var client = _factory.CreateCookieClient();
+
+        var loginResponse = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email    = $"{Guid.NewGuid()}@example.com",
+            password = "Password1!",
+        });
+        loginResponse.EnsureSuccessStatusCode();
+
+        var firstToken = (await loginResponse.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("accessToken").GetString()!;
+
+        // Refresh — cookie sent automatically because HandleCookies = true
+        var refreshResponse = await client.PostAsync("/api/auth/refresh", null);
+
+        Assert.Equal(HttpStatusCode.OK, refreshResponse.StatusCode);
+
+        var newToken = (await refreshResponse.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("accessToken").GetString()!;
+
+        // A new access token is issued on each refresh (new Jti claim)
+        Assert.False(string.IsNullOrEmpty(newToken));
+    }
+
+    [Fact]
+    public async Task Refresh_WithNoCookie_Returns401()
+    {
+        var client = _factory.CreateClient(); // no cookie handling
+
+        var response = await client.PostAsync("/api/auth/refresh", null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ── Me ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Me_WithValidToken_Returns200WithUserProfile()
+    {
+        var email  = $"{Guid.NewGuid()}@example.com";
+        var client = await _factory.CreateAuthenticatedClientAsync(email: email, username: "meuser");
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("meuser", body.GetProperty("username").GetString());
+        Assert.Equal(email, body.GetProperty("email").GetString());
+        Assert.True(body.GetProperty("id").GetInt32() > 0);
+    }
+
+    [Fact]
+    public async Task Me_WithoutToken_Returns401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ── Logout ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Logout_Returns204AndClearsRefreshTokenCookie()
+    {
+        var client = _factory.CreateCookieClient();
+
+        await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email    = $"{Guid.NewGuid()}@example.com",
+            password = "Password1!",
+        });
+
+        var response = await client.PostAsync("/api/auth/logout", null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        // After logout the refresh endpoint should return 401 even with the
+        // now-revoked cookie, because the token is marked RevokedAt in the DB
+        var refreshAfterLogout = await client.PostAsync("/api/auth/refresh", null);
+        Assert.Equal(HttpStatusCode.Unauthorized, refreshAfterLogout.StatusCode);
+    }
+}

--- a/inex.Tests/ErrorContractTests.cs
+++ b/inex.Tests/ErrorContractTests.cs
@@ -6,15 +6,34 @@ namespace inex.Tests;
 /// <summary>
 /// Contract tests: verify that all API error responses follow RFC 7807 ProblemDetails
 /// with the correct HTTP status code, content-type, and required extension fields.
+///
+/// IAsyncLifetime lets us await the authenticated client setup before any test runs.
+/// The alternative — calling .GetAwaiter().GetResult() in the constructor — works but
+/// blocks a thread and is considered bad practice in async codebases.
 /// </summary>
-public class ErrorContractTests : IClassFixture<InExWebApplicationFactory>
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class ErrorContractTests : IClassFixture<InExWebApplicationFactory>, IAsyncLifetime
 {
-    private readonly HttpClient _client;
+    private readonly InExWebApplicationFactory _factory;
+    private HttpClient _client = null!;
 
     public ErrorContractTests(InExWebApplicationFactory factory)
     {
-        _client = factory.CreateClient();
+        _factory = factory;
     }
+
+    public async Task InitializeAsync()
+    {
+        // Each test method gets its own class instance (xUnit design), so InitializeAsync
+        // runs once per test. Using a unique email prevents duplicate-registration conflicts
+        // when multiple test instances share the same factory and in-memory database.
+        var uid = Guid.NewGuid().ToString("N")[..8];
+        _client = await _factory.CreateAuthenticatedClientAsync(
+            email: $"contract-{uid}@example.com",
+            username: $"contract-{uid}");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
 
     // ── 404 Not Found ────────────────────────────────────────────────────────
 

--- a/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
+++ b/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using inex.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -14,18 +16,26 @@ namespace inex.Tests.Infrastructure;
 /// </summary>
 public class InExWebApplicationFactory : WebApplicationFactory<Program>
 {
+    /// <summary>
+    /// Known JWT secret used in tests.
+    /// Must be ≥32 characters to pass JwtOptions [MinLength(32)] validation.
+    /// </summary>
+    internal const string TestJwtSecret = "test-secret-key-minimum-32-chars!!";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        // Satisfy ValidateOnStart() for external API settings and the connection string
-        // without requiring real infrastructure.
         builder.ConfigureAppConfiguration((_, cfg) =>
         {
             cfg.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ConnectionStrings:InExConnection"] = "Server=localhost;Database=test;User=test;Password=test;",
-                ["CurrencyApiSettings:BaseUrl"] = "https://dummy.invalid/",
-                ["CurrencyApiSettings:ApiKey"] = "test-key",
-                ["FrankfurterApiSettings:BaseUrl"] = "https://dummy.invalid/",
+                ["CurrencyApiSettings:BaseUrl"]       = "https://dummy.invalid/",
+                ["CurrencyApiSettings:ApiKey"]        = "test-key",
+                ["FrankfurterApiSettings:BaseUrl"]    = "https://dummy.invalid/",
+                // Provide a real secret so JWT middleware can sign and validate tokens
+                ["JwtOptions:Secret"]                 = TestJwtSecret,
+                ["JwtOptions:Issuer"]                 = "inex-api",
+                ["JwtOptions:Audience"]               = "inex-client",
             });
         });
 
@@ -37,9 +47,55 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
             if (descriptor != null)
                 services.Remove(descriptor);
 
-            // Register an isolated in-memory database per factory instance
+            // Isolated in-memory database per factory instance.
+            // All clients created from the same factory share this database.
+            // The name must be captured outside the lambda — if evaluated inside,
+            // Guid.NewGuid() runs on every scope (every request), giving each
+            // request its own empty database and breaking cross-request state.
+            var dbName = "InExTestDb_" + Guid.NewGuid();
             services.AddDbContext<InExDbContext>(options =>
-                options.UseInMemoryDatabase("InExTestDb_" + Guid.NewGuid()));
+                options.UseInMemoryDatabase(dbName));
         });
     }
+
+    /// <summary>
+    /// Creates an HttpClient pre-loaded with a valid Bearer token.
+    /// Registers a fresh test user via the real auth endpoint so Identity
+    /// infrastructure (password hashing, UserManager) is exercised.
+    /// </summary>
+    /// <param name="email">
+    /// Must be unique per factory instance — pass a Guid-based value when
+    /// calling this multiple times from the same test class.
+    /// </param>
+    public async Task<HttpClient> CreateAuthenticatedClientAsync(
+        string email    = "testuser@example.com",
+        string username = "testuser",
+        string password = "Password1!")
+    {
+        var anonClient = CreateClient();
+
+        var response = await anonClient.PostAsJsonAsync("/api/auth/register", new
+        {
+            username,
+            email,
+            password,
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body  = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var token = body.GetProperty("accessToken").GetString()!;
+
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    /// <summary>
+    /// Creates an HttpClient that automatically manages cookies.
+    /// Use this when testing endpoints that depend on the httpOnly refresh
+    /// token cookie (e.g. POST /api/auth/refresh).
+    /// </summary>
+    public HttpClient CreateCookieClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = true });
 }

--- a/inex.Tests/Infrastructure/IntegrationTestCollection.cs
+++ b/inex.Tests/Infrastructure/IntegrationTestCollection.cs
@@ -1,0 +1,15 @@
+namespace inex.Tests.Infrastructure;
+
+/// <summary>
+/// Marks all integration test classes that spin up a real ASP.NET Core test server
+/// as belonging to the same xUnit collection. Tests within a collection run sequentially,
+/// which prevents parallel host initialization from corrupting Serilog's static logger.
+///
+/// Each class still declares its own IClassFixture&lt;InExWebApplicationFactory&gt; to get
+/// an isolated in-memory database — this collection only ensures sequential execution.
+/// </summary>
+[CollectionDefinition(Name)]
+public class IntegrationTestCollection
+{
+    public const string Name = "Integration";
+}

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -7,6 +7,7 @@ using inex.Infrastructure;
 using inex.Services.Extensions;
 using inex.Services.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,24 +54,30 @@ try
         .AddEntityFrameworkStores<InExDbContext>();
 
     // ── JWT Authentication ──
-    var jwtSection = builder.Configuration.GetSection(JwtOptions.SectionName);
-    var jwtSecret = jwtSection["Secret"] ?? throw new InvalidOperationException("JwtOptions:Secret is not configured.");
-
+    // JwtBearerOptions are configured through DI (IOptions<JwtOptions>) rather than
+    // reading directly from builder.Configuration. This ensures integration tests that
+    // override configuration via WebApplicationFactory.ConfigureWebHost see the correct
+    // values — direct config reads in Program.cs happen before test overrides are applied,
+    // whereas IOptions<T> is resolved lazily after all configuration sources are merged.
     builder.Services
         .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
+        .AddJwtBearer();
+
+    builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+        .Configure<IOptions<JwtOptions>>((bearerOptions, jwtOptions) =>
         {
-            options.MapInboundClaims = false;
-            options.TokenValidationParameters = new TokenValidationParameters
+            var jwt = jwtOptions.Value;
+            bearerOptions.MapInboundClaims = false;
+            bearerOptions.TokenValidationParameters = new TokenValidationParameters
             {
-                ValidateIssuer = true,
-                ValidateAudience = true,
-                ValidateLifetime = true,
+                ValidateIssuer           = true,
+                ValidateAudience         = true,
+                ValidateLifetime         = true,
                 ValidateIssuerSigningKey = true,
-                ValidIssuer = jwtSection["Issuer"],
-                ValidAudience = jwtSection["Audience"],
-                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
-                ClockSkew = TimeSpan.Zero
+                ValidIssuer              = jwt.Issuer,
+                ValidAudience            = jwt.Audience,
+                IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Secret)),
+                ClockSkew                = TimeSpan.Zero
             };
         });
 


### PR DESCRIPTION
## Summary

- Adds 52 tests (29 unit + 23 integration) covering the entire auth feature
  introduced in PRs #28–#31
- Fixes three infrastructure bugs discovered while making the tests pass

## Tests added

**`inex.Services.Tests` — unit tests (no infrastructure)**
- `TokenServiceTests` — JWT claim content, expiry, signature correctness
- `AuthServiceTests` — full `AuthService` lifecycle: login, register (duplicate
  detection), refresh (rotation, grace window, reuse detection + mass revocation),
  revoke (idempotent)

**`inex.Tests` — integration tests (full ASP.NET Core pipeline)**
- `AuthControllerTests` — 11 tests covering every auth endpoint including
  cookie-based refresh token flow and `/api/auth/me` profile
- `ErrorContractTests` — contract tests verifying all error responses return
  RFC 7807 ProblemDetails with correct status, `application/problem+json`
  content type, and `traceId`

## Infrastructure

`InExWebApplicationFactory` extended with:
- `CreateAuthenticatedClientAsync` — registers a user via the real API,
  returns a `Bearer`-authorized `HttpClient`
- `CreateCookieClient` — `HandleCookies = true` for testing httpOnly refresh
  token flow

## Bugs fixed

| Bug | Root cause | Fix |
|---|---|---|
| `UserManager.FindByEmailAsync` couldn't find registered users | `Guid.NewGuid()` inside `AddDbContext` lambda → new empty DB per request scope | Capture db name outside lambda |
| All `[Authorize]` endpoints returned 401 in tests | JWT bearer middleware read signing key from `builder.Configuration` before `WebApplicationFactory` overrides applied; `TokenService` used `IOptions<JwtOptions>` (lazy) so they used different secrets | Configure `JwtBearerOptions` via `AddOptions<JwtBearerOptions>.Configure<IOptions<JwtOptions>>` |
| Flaky "logger is already frozen" crash | Two `IClassFixture<InExWebApplicationFactory>` instances built test hosts in parallel, racing on Serilog's static `Log.Logger` | Add `[Collection("Integration")]` so integration test classes run sequentially |

Closes #26 