### PR TITLE
feat(prod): secrets hygiene + CORS lockdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,39 @@
-# Database Configuration
-DB_ROOT_PASSWORD=rootpassword123
+# ── Database ──────────────────────────────────────────────────────────────────
+# Used by docker-compose to create the MySQL container
+DB_ROOT_PASSWORD=change-me-root-password
 DB_NAME=inex_db
 DB_USER=inex_user
-DB_PASSWORD=inexuserpassword123
+DB_PASSWORD=change-me-db-password
 
-# API Configuration
+# Full connection string injected into the API container
+# ASP.NET Core env var format: __ = nested config separator
+ConnectionStrings__InExConnection=Server=mysql;Port=3306;Database=inex_db;User=inex_user;Password=change-me-db-password;Convert Zero Datetime=True
+
+# ── ASP.NET Core ──────────────────────────────────────────────────────────────
 ASPNETCORE_ENVIRONMENT=Production
 ASPNETCORE_URLS=http://+:80
+
+# ── JWT ───────────────────────────────────────────────────────────────────────
+# Must be ≥32 characters. Generate with: openssl rand -base64 48
+JwtOptions__Secret=change-me-generate-a-long-random-secret-min-32-chars
+JwtOptions__Issuer=inex-api
+JwtOptions__Audience=inex-client
+JwtOptions__AccessTokenExpiryMinutes=15
+JwtOptions__RefreshTokenExpiryDays=7
+
+# ── Registration ──────────────────────────────────────────────────────────────
+# Invite token required to register. Must be ≥8 characters.
+# Generate with: openssl rand -base64 24
+InviteOptions__Token=change-me-invite-token
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+# Production domain(s) allowed to call the API. Array syntax: __0, __1, etc.
+# MUST be set before deploying — empty list blocks all browser requests.
+AllowedOrigins__0=https://yourdomain.com
+
+# ── Exchange Rate API ─────────────────────────────────────────────────────────
 EXCHANGE_API_KEY=your_exchange_api_key_here
 
-# Application
-CURRENT_USER_ID=1
+# ── Design-time migrations only (not used at runtime) ─────────────────────────
+# Set this before running: dotnet ef migrations add <Name>
+# INEX_CONNECTION_STRING=Server=localhost;Port=3306;Database=inex_dev;User=root;Password=...

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,13 +2,25 @@ name: .NET CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main, refactor/**, test/**]
+    branches: [master, refactor/**, feature/**, test/**]
 
 jobs:
+  secrets-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history required for gitleaks
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
+    needs: secrets-scan
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ docker/mysql/mysql_data/
 docker/mysql/backup/
 scripts
 docs
-logs/
+logs/bash.exe.stackdump

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -183,6 +183,17 @@ try
     // ── 2. BUILD ──
     var app = builder.Build();
 
+    // ── P2: CORS guard ──
+    // Warn loudly at startup if AllowedOrigins is empty outside development.
+    // An empty list means CORS blocks all browser requests — the SPA won't work.
+    // Fix: set AllowedOrigins__0=https://yourdomain.com via env var or appsettings.
+    if (!app.Environment.IsDevelopment() && (allowedOrigins == null || allowedOrigins.Length == 0))
+    {
+        Log.Warning(
+            "CORS WARNING: AllowedOrigins is empty. All cross-origin browser requests will be blocked. " +
+            "Set AllowedOrigins__0=https://yourdomain.com before deploying.");
+    }
+
     // ── 3. PIPELINE PHASE ──
 
     app.UseExceptionHandler();


### PR DESCRIPTION
-   Rewrite .env.example with all required production env vars documented(ConnectionStrings, JwtOptions, InviteOptions, AllowedOrigins, ExchangeApi).
-   Fix CI workflow branch targets (main → master; was never triggering on PRs).
-   Add gitleaks secrets-scan job that gates the build — blocks merges if secretsare accidentally committed.
-   Add startup warning log when AllowedOrigins is empty outside developmentso misconfigured CORS is immediately visible in deployment logs.

Close #37 