### PR TITLE
fix(fe): replace eval() with expr-eval in ExpressionInputNumber

### DIFF
--- a/inex/ClientApp/package-lock.json
+++ b/inex/ClientApp/package-lock.json
@@ -12,6 +12,7 @@
         "@types/recharts": "^1.8.23",
         "antd": "^4.18.0",
         "axios": "^1.14.0",
+        "expr-eval": "^2.0.2",
         "moment": "^2.29.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7543,6 +7544,11 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/expr-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
+      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg=="
     },
     "node_modules/express": {
       "version": "4.22.1",

--- a/inex/ClientApp/package.json
+++ b/inex/ClientApp/package.json
@@ -7,6 +7,7 @@
     "@types/recharts": "^1.8.23",
     "antd": "^4.18.0",
     "axios": "^1.14.0",
+    "expr-eval": "^2.0.2",
     "moment": "^2.29.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/inex/ClientApp/src/components/ExpressionInputNumber.tsx
+++ b/inex/ClientApp/src/components/ExpressionInputNumber.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Input } from "antd";
+import { Parser } from "expr-eval";
 
 interface ExpressionInputNumberProps {
     value?: number;
@@ -11,14 +12,13 @@ interface ExpressionInputNumberProps {
     style?: React.CSSProperties;
 }
 
+const parser = new Parser();
+
 const evaluateExpression = (input: string): number | null => {
     let expr = input.trim().replace(/^=/, "");
     expr = expr.replace(/,/g, '.');
-    // Only allow numbers, operators, dot, minus, and spaces
-    if (!/^[\d+\-*/. ()]+$/.test(expr)) return null;
     try {
-        // eslint-disable-next-line no-eval
-        const result = eval(expr);
+        const result = parser.evaluate(expr);
         if (typeof result === "number" && !isNaN(result) && isFinite(result)) {
             return result;
         }


### PR DESCRIPTION
  Eliminates XSS/code-injection risk from using eval() to parse math
  expressions. expr-eval is a sandboxed math parser with no access to
  JS scope — invalid syntax throws instead of silently returning undefined.

Closes #33 