### PR TITLE
refactor(validation): add FluentValidation for all request DTOs

### DIFF
--- a/inex.Services/Models/Records/Auth/ChangePasswordRequest.cs
+++ b/inex.Services/Models/Records/Auth/ChangePasswordRequest.cs
@@ -1,13 +1,7 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace inex.Services.Models.Records.Auth;
 
 public record ChangePasswordRequest
 {
-    [Required]
     public string CurrentPassword { get; init; } = string.Empty;
-
-    [Required]
-    [MinLength(8)]
     public string NewPassword { get; init; } = string.Empty;
 }

--- a/inex.Services/Models/Records/Auth/LoginRequest.cs
+++ b/inex.Services/Models/Records/Auth/LoginRequest.cs
@@ -1,13 +1,7 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace inex.Services.Models.Records.Auth;
 
 public record LoginRequest
 {
-    [Required]
-    [EmailAddress]
     public string Email { get; init; } = string.Empty;
-
-    [Required]
     public string Password { get; init; } = string.Empty;
 }

--- a/inex.Services/Models/Records/Auth/RegisterRequest.cs
+++ b/inex.Services/Models/Records/Auth/RegisterRequest.cs
@@ -1,26 +1,10 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace inex.Services.Models.Records.Auth;
 
 public record RegisterRequest
 {
-    [Required]
-    [MaxLength(256)]
     public string Username { get; init; } = string.Empty;
-
-    [Required]
-    [EmailAddress]
-    [MaxLength(256)]
     public string Email { get; init; } = string.Empty;
-
-    [Required]
-    [MinLength(8)]
     public string Password { get; init; } = string.Empty;
-
-    [Required]
     public string InviteToken { get; init; } = string.Empty;
-
-    [Required]
-    [Range(1, int.MaxValue)]
     public int CurrencyId { get; init; }
 }

--- a/inex.Services/Models/Records/Auth/UpdateProfileRequest.cs
+++ b/inex.Services/Models/Records/Auth/UpdateProfileRequest.cs
@@ -1,14 +1,7 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace inex.Services.Models.Records.Auth;
 
 public record UpdateProfileRequest
 {
-    [Required]
-    [MaxLength(256)]
     public string Username { get; init; } = string.Empty;
-
-    [Required]
-    [Range(1, int.MaxValue)]
     public int CurrencyId { get; init; }
 }

