### PR TITLE
feat(security): rate limiting on auth endpoints + invite-token registration gating

### DIFF
--- a/inex.Services.Tests/Services/Auth/AuthServiceTests.cs
+++ b/inex.Services.Tests/Services/Auth/AuthServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using JwtOptions = inex.Services.Options.JwtOptions;
+using InviteOptions = inex.Services.Options.InviteOptions;
 
 namespace inex.Services.Tests.Services.Auth;
 
@@ -61,17 +62,22 @@ public class AuthServiceTests
         return mock;
     }
 
+    private static IOptions<InviteOptions> CreateInviteOptions(string token = "test-invite-token") =>
+        Microsoft.Extensions.Options.Options.Create(new InviteOptions { Token = token });
+
     private static AuthService CreateService(
         InExDbContext db,
         Mock<UserManager<AppUser>>? userManager  = null,
         Mock<ITokenService>?        tokenService = null,
-        int graceSeconds = 30)
+        int graceSeconds = 30,
+        string inviteToken = "test-invite-token")
     {
         return new AuthService(
             (userManager  ?? CreateUserManagerMock()).Object,
             db,
             (tokenService ?? CreateTokenServiceMock()).Object,
-            CreateJwtOptions(graceSeconds));
+            CreateJwtOptions(graceSeconds),
+            CreateInviteOptions(inviteToken));
     }
 
     // ── LoginAsync ────────────────────────────────────────────────────────────
@@ -144,7 +150,7 @@ public class AuthServiceTests
 
         await Assert.ThrowsAsync<ConflictException>(
             () => service.RegisterAsync(
-                new RegisterRequest { Username = "user", Email = "existing@example.com", Password = "Password1!" }));
+                new RegisterRequest { Username = "user", Email = "existing@example.com", Password = "Password1!", InviteToken = "test-invite-token" }));
     }
 
     // ── RefreshAsync ──────────────────────────────────────────────────────────

--- a/inex.Services/Extensions/InExServicesExtensions.cs
+++ b/inex.Services/Extensions/InExServicesExtensions.cs
@@ -23,6 +23,7 @@ public static class InExServicesExtensions
         ?? throw new InvalidOperationException("InExConnection connection string is not configured.");
 
         services.AddOptions<JwtOptions>().BindConfiguration(JwtOptions.SectionName).ValidateDataAnnotations().ValidateOnStart();
+        services.AddOptions<InviteOptions>().BindConfiguration(InviteOptions.SectionName).ValidateDataAnnotations().ValidateOnStart();
         services.AddOptions<CurrencyApiSettings>().BindConfiguration(CurrencyApiSettings.SectionName).ValidateDataAnnotations().ValidateOnStart();
         services.AddOptions<FrankfurterApiSettings>().BindConfiguration(FrankfurterApiSettings.SectionName).ValidateDataAnnotations().ValidateOnStart();
 

--- a/inex.Services/Models/Records/Auth/RegisterRequest.cs
+++ b/inex.Services/Models/Records/Auth/RegisterRequest.cs
@@ -16,4 +16,7 @@ public record RegisterRequest
     [Required]
     [MinLength(8)]
     public string Password { get; init; } = string.Empty;
+
+    [Required]
+    public string InviteToken { get; init; } = string.Empty;
 }

--- a/inex.Services/Options/InviteOptions.cs
+++ b/inex.Services/Options/InviteOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace inex.Services.Options;
+
+public class InviteOptions
+{
+    public const string SectionName = "InviteOptions";
+
+    [Required]
+    [MinLength(8)]
+    public string Token { get; set; } = string.Empty;
+}

--- a/inex.Services/Services/Auth/AuthService.cs
+++ b/inex.Services/Services/Auth/AuthService.cs
@@ -15,21 +15,27 @@ public class AuthService : IAuthService
     private readonly InExDbContext _db;
     private readonly ITokenService _tokenService;
     private readonly JwtOptions _jwt;
+    private readonly InviteOptions _invite;
 
     public AuthService(
         UserManager<AppUser> userManager,
         InExDbContext db,
         ITokenService tokenService,
-        IOptions<JwtOptions> jwtOptions)
+        IOptions<JwtOptions> jwtOptions,
+        IOptions<InviteOptions> inviteOptions)
     {
         _userManager = userManager;
         _db = db;
         _tokenService = tokenService;
         _jwt = jwtOptions.Value;
+        _invite = inviteOptions.Value;
     }
 
     public async Task<AuthResult> RegisterAsync(RegisterRequest request)
     {
+        if (!string.Equals(request.InviteToken, _invite.Token, StringComparison.Ordinal))
+            throw new AccessDeniedException("Registration requires a valid invite token.", reason: "invalid-invite-token");
+
         var existing = await _userManager.FindByEmailAsync(request.Email);
         if (existing is not null)
             throw new ConflictException($"Email '{request.Email}' is already registered.");

--- a/inex.Tests/Auth/AuthControllerTests.cs
+++ b/inex.Tests/Auth/AuthControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using inex.Tests.Infrastructure;
+using static inex.Tests.Infrastructure.InExWebApplicationFactory;
 
 namespace inex.Tests.Auth;
 
@@ -29,9 +30,10 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
 
         var response = await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
-            email    = $"{Guid.NewGuid()}@example.com",
-            password = "Password1!",
+            username    = $"user-{Guid.NewGuid():N}",
+            email       = $"{Guid.NewGuid()}@example.com",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -48,9 +50,10 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
 
         var response = await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
-            email    = $"{Guid.NewGuid()}@example.com",
-            password = "Password1!",
+            username    = $"user-{Guid.NewGuid():N}",
+            email       = $"{Guid.NewGuid()}@example.com",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -75,24 +78,62 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
         // rejecting either request independently of the email conflict we're testing.
         var first = await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
+            username    = $"user-{Guid.NewGuid():N}",
             email,
-            password = "Password1!",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
         Assert.Equal(HttpStatusCode.OK, first.StatusCode);
 
         // Second registration with the same email — different username, same email
         var response = await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
+            username    = $"user-{Guid.NewGuid():N}",
             email,
-            password = "Password1!",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
 
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("/errors/conflict", body.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task Register_WithoutInviteToken_Returns422()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username = $"user-{Guid.NewGuid():N}",
+            email    = $"{Guid.NewGuid()}@example.com",
+            password = "Password1!",
+            // inviteToken omitted — [Required] triggers model binding 422
+        });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WithWrongInviteToken_Returns403()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new
+        {
+            username    = $"user-{Guid.NewGuid():N}",
+            email       = $"{Guid.NewGuid()}@example.com",
+            password    = "Password1!",
+            inviteToken = "definitely-wrong-token",
+        });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("/errors/access-denied", body.GetProperty("type").GetString());
+        Assert.Equal("invalid-invite-token", body.GetProperty("reason").GetString());
     }
 
     // ── Login ─────────────────────────────────────────────────────────────────
@@ -105,9 +146,10 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
 
         await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
+            username    = $"user-{Guid.NewGuid():N}",
             email,
-            password = "Password1!",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
 
         var response = await client.PostAsJsonAsync("/api/auth/login", new
@@ -130,9 +172,10 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
 
         await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
+            username    = $"user-{Guid.NewGuid():N}",
             email,
-            password = "Password1!",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
 
         var response = await client.PostAsJsonAsync("/api/auth/login", new
@@ -169,9 +212,10 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
 
         var loginResponse = await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
-            email    = $"{Guid.NewGuid()}@example.com",
-            password = "Password1!",
+            username    = $"user-{Guid.NewGuid():N}",
+            email       = $"{Guid.NewGuid()}@example.com",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
         loginResponse.EnsureSuccessStatusCode();
 
@@ -237,9 +281,10 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
 
         await client.PostAsJsonAsync("/api/auth/register", new
         {
-            username = $"user-{Guid.NewGuid():N}",
-            email    = $"{Guid.NewGuid()}@example.com",
-            password = "Password1!",
+            username    = $"user-{Guid.NewGuid():N}",
+            email       = $"{Guid.NewGuid()}@example.com",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
         });
 
         var response = await client.PostAsync("/api/auth/logout", null);

--- a/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
+++ b/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
@@ -1,12 +1,15 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Threading.RateLimiting;
 using inex.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace inex.Tests.Infrastructure;
 
@@ -22,6 +25,9 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
     /// </summary>
     internal const string TestJwtSecret = "test-secret-key-minimum-32-chars!!";
 
+    /// <summary>Invite token used in tests — matches InviteOptions:Token in test config.</summary>
+    internal const string TestInviteToken = "test-invite-token";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureAppConfiguration((_, cfg) =>
@@ -36,6 +42,7 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
                 ["JwtOptions:Secret"]                 = TestJwtSecret,
                 ["JwtOptions:Issuer"]                 = "inex-api",
                 ["JwtOptions:Audience"]               = "inex-client",
+                ["InviteOptions:Token"]               = TestInviteToken,
             });
         });
 