--- a/inex.Services/Validators/Account/AccountCreateValidator.cs
+++ b/inex.Services/Validators/Account/AccountCreateValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+using inex.Services.Models.Records.Account;
+
+namespace inex.Services.Validators.Account;
+
+public class AccountCreateValidator : AbstractValidator<AccountCreateDTO>
+{
+    public AccountCreateValidator()
+    {
+        RuleFor(x => x.Key)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.CurrencyId)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Account/AccountUpdateValidator.cs
+++ b/inex.Services/Validators/Account/AccountUpdateValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using inex.Services.Models.Records.Account;
+
+namespace inex.Services.Validators.Account;
+
+public class AccountUpdateValidator : AbstractValidator<AccountUpdateDTO>
+{
+    public AccountUpdateValidator()
+    {
+        Include(new AccountCreateValidator());
+
+        RuleFor(x => x.Id)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Auth/ChangePasswordValidator.cs
+++ b/inex.Services/Validators/Auth/ChangePasswordValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using inex.Services.Models.Records.Auth;
+
+namespace inex.Services.Validators.Auth;
+
+public class ChangePasswordValidator : AbstractValidator<ChangePasswordRequest>
+{
+    public ChangePasswordValidator()
+    {
+        RuleFor(x => x.CurrentPassword)
+            .NotEmpty();
+
+        RuleFor(x => x.NewPassword)
+            .NotEmpty()
+            .MinimumLength(8);
+    }
+}

--- a/inex.Services/Validators/Auth/LoginValidator.cs
+++ b/inex.Services/Validators/Auth/LoginValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using inex.Services.Models.Records.Auth;
+
+namespace inex.Services.Validators.Auth;
+
+public class LoginValidator : AbstractValidator<LoginRequest>
+{
+    public LoginValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress();
+
+        RuleFor(x => x.Password)
+            .NotEmpty();
+    }
+}

--- a/inex.Services/Validators/Auth/RegisterValidator.cs
+++ b/inex.Services/Validators/Auth/RegisterValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using inex.Services.Models.Records.Auth;
+
+namespace inex.Services.Validators.Auth;
+
+public class RegisterValidator : AbstractValidator<RegisterRequest>
+{
+    public RegisterValidator()
+    {
+        RuleFor(x => x.Username)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(8);
+
+        RuleFor(x => x.InviteToken)
+            .NotEmpty();
+
+        RuleFor(x => x.CurrencyId)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Auth/UpdateProfileValidator.cs
+++ b/inex.Services/Validators/Auth/UpdateProfileValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using inex.Services.Models.Records.Auth;
+
+namespace inex.Services.Validators.Auth;
+
+public class UpdateProfileValidator : AbstractValidator<UpdateProfileRequest>
+{
+    public UpdateProfileValidator()
+    {
+        RuleFor(x => x.Username)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.CurrencyId)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Budget/BudgetCreateValidator.cs
+++ b/inex.Services/Validators/Budget/BudgetCreateValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using inex.Services.Models.Records.Budget;
+
+namespace inex.Services.Validators.Budget;
+
+public class BudgetCreateValidator : AbstractValidator<BudgetCreateDTO>
+{
+    public BudgetCreateValidator()
+    {
+        RuleFor(x => x.Key)
+            .NotEmpty();
+
+        RuleFor(x => x.Value)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Year)
+            .InclusiveBetween(2000, 2100);
+
+        RuleFor(x => x.Month)
+            .InclusiveBetween(1, 12);
+    }
+}

--- a/inex.Services/Validators/Budget/BudgetUpdateValidator.cs
+++ b/inex.Services/Validators/Budget/BudgetUpdateValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using inex.Services.Models.Records.Budget;
+
+namespace inex.Services.Validators.Budget;
+
+public class BudgetUpdateValidator : AbstractValidator<BudgetUpdateDTO>
+{
+    public BudgetUpdateValidator()
+    {
+        Include(new BudgetCreateValidator());
+
+        RuleFor(x => x.Id)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Category/CategoryCreateValidator.cs
+++ b/inex.Services/Validators/Category/CategoryCreateValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using inex.Services.Models.Records.Category;
+
+namespace inex.Services.Validators.Category;
+
+public class CategoryCreateValidator : AbstractValidator<CategoryCreateDTO>
+{
+    public CategoryCreateValidator()
+    {
+        RuleFor(x => x.Key)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(256);
+    }
+}

--- a/inex.Services/Validators/Category/CategoryUpdateValidator.cs
+++ b/inex.Services/Validators/Category/CategoryUpdateValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using inex.Services.Models.Records.Category;
+
+namespace inex.Services.Validators.Category;
+
+public class CategoryUpdateValidator : AbstractValidator<CategoryUpdateDTO>
+{
+    public CategoryUpdateValidator()
+    {
+        Include(new CategoryCreateValidator());
+
+        RuleFor(x => x.Id)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Transaction/TransactionCreateValidator.cs
+++ b/inex.Services/Validators/Transaction/TransactionCreateValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using inex.Services.Models.Records.Transaction;
+
+namespace inex.Services.Validators.Transaction;
+
+public class TransactionCreateValidator : AbstractValidator<TransactionCreateDTO>
+{
+    public TransactionCreateValidator()
+    {
+        RuleFor(x => x.Amount)
+            .NotEqual(0).WithMessage("Amount must not be zero.");
+
+        RuleFor(x => x.AccountId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.CategoryId)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Transaction/TransactionUpdateValidator.cs
+++ b/inex.Services/Validators/Transaction/TransactionUpdateValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using inex.Services.Models.Records.Transaction;
+
+namespace inex.Services.Validators.Transaction;
+
+public class TransactionUpdateValidator : AbstractValidator<TransactionUpdateDTO>
+{
+    public TransactionUpdateValidator()
+    {
+        Include(new TransactionCreateValidator());
+
+        RuleFor(x => x.Id)
+            .GreaterThan(0);
+    }
+}

--- a/inex.Services/Validators/Transaction/TransferCreateValidator.cs
+++ b/inex.Services/Validators/Transaction/TransferCreateValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using inex.Services.Models.Records.Transaction;
+
+namespace inex.Services.Validators.Transaction;
+
+public class TransferCreateValidator : AbstractValidator<TransferCreateDTO>
+{
+    public TransferCreateValidator()
+    {
+        RuleFor(x => x.AmountFrom)
+            .GreaterThan(0);
+
+        RuleFor(x => x.AmountTo)
+            .GreaterThan(0);
+
+        RuleFor(x => x.AccountFromId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.AccountToId)
+            .GreaterThan(0)
+            .Must((dto, toId) => toId != dto.AccountFromId)
+            .WithMessage("Source and destination accounts must differ.");
+    }
+}

--- a/inex.Services/inex.Services.csproj
+++ b/inex.Services/inex.Services.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="CsvHelper" Version="32.0.3" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.*" />

--- a/inex.Tests/Validation/ValidationTests.cs
+++ b/inex.Tests/Validation/ValidationTests.cs
@@ -1,0 +1,215 @@
+using System.Net.Http.Json;
+using inex.Tests.Infrastructure;
+using static inex.Tests.Infrastructure.InExWebApplicationFactory;
+
+namespace inex.Tests.Validation;
+
+/// <summary>
+/// Verifies that FluentValidation rejects invalid request bodies with 422 Unprocessable Entity
+/// and returns RFC 7807 Problem Details with type "/errors/validation-failed".
+/// </summary>
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class ValidationTests : IClassFixture<InExWebApplicationFactory>
+{
+    private readonly InExWebApplicationFactory _factory;
+
+    public ValidationTests(InExWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<HttpClient> AuthenticatedClient() =>
+        await _factory.CreateAuthenticatedClientAsync(
+            email: $"{Guid.NewGuid()}@example.com",
+            username: $"user-{Guid.NewGuid():N}");
+
+    private static async Task AssertValidationError(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("/errors/validation-failed", body.GetProperty("type").GetString());
+        Assert.Equal(422, body.GetProperty("status").GetInt32());
+    }
+
+    // ── Transactions ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Transaction_ZeroAmount_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId  = 1,
+            categoryId = 1,
+            created    = "2026-01-01",
+            amount     = 0,
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Transaction_ZeroAccountId_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId  = 0,
+            categoryId = 1,
+            created    = "2026-01-01",
+            amount     = 100,
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Transaction_ZeroCategoryId_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId  = 1,
+            categoryId = 0,
+            created    = "2026-01-01",
+            amount     = 100,
+        });
+        await AssertValidationError(response);
+    }
+
+    // ── Transfers ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Transfer_SameAccounts_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = 1,
+            accountToId   = 1,
+            amountFrom    = 100,
+            amountTo      = 100,
+            created       = "2026-01-01",
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Transfer_ZeroAmountFrom_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = 1,
+            accountToId   = 2,
+            amountFrom    = 0,
+            amountTo      = 100,
+            created       = "2026-01-01",
+        });
+        await AssertValidationError(response);
+    }
+
+    // ── Accounts ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Account_EmptyName_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            key        = "ACC",
+            name       = "",
+            currencyId = 1,
+            isEnabled  = true,
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Account_ZeroCurrencyId_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            key        = "ACC",
+            name       = "My Account",
+            currencyId = 0,
+            isEnabled  = true,
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Account_EmptyKey_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            key        = "",
+            name       = "My Account",
+            currencyId = 1,
+            isEnabled  = true,
+        });
+        await AssertValidationError(response);
+    }
+
+    // ── Budgets ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Budget_InvalidMonth_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/budgets", new
+        {
+            key   = "BDG",
+            value = 500,
+            year  = 2026,
+            month = 13,
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Budget_NegativeValue_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/budgets", new
+        {
+            key   = "BDG",
+            value = -1,
+            year  = 2026,
+            month = 6,
+        });
+        await AssertValidationError(response);
+    }
+
+    // ── Categories ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Category_EmptyKey_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key       = "",
+            name      = "Food",
+            isEnabled = true,
+            isSystem  = false,
+        });
+        await AssertValidationError(response);
+    }
+
+    [Fact]
+    public async Task Category_EmptyName_Returns422()
+    {
+        var client = await AuthenticatedClient();
+        var response = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key       = "FOOD",
+            name      = "",
+            isEnabled = true,
+            isSystem  = false,
+        });
+        await AssertValidationError(response);
+    }
+}

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -19,6 +19,9 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Amazon.CloudWatchLogs;
 using inex.Exceptions;
+using FluentValidation.AspNetCore;
+using FluentValidation;
+using inex.Services.Validators.Account;
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting.Compact;
@@ -67,6 +70,7 @@ try
     });
 
     builder.Services.AddInExServices(builder.Configuration);
+    builder.Services.AddValidatorsFromAssemblyContaining<AccountCreateValidator>();
 
     builder.Services.AddRateLimiter(options =>
     {
@@ -156,6 +160,8 @@ try
     builder.Services.AddControllers()
         .AddJsonOptions(x => x.JsonSerializerOptions.DefaultIgnoreCondition
             = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull);
+
+    builder.Services.AddFluentValidationAutoValidation();
 
     // Configure API behavior to return Problem Details for validation/model-binding errors.
     // Must be called AFTER AddControllers() so our factory overrides the default 400 factory

--- a/inex/inex.csproj
+++ b/inex/inex.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">


### PR DESCRIPTION
Centralizes input validation into explicit AbstractValidator<T> classes, one per request DTO. Validators run via AddFluentValidationAutoValidation(), which hooks into the ASP.NET Core model-binding pipeline so failures use the existing 422 Problem Details response format with no controller changes.

Closes #72 