@@ -55,6 +62,20 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
             var dbName = "InExTestDb_" + Guid.NewGuid();
             services.AddDbContext<InExDbContext>(options =>
                 options.UseInMemoryDatabase(dbName));
+
+            // Disable rate limiting in tests — multiple test classes share the same
+            // IP (::1) and would exceed the 5/min limit. Remove the production
+            // IConfigureOptions<RateLimiterOptions> descriptor and re-register with
+            // a no-op policy so AddPolicy doesn't throw "already exists".
+            var rateLimiterConfigDescriptors = services
+                .Where(d => d.ServiceType == typeof(IConfigureOptions<RateLimiterOptions>))
+                .ToList();
+            foreach (var d in rateLimiterConfigDescriptors)
+                services.Remove(d);
+
+            services.Configure<RateLimiterOptions>(options =>
+                options.AddPolicy(inex.Infrastructure.RateLimitPolicies.AuthFixedWindow, _ =>
+                    RateLimitPartition.GetNoLimiter("test")));
         });
     }
 
@@ -79,6 +100,7 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
             username,
             email,
             password,
+            inviteToken = TestInviteToken,
         });
         response.EnsureSuccessStatusCode();
 

--- a/inex/Controllers/AuthController.cs
+++ b/inex/Controllers/AuthController.cs
@@ -1,10 +1,12 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using inex.Infrastructure;
 using inex.Services.Models.Records.Auth;
 using inex.Services.Options;
 using inex.Services.Services.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 
 namespace inex.Controllers;
@@ -28,6 +30,7 @@ public class AuthController : ControllerBase
     /// <summary>Register a new user account</summary>
     [HttpPost("register")]
     [AllowAnonymous]
+    [EnableRateLimiting(RateLimitPolicies.AuthFixedWindow)]
     [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<TokenResponse>> Register([FromBody] RegisterRequest request)
     {
@@ -39,6 +42,7 @@ public class AuthController : ControllerBase
     /// <summary>Authenticate with email and password</summary>
     [HttpPost("login")]
     [AllowAnonymous]
+    [EnableRateLimiting(RateLimitPolicies.AuthFixedWindow)]
     [ProducesResponseType(typeof(TokenResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<TokenResponse>> Login([FromBody] LoginRequest request)
     {

--- a/inex/Infrastructure/RateLimitPolicies.cs
+++ b/inex/Infrastructure/RateLimitPolicies.cs
@@ -1,0 +1,6 @@
+namespace inex.Infrastructure;
+
+public static class RateLimitPolicies
+{
+    public const string AuthFixedWindow = "auth-fixed-window";
+}

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.RateLimiting;
 using inex.Data;
 using inex.Data.Models;
 using inex.Extensions;
@@ -7,6 +9,7 @@ using inex.Infrastructure;
 using inex.Services.Extensions;
 using inex.Services.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
@@ -40,6 +43,30 @@ try
             .Enrich.FromLogContext());
 
     builder.Services.AddInExServices(builder.Configuration);
+
+    builder.Services.AddRateLimiter(options =>
+    {
+        options.AddPolicy(RateLimitPolicies.AuthFixedWindow, httpContext =>
+            RateLimitPartition.GetFixedWindowLimiter(
+                httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 5,
+                    Window = TimeSpan.FromMinutes(1),
+                    QueueLimit = 0
+                }));
+
+        options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+        options.OnRejected = async (context, ct) =>
+        {
+            if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+                context.HttpContext.Response.Headers.RetryAfter =
+                    ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+
+            context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            await context.HttpContext.Response.WriteAsync("Too many requests. Please try again later.", ct);
+        };
+    });
 
     // ── Identity (AddIdentityCore = UserManager + RoleManager only, no Cookie auth scheme) ──
     builder.Services
@@ -218,6 +245,8 @@ try
     app.UseRouting();
 
     app.UseCors("AllowLocalhost");
+
+    app.UseRateLimiter();
 
     app.UseAuthentication();
     app.UseAuthorization();

--- a/inex/appsettings.json
+++ b/inex/appsettings.json
@@ -37,6 +37,9 @@
     ]
   },
   "AllowedHosts": "*",
+  "InviteOptions": {
+    "Token": ""
+  },
   "JwtOptions": {
     "Issuer": "inex-api",
     "Audience": "inex-client",


### PR DESCRIPTION
-   B4: Add ASP.NET Core built-in per-IP fixed-window rate limiter (5 req/min)on /api/auth/login and /api/auth/register via [EnableRateLimiting] attribute.
- Gate registration behind a static invite token stored in InviteOptions

Close #35 
