### PR TITLE
fix: materialize BuildDataResponse and fix N+1 in report services

### DIFF
--- a/docs/implementation/1-1-enforce-object-level-authorization-in-service-methods.md
+++ b/docs/implementation/1-1-enforce-object-level-authorization-in-service-methods.md
@@ -1,6 +1,6 @@
 # Story 1.1: Enforce Object-Level Authorization in Service Methods
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -20,31 +20,40 @@ so that another user cannot read, modify, or delete my financial data by guessin
 
 ## Tasks / Subtasks
 
-- [ ] Update service and interface contracts so current user ID reaches every single-entity read and delete path. (AC: 1, 2, 4)
-  - [ ] Add `userId` to `GetAsync` signatures in `IAccountService`, `ICategoryService`, `IBudgetService`, `ITransactionService`, and their implementations.
-  - [ ] Add ownership-aware delete signatures for these four domain services; do not continue using the base `IInExService.DeleteAsync(id, ct)` path for user-owned deletes because it has no `userId`.
-  - [ ] Update `AccountsController`, `CategoriesController`, `BudgetsController`, and `TransactionsController` to pass `CurrentUserId` for single read, single delete, and bulk delete routes.
-- [ ] Replace ID-only reads with ownership-constrained queries. (AC: 1, 2, 3, 4)
-  - [ ] `AccountService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId`; preserve `Currency` inclusion where response mapping needs it.
-  - [ ] `CategoryService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId`; preserve existing system-category behavior for owned system categories.
-  - [ ] `BudgetService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId` with `BudgetCategories` included; preserve category assignment and uniqueness behavior.
-  - [ ] `TransactionService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId` with `TransactionTagDetails.Tag` included; preserve tag/ref processing.
-- [ ] Replace ID-only deletes with ownership-constrained deletes. (AC: 1, 2, 3, 4)
-  - [ ] Account delete: delete only rows where `ids.Contains(i.Id) && i.UserId == userId`.
-  - [ ] Category delete: check `IsSystem` only among categories owned by the current user, return not found for non-owned IDs, and preserve `system-category-delete` for owned system categories.
-  - [ ] Budget delete: load only owned budgets with `BudgetCategories`, delete their join rows, then delete owned budgets.
-  - [ ] Transaction delete: use a predicate containing both `ids.Contains(i.Id)` and `i.UserId == userId`.
-- [ ] Preserve error and API contracts. (AC: 1, 2, 3)
-  - [ ] Cross-user access must use the same `ResourceNotFoundException` path as missing resources so `GlobalExceptionsHandler` emits RFC 7807 `application/problem+json` with HTTP 404.
-  - [ ] Do not add new routes, change JSON property names, return `403`, expose ownership information, or trust client-supplied ownership fields.
-- [ ] Add integration regression coverage in `inex.Tests`. (AC: 1, 2, 3, 5)
-  - [ ] Extend `inex.Tests/Accounts/AccountsControllerTests.cs` and `inex.Tests/Categories/CategoriesControllerTests.cs` with cross-user GET, PUT, and DELETE denial tests.
-  - [ ] Add matching test files under new `inex.Tests/Budgets` and `inex.Tests/Transactions` folders if they do not already exist.
-  - [ ] Create entities through authenticated clients so tests exercise the real auth, controller, service, mapper, and exception-handler pipeline.
-  - [ ] Assert owner operations still return the existing successful responses.
-- [ ] Run verification. (AC: 5)
-  - [ ] Run targeted `rg` searches for remaining unsafe patterns in affected services.
-  - [ ] Run `dotnet test inex.sln` from the repo root; if a narrower test run is used while iterating, finish with the solution-level test command or document the blocker.
+- [x] Update service and interface contracts so current user ID reaches every single-entity read and delete path. (AC: 1, 2, 4)
+  - [x] Add `userId` to `GetAsync` signatures in `IAccountService`, `ICategoryService`, `IBudgetService`, `ITransactionService`, and their implementations.
+  - [x] Add ownership-aware delete signatures for these four domain services; do not continue using the base `IInExService.DeleteAsync(id, ct)` path for user-owned deletes because it has no `userId`.
+  - [x] Update `AccountsController`, `CategoriesController`, `BudgetsController`, and `TransactionsController` to pass `CurrentUserId` for single read, single delete, and bulk delete routes.
+- [x] Replace ID-only reads with ownership-constrained queries. (AC: 1, 2, 3, 4)
+  - [x] `AccountService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId`; preserve `Currency` inclusion where response mapping needs it.
+  - [x] `CategoryService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId`; preserve existing system-category behavior for owned system categories.
+  - [x] `BudgetService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId` with `BudgetCategories` included; preserve category assignment and uniqueness behavior.
+  - [x] `TransactionService.GetAsync` and `UpdateAsync`: load by `Id` and `UserId` with `TransactionTagDetails.Tag` included; preserve tag/ref processing.
+- [x] Replace ID-only deletes with ownership-constrained deletes. (AC: 1, 2, 3, 4)
+  - [x] Single-item delete must return `404 Not Found` for missing or non-owned IDs; do not treat a zero-row ownership-filtered delete as success.
+  - [x] Account delete: delete only rows where `ids.Contains(i.Id) && i.UserId == userId`; for single-item delete, throw `ResourceNotFoundException` when no owned row is found or no row is affected.
+  - [x] Category delete: check `IsSystem` only among categories owned by the current user, return not found for non-owned IDs, and preserve `system-category-delete` for owned system categories.
+  - [x] Budget delete: load only owned budgets with `BudgetCategories`, throw not found for a missing/non-owned single ID, delete their join rows, then delete owned budgets.
+  - [x] Transaction delete: use a predicate containing both `ids.Contains(i.Id)` and `i.UserId == userId`; for single-item delete, throw `ResourceNotFoundException` when no owned row is found or no row is affected.
+  - [x] Bulk delete routes must pass `CurrentUserId` and delete only rows owned by that user; this story does not require bulk routes to fail when the request contains a mix of owned and non-owned IDs unless an existing domain rule already does so.
+- [x] Preserve error and API contracts. (AC: 1, 2, 3)
+  - [x] Cross-user access must use the same `ResourceNotFoundException` path as missing resources so `GlobalExceptionsHandler` emits RFC 7807 `application/problem+json` with HTTP 404.
+  - [x] Do not add new routes, change JSON property names, return `403`, expose ownership information, or trust client-supplied ownership fields.
+- [x] Add integration regression coverage in `inex.Tests`. (AC: 1, 2, 3, 5)
+  - [x] Extend `inex.Tests/Accounts/AccountsControllerTests.cs` and `inex.Tests/Categories/CategoriesControllerTests.cs` with cross-user GET, PUT, and DELETE denial tests.
+  - [x] Add matching test files under new `inex.Tests/Budgets` and `inex.Tests/Transactions` folders if they do not already exist.
+  - [x] Create entities through authenticated clients so tests exercise the real auth, controller, service, mapper, and exception-handler pipeline.
+  - [x] For cross-user denial responses, assert `HttpStatusCode.NotFound`, RFC 7807 `application/problem+json`, and no body content that reveals another user's ownership.
+  - [x] Assert owner operations still return the existing successful responses.
+- [x] Run verification. (AC: 5)
+  - [x] Run targeted `rg` searches for remaining unsafe patterns in affected services.
+  - [x] Run `dotnet test inex.sln` from the repo root; if a narrower test run is used while iterating, finish with the solution-level test command or document the blocker.
+
+### Review Findings
+
+- [x] [Review][Patch] Transaction write paths accept cross-user account/category IDs [inex.Services/Services/TransactionService.cs:53]
+- [x] [Review][Patch] Budget write paths accept cross-user category IDs [inex.Services/Services/BudgetService.cs:57]
+- [x] [Review][Defer] Transfer creation loads source and destination accounts by ID only [inex.Services/Services/TransactionService.cs:75] - deferred, pre-existing
 
 ## Dev Notes
 
@@ -70,12 +79,38 @@ var account = await DbInEx.AccountRepository
 For set-based deletes, keep the ownership predicate in the delete query:
 
 ```csharp
-await DbInEx.TransactionRepository.ExecuteDeleteAsync(
+var affectedRows = await DbInEx.TransactionRepository.ExecuteDeleteAsync(
     i => ids.Contains(i.Id) && i.UserId == userId,
     ct);
+
+if (isSingleDelete && affectedRows == 0)
+{
+    throw new ResourceNotFoundException($"Transaction {id} was not found.", "Transaction", id);
+}
 ```
 
 EF Core `ExecuteDeleteAsync` executes directly in the database and does not require `SaveChanges`; use it only where existing behavior does not require loaded navigation cleanup. Microsoft documents `ExecuteDelete`/`ExecuteDeleteAsync` as set-based operations that bypass change tracking and `SaveChanges`. [Source: Microsoft Learn, ExecuteUpdate and ExecuteDelete - EF Core, https://learn.microsoft.com/en-us/ef/core/saving/execute-insert-update-delete]
+
+For loaded deletes that need domain checks or navigation cleanup, load owned rows first and treat a missing owned row as not found for single-item delete:
+
+```csharp
+var budgets = DbInEx.BudgetRepository
+    .Get(false, i => ids.Contains(i.Id) && i.UserId == userId, i => i.BudgetCategories)
+    .ToList();
+
+if (isSingleDelete && budgets.Count == 0)
+{
+    throw new ResourceNotFoundException($"Budget {id} was not found.", "Budget", id);
+}
+
+foreach (var budget in budgets)
+{
+    DbInEx.BudgetCategoryRepository.Delete(budget.BudgetCategories);
+}
+
+DbInEx.BudgetRepository.Delete(budgets);
+await DbInEx.SaveAsync(ct);
+```
 
 ### Domain-Specific Guardrails
 
@@ -88,6 +123,7 @@ EF Core `ExecuteDeleteAsync` executes directly in the database and does not requ
 ### Error Handling
 
 - Cross-user access must be indistinguishable from a missing entity. Throw `ResourceNotFoundException` with the existing resource type/id pattern.
+- Single-item delete is part of the cross-user surface. If an ownership-filtered delete finds no owned row or affects zero rows, throw `ResourceNotFoundException` instead of returning `Ok()`.
 - `GlobalExceptionsHandler` maps domain exceptions to RFC 7807 ProblemDetails and writes `application/problem+json`; keep this path. [Source: inex/Exceptions/GlobalExceptionsHandler.cs; inex.Services/Exceptions/DomainExceptions.cs]
 - ASP.NET Core 8 supports centralized API error handling with ProblemDetails through its exception handling pipeline; this project already has a custom `IExceptionHandler`, so extend existing mappings only if necessary. [Source: Microsoft Learn, Handle errors in ASP.NET Core APIs, https://learn.microsoft.com/en-us/aspnet/core/web-api/handle-errors?view=aspnetcore-8.0]
 
@@ -96,6 +132,7 @@ EF Core `ExecuteDeleteAsync` executes directly in the database and does not requ
 - Add cross-user integration tests in `inex.Tests`, not only service tests, because the acceptance criteria are API status-code behaviors.
 - Use `InExWebApplicationFactory.CreateAuthenticatedClientAsync` to create two authenticated clients in the same factory-backed test database.
 - Create user B's entity with user B's client, then call user A's GET/PUT/DELETE endpoint with that ID and assert `HttpStatusCode.NotFound`.
+- For denial tests, also assert the ProblemDetails content type and verify the response does not distinguish "exists but owned by another user" from "does not exist."
 - For PUT denial tests, send otherwise valid request bodies so the failure proves ownership enforcement, not validation.
 - Existing domain tests show request-body shapes and helper patterns for accounts and categories. Reuse those patterns; add budgets/transactions equivalents rather than inventing a new test harness.
 - In-memory EF tests do not prove MySQL-specific behavior, but this story is predicate/authorization logic and should still be covered through the integration pipeline. No schema change or migration is expected.
@@ -138,15 +175,53 @@ EF Core `ExecuteDeleteAsync` executes directly in the database and does not requ
 
 ### Agent Model Used
 
-TBD by dev agent.
+GPT-5 Codex
 
 ### Debug Log References
+
+- 2026-05-26: Started implementation; loaded story, project context, and sprint status.
+- 2026-05-26: Added failing cross-user API tests for accounts, categories, budgets, and transactions; confirmed targeted failures before implementation.
+- 2026-05-26: Implemented ownership-aware service reads, updates, and deletes; updated controllers to pass `CurrentUserId`.
+- 2026-05-26: Ran targeted unsafe-pattern searches and `dotnet test inex.sln` successfully.
 
 ### Completion Notes List
 
 - Story context generated from BMAD create-story workflow.
 - No previous story intelligence applies; this is the first story in Epic 1.
 - Git history analysis was not available in the sandbox because Git rejected the repository as a dubious ownership path.
+- Single-entity read, update, and delete paths now use `Id` plus `UserId` predicates in the four affected domain services.
+- User-owned delete routes now call ownership-aware service overloads; the inherited no-user delete path is guarded for these services.
+- Added API regression tests that create data through authenticated clients and assert cross-user `404` ProblemDetails responses.
+- Recorded the out-of-scope transfer-create account ownership risk in deferred work.
 
 ### File List
+
+- docs/implementation/1-1-enforce-object-level-authorization-in-service-methods.md
+- docs/implementation/deferred-work.md
+- docs/implementation/sprint-status.yaml
+- inex.Data/Repositories/Base/IRepository.cs
+- inex.Data/Repositories/Base/Repository.cs
+- inex.Services/Services/AccountService.cs
+- inex.Services/Services/CategoryService.cs
+- inex.Services/Services/BudgetService.cs
+- inex.Services/Services/TransactionService.cs
+- inex.Services/Services/Base/IAccountService.cs
+- inex.Services/Services/Base/ICategoryService.cs
+- inex.Services/Services/Base/IBudgetService.cs
+- inex.Services/Services/Base/ITransactionService.cs
+- inex/Controllers/AccountsController.cs
+- inex/Controllers/CategoriesController.cs
+- inex/Controllers/BudgetsController.cs
+- inex/Controllers/TransactionsController.cs
+- inex.Tests/Accounts/AccountsControllerTests.cs
+- inex.Tests/Categories/CategoriesControllerTests.cs
+- inex.Tests/Budgets/BudgetsControllerTests.cs
+- inex.Tests/Transactions/TransactionsControllerTests.cs
+- inex.Tests/Infrastructure/InExWebApplicationFactory.cs
+- inex.Tests/Infrastructure/ProblemDetailsAssertions.cs
+
+### Change Log
+
+- 2026-05-26: Enforced object-level authorization for single-entity account, category, budget, and transaction read/update/delete paths.
+- 2026-05-26: Added cross-user API regression coverage and completed solution-level verification.
 

--- a/docs/implementation/1-2-fix-refresh-token-rotation-race-condition.md
+++ b/docs/implementation/1-2-fix-refresh-token-rotation-race-condition.md
@@ -1,6 +1,6 @@
 # Story 1.2: Fix Refresh Token Rotation Race Condition
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -20,33 +20,41 @@ so that my session security does not depend on request timing.
 
 ## Tasks / Subtasks
 
-- [ ] Replace the current grace-window refresh success behavior with single-winner rotation. (AC: 1, 2, 3)
-  - [ ] Update `AuthService.RefreshAsync` so an already-used token never returns `stored.ReplacedByToken` as a successful refresh.
-  - [ ] Keep reuse detection: when a request initially observes `UsedAt is not null`, revoke all active refresh tokens for the user and throw an auth failure.
-  - [ ] For a pure concurrent lost race, return one consistent non-success response without issuing a replacement token; prefer `409 Conflict` for a detected write race or `401 Unauthorized` if implemented through the existing auth-failure path.
-- [ ] Implement a built-in EF Core single-winner strategy. (AC: 1, 3)
-  - [ ] Preferred path: add an application-managed concurrency token to `RefreshToken`, configure it in `RefreshTokenConfiguration`, and update it whenever a refresh token row is mutated.
-  - [ ] Add an EF migration if the chosen strategy changes the `RefreshTokens` schema.
-  - [ ] Alternative path: use a transaction plus conditional database update and verify row-count equals 1 before inserting the replacement token.
-  - [ ] Do not add distributed locks, Redis, new auth libraries, or frontend changes for this story.
-- [ ] Preserve existing refresh-token lifecycle semantics. (AC: 2, 5)
-  - [ ] Keep invalid, revoked, and expired refresh tokens rejected as `401 Unauthorized`.
-  - [ ] Keep logout idempotent and continue clearing the `refreshToken` cookie in `AuthController.Logout`.
-  - [ ] Keep refresh cookie attributes unchanged: `HttpOnly`, `SameSite.Strict`, environment-dependent `Secure`, expiry based on `RefreshTokenExpiryDays`, and `Path = "/api/auth"`.
-  - [ ] Keep `TokenResponse` body shape as `{ accessToken, expiresIn }`; the refresh token stays in the HTTP-only cookie only.
-- [ ] Update or replace auth unit tests that encode the old grace-window behavior. (AC: 1, 2)
-  - [ ] Replace `RefreshAsync_WithinGraceWindow_ReturnsCachedToken` with a test proving used-token reuse is rejected and active user tokens are revoked.
-  - [ ] Add a focused service-level race test if the implementation uses EF concurrency tokens and can be exercised with two `InExDbContext` instances sharing the same test database.
-  - [ ] Ensure mocked refresh-token generation returns distinct replacement token values to avoid testing unique-index collisions instead of rotation behavior.
-- [ ] Add API-level concurrency regression coverage in `inex.Tests/Auth/AuthControllerTests.cs`. (AC: 1, 4, 5)
-  - [ ] Register or log in with a cookie-aware client, then extract the issued `refreshToken` from the `Set-Cookie` header for test setup.
-  - [ ] Send two concurrent `POST /api/auth/refresh` requests with the same cookie value using separate clients or manual `Cookie` headers so both requests use the original token.
-  - [ ] Assert exactly one response is `200 OK`; assert the other response is the chosen non-success status.
-  - [ ] Assert only one new replacement refresh token is persisted for the original token chain.
-- [ ] Verify provider-sensitive behavior. (AC: 1, 3, 4)
-  - [ ] Run `dotnet test inex.sln` from the repo root.
-  - [ ] If a schema/concurrency-token migration is added, run `dotnet build inex.sln` and verify migration generation does not modify unrelated schema.
-  - [ ] Because `InExWebApplicationFactory` replaces MySQL with EF InMemory, manually verify the chosen concurrency strategy against MySQL or document the blocker in completion notes before marking done.
+- [x] Replace the current grace-window refresh success behavior with single-winner rotation. (AC: 1, 2, 3)
+  - [x] Update `AuthService.RefreshAsync` so an already-used token never returns `stored.ReplacedByToken` as a successful refresh.
+  - [x] Keep reuse detection: when a request initially observes `UsedAt is not null`, revoke all active refresh tokens for the user and throw an auth failure.
+  - [x] For a pure concurrent lost race, return one consistent non-success response without issuing a replacement token; prefer `409 Conflict` for a detected write race or `401 Unauthorized` if implemented through the existing auth-failure path.
+- [x] Implement a built-in EF Core single-winner strategy. (AC: 1, 3)
+  - [x] Preferred path: add an application-managed concurrency token to `RefreshToken`, configure it in `RefreshTokenConfiguration`, and update it whenever a refresh token row is mutated.
+  - [x] Add an EF migration if the chosen strategy changes the `RefreshTokens` schema.
+  - [x] Alternative path not used; preferred EF concurrency-token path implemented.
+  - [x] Do not add distributed locks, Redis, new auth libraries, or frontend changes for this story.
+- [x] Preserve existing refresh-token lifecycle semantics. (AC: 2, 5)
+  - [x] Keep invalid, revoked, and expired refresh tokens rejected as `401 Unauthorized`.
+  - [x] Keep logout idempotent and continue clearing the `refreshToken` cookie in `AuthController.Logout`.
+  - [x] Keep refresh cookie attributes unchanged: `HttpOnly`, `SameSite.Strict`, environment-dependent `Secure`, expiry based on `RefreshTokenExpiryDays`, and `Path = "/api/auth"`.
+  - [x] Keep `TokenResponse` body shape as `{ accessToken, expiresIn }`; the refresh token stays in the HTTP-only cookie only.
+- [x] Update or replace auth unit tests that encode the old grace-window behavior. (AC: 1, 2)
+  - [x] Replace `RefreshAsync_WithinGraceWindow_ReturnsCachedToken` with a test proving used-token reuse is rejected and active user tokens are revoked.
+  - [x] Add a focused service-level race test if the implementation uses EF concurrency tokens and can be exercised with two `InExDbContext` instances sharing the same test database.
+  - [x] Ensure mocked refresh-token generation returns distinct replacement token values to avoid testing unique-index collisions instead of rotation behavior.
+- [x] Add API-level concurrency regression coverage in `inex.Tests/Auth/AuthControllerTests.cs`. (AC: 1, 4, 5)
+  - [x] Register or log in with a cookie-aware client, then extract the issued `refreshToken` from the `Set-Cookie` header for test setup.
+  - [x] Send two concurrent `POST /api/auth/refresh` requests with the same cookie value using separate clients or manual `Cookie` headers so both requests use the original token.
+  - [x] Assert exactly one response is `200 OK`; assert the other response is the chosen non-success status.
+  - [x] Assert only one new replacement refresh token is persisted for the original token chain.
+- [x] Verify provider-sensitive behavior. (AC: 1, 3, 4)
+  - [x] Run `dotnet test inex.sln` from the repo root.
+  - [x] If a schema/concurrency-token migration is added, run `dotnet build inex.sln` and verify migration generation does not modify unrelated schema.
+  - [x] Because `InExWebApplicationFactory` replaces MySQL with EF InMemory, manually verify the chosen concurrency strategy against MySQL or document the blocker in completion notes before marking done.
+
+### Review Findings
+
+- [x] [Review][Patch] Late duplicate refresh can revoke the winning replacement token [inex.Services/Services/Auth/AuthService.cs:87]
+- [x] [Review][Patch] Concurrent logout can return 500 instead of remaining idempotent [inex.Services/Services/Auth/AuthService.cs:131]
+- [x] [Review][Patch] Reuse-detection revocation can roll back on token concurrency conflicts [inex.Services/Services/Auth/AuthService.cs:190]
+- [x] [Review][Patch] API regression test misses extra or revoked replacement tokens [inex.Tests/Auth/AuthControllerTests.cs:292]
+- [x] [Review][Patch] MySQL runtime concurrency verification remains unproven while provider-sensitive work is checked complete [docs/implementation/1-2-fix-refresh-token-rotation-race-condition.md:46]
 
 ## Dev Notes
 
@@ -163,17 +171,50 @@ If using conditional update instead of a concurrency token:
 
 ### Agent Model Used
 
-TBD by dev agent.
+GPT-5 Codex
 
 ### Debug Log References
+
+- 2026-05-27: Created branch `story-1-2-fix-refresh-token-rotation-race-condition`.
+- 2026-05-27: Confirmed red phase with `dotnet test D:\work\inex\inex.Services.Tests\inex.Services.Tests.csproj --filter AuthServiceTests`; new reuse and stale-concurrency tests failed against old grace-window behavior.
+- 2026-05-27: Ran focused green checks: `dotnet test D:\work\inex\inex.Services.Tests\inex.Services.Tests.csproj --filter AuthServiceTests` and `dotnet test D:\work\inex\inex.Tests\inex.Tests.csproj --filter AuthControllerTests`.
+- 2026-05-27: Ran final verification: `dotnet test D:\work\inex\inex.sln` and `dotnet build D:\work\inex\inex.sln`.
+- 2026-05-27: Generated MySQL migration SQL with `dotnet ef migrations script 20260424070214_AddExchangeRateUniqueConstraint 20260527052323_AddRefreshTokenConcurrencyStamp`; SQL only adds `RefreshTokens.ConcurrencyStamp`.
+- 2026-05-27: Addressed code-review findings and ran focused auth verification: `dotnet test D:\work\inex\inex.Services.Tests\inex.Services.Tests.csproj --filter AuthServiceTests` and `dotnet test D:\work\inex\inex.Tests\inex.Tests.csproj --filter AuthControllerTests`.
+- 2026-05-27: Ran final post-review verification: `dotnet test D:\work\inex\inex.sln`.
+- 2026-05-27: Ran disposable MySQL EF concurrency probe against local `inex-mysql`; two contexts racing on the same refresh-token concurrency stamp produced one successful replacement and one `DbUpdateConcurrencyException`.
 
 ### Completion Notes List
 
 - Story context generated from BMAD create-story workflow.
 - Ultimate context engine analysis completed - comprehensive developer guide created.
-- `docs/implementation/sprint-status.yaml` was read for context only and intentionally not updated because the parent workflow owns status updates.
-- Git status/history analysis was unavailable because Git rejected `D:/work/inex` as a dubious ownership path for the sandbox user.
-- Web research was limited to official Microsoft EF Core documentation for concurrency-token and affected-row-count guidance.
+- `docs/implementation/sprint-status.yaml` was updated from `ready-for-dev` to `in-progress`, then to `review`.
+- Git branch `story-1-2-fix-refresh-token-rotation-race-condition` was created before implementation.
+- No new external library dependencies were added.
+- Implemented single-winner refresh-token rotation with an application-managed EF Core concurrency token on `RefreshToken`.
+- Removed grace-window successful reuse; observed used-token reuse now revokes active refresh tokens and returns the existing authentication failure path.
+- Concurrent stale writes now map to `ConflictException` / `409 Conflict` and clean up the failed replacement token for EF InMemory test consistency.
+- Added `AddRefreshTokenConcurrencyStamp` migration; generated SQL was reviewed to avoid unrelated schema or seed-data churn.
+- Added service-level tests for used-token reuse revocation and two-context stale rotation conflict with distinct replacement tokens.
+- Added API-level concurrent refresh regression coverage using two manual-cookie clients and asserting exactly one success plus one replacement token.
+- MySQL provider note: local `inex-mysql` was available; generated migration SQL was reviewed, and a disposable MySQL database probe verified EF concurrency-token behavior with two contexts racing on the same refresh-token row.
+- Code review findings were resolved: late duplicate refresh now returns `409 Conflict` within the configured race window without revoking the winning replacement, logout treats stale revoke races idempotently, reuse-detection revocation retries concurrency conflicts, and API coverage asserts exactly one active replacement token.
 
 ### File List
+
+- `docs/implementation/1-2-fix-refresh-token-rotation-race-condition.md`
+- `docs/implementation/sprint-status.yaml`
+- `inex.Data/Models/RefreshToken.cs`
+- `inex.Data/Configurations/RefreshTokenConfiguration.cs`
+- `inex.Data/Migrations/20260527052323_AddRefreshTokenConcurrencyStamp.cs`
+- `inex.Data/Migrations/20260527052323_AddRefreshTokenConcurrencyStamp.Designer.cs`
+- `inex.Data/Migrations/InExDbContextModelSnapshot.cs`
+- `inex.Services/Services/Auth/AuthService.cs`
+- `inex.Services.Tests/Services/Auth/AuthServiceTests.cs`
+- `inex.Tests/Auth/AuthControllerTests.cs`
+
+### Change Log
+
+- 2026-05-27: Implemented Story 1.2 refresh-token single-winner rotation fix and moved story to review.
+- 2026-05-27: Resolved code-review findings for Story 1.2.
 

--- a/docs/implementation/deferred-work.md
+++ b/docs/implementation/deferred-work.md
@@ -4,6 +4,18 @@ Items surfaced during review but out of scope for the originating story. Each en
 
 ---
 
+## From: Story 1.1 Object-Level Authorization
+
+- **Transfer creation still loads source and destination accounts by ID only** - `TransactionService.CreateAsync(CreateTransferRequest, userId)` uses `AccountRepository.Get(true).First(i => i.Id == itemDTO.AccountFromId)` and the same pattern for `AccountToId`. Story 1.1 covered single-entity read/update/delete endpoints only; transfer creation needs a follow-up ownership predicate on both accounts before creating paired transactions.
+
+---
+
+## Deferred from: code review of 1-1-enforce-object-level-authorization-in-service-methods.md (2026-05-26)
+
+- **Transfer creation loads source and destination accounts by ID only** - `TransactionService.CreateAsync(CreateTransferRequest, userId)` loads `AccountFromId` and `AccountToId` without `UserId` predicates. This was pre-existing and explicitly called out by the story as adjacent follow-up work.
+
+---
+
 ## From: DTO Infrastructure Base Type Renames (Commit #1)
 
 - **`ResponseTransferDTO` not yet renamed** — Follows the same old `Response*DTO` pattern. Planned for PR #6 (Transactions domain) per the DTO migration plan in `docs/brainstorming/brainstorming-session-2026-05-20-1.md`.

--- a/docs/implementation/sprint-status.yaml
+++ b/docs/implementation/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-26T16:11:20.6477763+02:00
-# last_updated: 2026-05-26T18:30:44.3310702+02:00
+# last_updated: 2026-05-26T20:58:00+02:00
 # project: inex
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-05-26T16:11:20.6477763+02:00
-last_updated: 2026-05-26T18:30:44.3310702+02:00
+last_updated: 2026-05-26T20:58:00+02:00
 project: inex
 project_key: NOKEY
 tracking_system: file-system
@@ -43,7 +43,7 @@ story_location: D:\work\inex/docs/implementation
 
 development_status:
   epic-1: in-progress
-  1-1-enforce-object-level-authorization-in-service-methods: ready-for-dev
+  1-1-enforce-object-level-authorization-in-service-methods: done
   1-2-fix-refresh-token-rotation-race-condition: ready-for-dev
   1-3-fix-account-update-returns-422: ready-for-dev
   1-4-rotate-and-externalize-local-secrets: ready-for-dev

--- a/docs/implementation/sprint-status.yaml
+++ b/docs/implementation/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-05-26T16:11:20.6477763+02:00
-last_updated: 2026-05-26T20:58:00+02:00
+last_updated: 2026-05-27T08:25:00+02:00
 project: inex
 project_key: NOKEY
 tracking_system: file-system
@@ -44,7 +44,7 @@ story_location: D:\work\inex/docs/implementation
 development_status:
   epic-1: in-progress
   1-1-enforce-object-level-authorization-in-service-methods: done
-  1-2-fix-refresh-token-rotation-race-condition: ready-for-dev
+  1-2-fix-refresh-token-rotation-race-condition: done
   1-3-fix-account-update-returns-422: ready-for-dev
   1-4-rotate-and-externalize-local-secrets: ready-for-dev
   1-5-remove-tracked-frontend-build-artifacts: ready-for-dev

--- a/inex.Data/Configurations/RefreshTokenConfiguration.cs
+++ b/inex.Data/Configurations/RefreshTokenConfiguration.cs
@@ -17,6 +17,11 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
         builder.Property(t => t.ReplacedByToken)
                .HasMaxLength(512);
 
+        builder.Property(t => t.ConcurrencyStamp)
+               .IsRequired()
+               .HasMaxLength(32)
+               .IsConcurrencyToken();
+
         builder.HasOne(t => t.User)
                .WithMany(u => u.RefreshTokens)
                .HasForeignKey(t => t.UserId)

--- a/inex.Data/Migrations/20260527052323_AddRefreshTokenConcurrencyStamp.Designer.cs
+++ b/inex.Data/Migrations/20260527052323_AddRefreshTokenConcurrencyStamp.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using inex.Data;
 
@@ -11,9 +12,11 @@ using inex.Data;
 namespace inex.Data.Migrations
 {
     [DbContext(typeof(InExDbContext))]
-    partial class InExDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527052323_AddRefreshTokenConcurrencyStamp")]
+    partial class AddRefreshTokenConcurrencyStamp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/inex.Data/Migrations/20260527052323_AddRefreshTokenConcurrencyStamp.cs
+++ b/inex.Data/Migrations/20260527052323_AddRefreshTokenConcurrencyStamp.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace inex.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenConcurrencyStamp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "RefreshTokens",
+                type: "varchar(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "00000000000000000000000000000000")
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConcurrencyStamp",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/inex.Data/Models/RefreshToken.cs
+++ b/inex.Data/Models/RefreshToken.cs
@@ -9,6 +9,7 @@ public class RefreshToken
     public DateTime? UsedAt { get; set; }
     public DateTime? RevokedAt { get; set; }
     public string? ReplacedByToken { get; set; }
+    public string ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString("N");
 
     public AppUser User { get; set; } = null!;
 }

--- a/inex.Data/Repositories/Base/IRepository.cs
+++ b/inex.Data/Repositories/Base/IRepository.cs
@@ -7,4 +7,5 @@ public interface IRepository<T> : IDisposable
     T? Get(int id);
     Task<T?> GetAsync(int id, CancellationToken ct = default);
     IQueryable<T> Get(bool isReadOnly, Expression<Func<T, bool>>? predicate = null, params Expression<Func<T, object>>[] includeExpressions);
+    IQueryable<T> GetWithIncludePaths(bool isReadOnly, Expression<Func<T, bool>>? predicate, params string[] includePaths);
 }

--- a/inex.Data/Repositories/Base/Repository.cs
+++ b/inex.Data/Repositories/Base/Repository.cs
@@ -49,6 +49,23 @@ public class Repository<T> : IRepository<T> where T : class
         return set;
     }
 
+    public IQueryable<T> GetWithIncludePaths(bool isReadOnly, Expression<Func<T, bool>>? predicate, params string[] includePaths)
+    {
+        IQueryable<T> set = isReadOnly ? Db.Set<T>().AsNoTracking() : Db.Set<T>();
+
+        if (predicate != null)
+        {
+            set = set.Where(predicate);
+        }
+
+        foreach (var includePath in includePaths)
+        {
+            set = set.Include(includePath);
+        }
+
+        return set;
+    }
+
     public virtual void Dispose()
     {
         Db?.Dispose();

--- a/inex.Services.Tests/Services/Auth/AuthServiceTests.cs
+++ b/inex.Services.Tests/Services/Auth/AuthServiceTests.cs
@@ -27,8 +27,11 @@ public class AuthServiceTests
     // ── Fixtures ──────────────────────────────────────────────────────────────
 
     private static InExDbContext CreateContext() =>
+        CreateContext(Guid.NewGuid().ToString());
+
+    private static InExDbContext CreateContext(string databaseName) =>
         new(new DbContextOptionsBuilder<InExDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseInMemoryDatabase(databaseName)
             .Options);
 
     private static IOptions<JwtOptions> CreateJwtOptions(int graceSeconds = 30) =>
@@ -244,12 +247,8 @@ public class AuthServiceTests
     }
 
     [Fact]
-    public async Task RefreshAsync_WithinGraceWindow_ReturnsCachedToken()
+    public async Task RefreshAsync_LateDuplicateWithinRaceWindow_ThrowsConflictAndKeepsReplacementActive()
     {
-        // Grace window: two parallel requests both arrive with the same refresh token.
-        // The first one marks it UsedAt and stores ReplacedByToken.
-        // The second arrives within the grace window — should get the same new token
-        // rather than throwing a "token reuse detected" error.
         using var db = CreateContext();
         var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
         db.Users.Add(user);
@@ -258,17 +257,80 @@ public class AuthServiceTests
             Token           = "shared-rt",
             UserId          = 1,
             ExpiresAt       = DateTime.UtcNow.AddDays(7),
-            UsedAt          = DateTime.UtcNow.AddSeconds(-5), // used 5 seconds ago
-            ReplacedByToken = "already-issued-rt",            // replacement already issued
+            UsedAt          = DateTime.UtcNow.AddSeconds(-5),
+            ReplacedByToken = "already-issued-rt",
+        });
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token     = "other-active-rt",
+            UserId    = 1,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
         });
         await db.SaveChangesAsync();
 
         var service = CreateService(db, graceSeconds: 30);
 
-        // Second request within the grace window
-        var result = await service.RefreshAsync("shared-rt");
+        await Assert.ThrowsAsync<ConflictException>(
+            () => service.RefreshAsync("shared-rt"));
 
-        Assert.Equal("already-issued-rt", result.RefreshToken);
+        var tokens = await db.RefreshTokens.ToListAsync();
+        Assert.All(tokens, t => Assert.Null(t.RevokedAt));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_ConcurrentStaleRotation_AllowsOnlyOneReplacement()
+    {
+        var databaseName = Guid.NewGuid().ToString();
+
+        await using (var seedDb = CreateContext(databaseName))
+        {
+            var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+            seedDb.Users.Add(user);
+            seedDb.RefreshTokens.Add(new RefreshToken
+            {
+                Token     = "race-rt",
+                UserId    = 1,
+                ExpiresAt = DateTime.UtcNow.AddDays(7),
+            });
+            await seedDb.SaveChangesAsync();
+        }
+
+        await using var firstDb = CreateContext(databaseName);
+        await using var secondDb = CreateContext(databaseName);
+
+        var firstTokenService = new Mock<ITokenService>();
+        firstTokenService.Setup(t => t.GenerateAccessToken(It.IsAny<AppUser>())).Returns("first-at");
+        firstTokenService.Setup(t => t.GenerateRefreshToken()).Returns("first-replacement-rt");
+
+        var secondTokenService = new Mock<ITokenService>();
+        secondTokenService.Setup(t => t.GenerateAccessToken(It.IsAny<AppUser>())).Returns("second-at");
+        secondTokenService.Setup(t => t.GenerateRefreshToken()).Returns("second-replacement-rt");
+
+        var firstService = CreateService(firstDb, tokenService: firstTokenService);
+        var secondService = CreateService(secondDb, tokenService: secondTokenService);
+
+        var firstStored = await firstDb.RefreshTokens.SingleAsync(t => t.Token == "race-rt");
+        var secondStored = await secondDb.RefreshTokens.SingleAsync(t => t.Token == "race-rt");
+        Assert.Null(firstStored.UsedAt);
+        Assert.Null(secondStored.UsedAt);
+
+        var firstResult = await firstService.RefreshAsync("race-rt");
+        var secondException = await Assert.ThrowsAsync<ConflictException>(
+            () => secondService.RefreshAsync("race-rt"));
+
+        Assert.Equal("first-replacement-rt", firstResult.RefreshToken);
+        Assert.Equal("Refresh token rotation conflict detected.", secondException.Message);
+
+        await using var verifyDb = CreateContext(databaseName);
+        var original = await verifyDb.RefreshTokens.SingleAsync(t => t.Token == "race-rt");
+        var replacements = await verifyDb.RefreshTokens
+            .Where(t => t.Token == "first-replacement-rt" || t.Token == "second-replacement-rt")
+            .ToListAsync();
+
+        Assert.NotNull(original.UsedAt);
+        Assert.Equal("first-replacement-rt", original.ReplacedByToken);
+        Assert.Single(replacements);
+        Assert.Equal("first-replacement-rt", replacements[0].Token);
     }
 
     [Fact]
@@ -466,5 +528,37 @@ public class AuthServiceTests
         // RevokedAt must not be overwritten
         var stored = await db.RefreshTokens.SingleAsync();
         Assert.Equal(revokedAt, stored.RevokedAt);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_ConcurrentStaleRevoke_IsIdempotent()
+    {
+        var databaseName = Guid.NewGuid().ToString();
+
+        await using (var seedDb = CreateContext(databaseName))
+        {
+            var user = new AppUser { Id = 1, UserName = "u", Email = "u@e.com" };
+            seedDb.Users.Add(user);
+            seedDb.RefreshTokens.Add(new RefreshToken
+            {
+                Token     = "logout-rt",
+                UserId    = 1,
+                ExpiresAt = DateTime.UtcNow.AddDays(7),
+            });
+            await seedDb.SaveChangesAsync();
+        }
+
+        await using var firstDb = CreateContext(databaseName);
+        await using var secondDb = CreateContext(databaseName);
+        _ = await firstDb.RefreshTokens.SingleAsync(t => t.Token == "logout-rt");
+        _ = await secondDb.RefreshTokens.SingleAsync(t => t.Token == "logout-rt");
+
+        var firstService = CreateService(firstDb);
+        var secondService = CreateService(secondDb);
+
+        await firstService.RevokeAsync("logout-rt");
+        var ex = await Record.ExceptionAsync(() => secondService.RevokeAsync("logout-rt"));
+
+        Assert.Null(ex);
     }
 }

--- a/inex.Services/Services/AccountService.cs
+++ b/inex.Services/Services/AccountService.cs
@@ -7,6 +7,7 @@ using inex.Services.Models.Records.Account;
 using inex.Services.Models.Records.Base;
 using inex.Services.Models.Records.Data;
 using inex.Services.Services.Base;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System;
 using System.Collections.Generic;
@@ -28,9 +29,11 @@ public class AccountService : InExService, IAccountService
 
     #region Public Interface
 
-    public async Task<AccountResponse> GetAsync(int id, CancellationToken ct = default)
+    public async Task<AccountResponse> GetAsync(int id, int userId, CancellationToken ct = default)
     {
-        var account = await DbInEx.AccountRepository.GetAsync(id, ct)
+        var account = await DbInEx.AccountRepository
+            .Get(false, i => i.Id == id && i.UserId == userId, i => i.Currency)
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Account {id} was not found.", "Account", id);
         return account.ToResponse();
     }
@@ -102,7 +105,9 @@ public class AccountService : InExService, IAccountService
         }
 
         // get item to update
-        var source = await DbInEx.AccountRepository.GetAsync(id, ct)
+        var source = await DbInEx.AccountRepository
+            .Get(false, i => i.Id == id && i.UserId == userId, i => i.Currency)
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Account {id} was not found.", "Account", id);
         // update item with new details
         source = itemDTO.ApplyTo(source);
@@ -115,10 +120,26 @@ public class AccountService : InExService, IAccountService
         return dest.Entity.ToResponse();
     }
 
-    public override async Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    public async Task DeleteAsync(int id, int userId, CancellationToken ct = default)
     {
-        DbInEx.AccountRepository.Delete(DbInEx.AccountRepository.Get(false).Where(i => ids.Contains(i.Id)));
+        var account = await DbInEx.AccountRepository
+            .Get(false, i => i.Id == id && i.UserId == userId)
+            .SingleOrDefaultAsync(ct)
+            ?? throw new ResourceNotFoundException($"Account {id} was not found.", "Account", id);
+
+        DbInEx.AccountRepository.Delete(account);
         await DbInEx.SaveAsync(ct);
+    }
+
+    public async Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default)
+    {
+        DbInEx.AccountRepository.Delete(DbInEx.AccountRepository.Get(false).Where(i => ids.Contains(i.Id) && i.UserId == userId));
+        await DbInEx.SaveAsync(ct);
+    }
+
+    public override Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    {
+        throw new OperationNotSupportedException("Account deletes require a current user id.");
     }
 
     #endregion Public Interface

--- a/inex.Services/Services/Auth/AuthService.cs
+++ b/inex.Services/Services/Auth/AuthService.cs
@@ -12,6 +12,8 @@ namespace inex.Services.Services.Auth;
 
 public class AuthService : IAuthService
 {
+    private const int MaxRevocationRetries = 3;
+
     private readonly UserManager<AppUser> _userManager;
     private readonly InExDbContext _db;
     private readonly ITokenService _tokenService;
@@ -84,17 +86,12 @@ public class AuthService : IAuthService
         if (stored.ExpiresAt < DateTime.UtcNow)
             throw new AuthenticationFailedException("Refresh token has expired.");
 
-        // Grace window: parallel requests may reuse the same token within the configured window
         if (stored.UsedAt is not null)
         {
-            var withinGraceWindow = DateTime.UtcNow - stored.UsedAt.Value < TimeSpan.FromSeconds(_jwt.RefreshGraceWindowSeconds);
-            if (withinGraceWindow && stored.ReplacedByToken is not null)
-                return new AuthResult(
-                    _tokenService.GenerateAccessToken(stored.User),
-                    stored.ReplacedByToken,
-                    _jwt.AccessTokenExpirySeconds);
+            var withinRaceWindow = DateTime.UtcNow - stored.UsedAt.Value < TimeSpan.FromSeconds(_jwt.RefreshGraceWindowSeconds);
+            if (withinRaceWindow && stored.ReplacedByToken is not null)
+                throw new ConflictException("Refresh token rotation conflict detected.", stored.Id);
 
-            // Reuse outside grace window — potential token theft
             await RevokeAllUserTokensAsync(stored.UserId, ct);
             throw new AuthenticationFailedException("Token reuse detected. All sessions have been revoked.");
         }
@@ -103,15 +100,25 @@ public class AuthService : IAuthService
         var newRefreshToken = _tokenService.GenerateRefreshToken();
         stored.UsedAt = DateTime.UtcNow;
         stored.ReplacedByToken = newRefreshToken;
+        stored.ConcurrencyStamp = CreateConcurrencyStamp();
 
-        _db.RefreshTokens.Add(new RefreshToken
+        var replacement = new RefreshToken
         {
             Token = newRefreshToken,
             UserId = stored.UserId,
             ExpiresAt = DateTime.UtcNow.AddDays(_jwt.RefreshTokenExpiryDays)
-        });
+        };
+        _db.RefreshTokens.Add(replacement);
 
-        await _db.SaveChangesAsync(ct);
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            await RemoveFailedReplacementAsync(replacement, ct);
+            throw new ConflictException("Refresh token rotation conflict detected.", stored.Id);
+        }
 
         return new AuthResult(
             _tokenService.GenerateAccessToken(stored.User),
@@ -128,7 +135,15 @@ public class AuthService : IAuthService
             return; // idempotent — logout is safe to call multiple times
 
         stored.RevokedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync(ct);
+        stored.ConcurrencyStamp = CreateConcurrencyStamp();
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            _db.ChangeTracker.Clear();
+        }
     }
 
     public async Task<AuthResult> UpdateProfileAsync(int userId, UpdateProfileRequest request, CancellationToken ct = default)
@@ -185,14 +200,49 @@ public class AuthService : IAuthService
 
     private async Task RevokeAllUserTokensAsync(int userId, CancellationToken ct = default)
     {
-        var tokens = await _db.RefreshTokens
-            .Where(t => t.UserId == userId && t.RevokedAt == null)
-            .ToListAsync(ct);
+        for (var attempt = 1; attempt <= MaxRevocationRetries; attempt++)
+        {
+            var tokens = await _db.RefreshTokens
+                .Where(t => t.UserId == userId && t.RevokedAt == null)
+                .ToListAsync(ct);
 
-        var now = DateTime.UtcNow;
-        foreach (var token in tokens)
-            token.RevokedAt = now;
+            if (tokens.Count == 0)
+                return;
 
+            var now = DateTime.UtcNow;
+            foreach (var token in tokens)
+            {
+                token.RevokedAt = now;
+                token.ConcurrencyStamp = CreateConcurrencyStamp();
+            }
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+                return;
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                _db.ChangeTracker.Clear();
+                if (attempt == MaxRevocationRetries)
+                    throw new ConflictException("Refresh token revocation conflict detected.", userId);
+            }
+        }
+    }
+
+    private static string CreateConcurrencyStamp() => Guid.NewGuid().ToString("N");
+
+    private async Task RemoveFailedReplacementAsync(RefreshToken replacement, CancellationToken ct)
+    {
+        _db.ChangeTracker.Clear();
+
+        var persistedReplacement = await _db.RefreshTokens
+            .FirstOrDefaultAsync(t => t.Token == replacement.Token, ct);
+
+        if (persistedReplacement is null)
+            return;
+
+        _db.RefreshTokens.Remove(persistedReplacement);
         await _db.SaveChangesAsync(ct);
     }
 }

--- a/inex.Services/Services/Base/IAccountService.cs
+++ b/inex.Services/Services/Base/IAccountService.cs
@@ -9,9 +9,11 @@ namespace inex.Services.Services.Base;
 
 public interface IAccountService : IInExService
 {
-    Task<AccountResponse> GetAsync(int id, CancellationToken ct = default);
+    Task<AccountResponse> GetAsync(int id, int userId, CancellationToken ct = default);
     ListResponse<AccountResponse> Get(int userId, ActivityMode mode);
     ListResponse<AccountSummary> GetDetails(int userId, IEnumerable<int> ids);
     Task<CreatedResponse> CreateAsync(CreateAccountRequest itemDTO, int userId, CancellationToken ct = default);
     Task<AccountResponse> UpdateAsync(int id, UpdateAccountRequest itemDTO, int userId, CancellationToken ct = default);
+    Task DeleteAsync(int id, int userId, CancellationToken ct = default);
+    Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default);
 }

--- a/inex.Services/Services/Base/IBudgetService.cs
+++ b/inex.Services/Services/Base/IBudgetService.cs
@@ -7,9 +7,11 @@ namespace inex.Services.Services.Base;
 
 public interface IBudgetService : IInExService
 {
-    Task<BudgetResponse> GetAsync(int id, CancellationToken ct = default);
+    Task<BudgetResponse> GetAsync(int id, int userId, CancellationToken ct = default);
     ListResponse<BudgetResponse> Get(int userId, int? year = null, int? month = null);
     Task<CreatedResponse> CreateAsync(CreateBudgetRequest itemDTO, int userId, CancellationToken ct = default);
     Task<BudgetResponse> UpdateAsync(int id, UpdateBudgetRequest itemDTO, int userId, CancellationToken ct = default);
+    Task DeleteAsync(int id, int userId, CancellationToken ct = default);
+    Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default);
     Task CopyBudgetsAsync(int userId, int sourceYear, int sourceMonth, int targetYear, int targetMonth, CancellationToken ct = default);
 }

--- a/inex.Services/Services/Base/ICategoryService.cs
+++ b/inex.Services/Services/Base/ICategoryService.cs
@@ -8,8 +8,10 @@ namespace inex.Services.Services.Base;
 
 public interface ICategoryService : IInExService
 {
-    Task<CategoryResponse> GetAsync(int id, CancellationToken ct = default);
+    Task<CategoryResponse> GetAsync(int id, int userId, CancellationToken ct = default);
     ListResponse<CategoryResponse> Get(int userId, ActivityMode mode);
     Task<CreatedResponse> CreateAsync(CreateCategoryRequest itemDTO, int userId, CancellationToken ct = default);
     Task<CategoryResponse> UpdateAsync(int id, UpdateCategoryRequest itemDTO, int userId, CancellationToken ct = default);
+    Task DeleteAsync(int id, int userId, CancellationToken ct = default);
+    Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default);
 }

--- a/inex.Services/Services/Base/ITransactionService.cs
+++ b/inex.Services/Services/Base/ITransactionService.cs
@@ -9,10 +9,12 @@ namespace inex.Services.Services.Base;
 
 public interface ITransactionService : IInExService
 {
-    Task<TransactionResponse> GetAsync(int id, CancellationToken ct = default);
+    Task<TransactionResponse> GetAsync(int id, int userId, CancellationToken ct = default);
     ListResponse<TransactionResponse> Get(int userId, ActivityMode mode, IDictionary<string, string> filters);
     PagedResponse<TransactionResponse, PaginationMetadata> Get(int userId, ActivityMode mode, int pageSize, int pageNumber, IDictionary<string, string> filters);
     Task<CreatedResponse> CreateAsync(CreateTransactionRequest itemDTO, int userId, CancellationToken ct = default);
     Task<TransferResponse> CreateAsync(CreateTransferRequest itemDTO, int userId, CancellationToken ct = default);
     Task<TransactionResponse> UpdateAsync(int id, UpdateTransactionRequest itemDTO, int userId, CancellationToken ct = default);
+    Task DeleteAsync(int id, int userId, CancellationToken ct = default);
+    Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default);
 }

--- a/inex.Services/Services/Base/Service.cs
+++ b/inex.Services/Services/Base/Service.cs
@@ -55,7 +55,7 @@ public abstract class Service : IDisposable
     {
         return new ListResponse<K>
         {
-            Data = items.Select(map)
+            Data = items.Select(map).ToList()
         };
     }
 

--- a/inex.Services/Services/BudgetReportService.cs
+++ b/inex.Services/Services/BudgetReportService.cs
@@ -53,7 +53,7 @@ public class BudgetReportService : Service, IBudgetReportService
 
         // 2.1 Get Accounts to resolve currency correctly
         var accountsResponse = _accountService.Get(userId, ActivityMode.ALL);
-        var accounts = accountsResponse.Data;
+        var accounts = accountsResponse.Data.ToDictionary(a => a.Id);
 
         // 2.2 Get Categories to identify system categories
         var categoriesResponse = _categoryService.Get(userId, ActivityMode.ALL);
@@ -84,7 +84,7 @@ public class BudgetReportService : Service, IBudgetReportService
             decimal amountInTargetCurrency = 0;
 
             // Resolve account currency from the accounts list
-            var account = accounts.FirstOrDefault(a => a.Id == transaction.AccountId);
+            accounts.TryGetValue(transaction.AccountId, out var account);
             var transactionCurrency = account?.Currency ?? transaction.AccountCurrency;
 
             // If transaction currency matches report currency, use amount directly
@@ -95,7 +95,7 @@ public class BudgetReportService : Service, IBudgetReportService
             else
             {
                 // O(1) exact-date lookup
-                if (rateMap.TryGetValue((transactionCurrency, transaction.Created.Date), out var rate))
+                if (rateMap.TryGetValue((transactionCurrency, transaction.Created.Date), out var rate) && rate.Rate != 0)
                 {
                     amountInTargetCurrency = transaction.Amount / rate.Rate;
                 }
@@ -103,7 +103,7 @@ public class BudgetReportService : Service, IBudgetReportService
                 {
                     // Fallback: nearest date for the same currency pair
                     var fallbackRate = rates
-                        .Where(r => r.CurrencyTo == transactionCurrency)
+                        .Where(r => r.CurrencyTo == transactionCurrency && r.Rate != 0)
                         .OrderBy(r => Math.Abs((r.Date.Date - transaction.Created.Date).TotalDays))
                         .FirstOrDefault();
 

--- a/inex.Services/Services/BudgetService.cs
+++ b/inex.Services/Services/BudgetService.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using inex.Services.Models.Records.Budget;
+using Microsoft.EntityFrameworkCore;
 
 namespace inex.Services.Services;
 
@@ -26,9 +27,11 @@ public class BudgetService : InExService, IBudgetService
 
     #region Public Interface
 
-    public async Task<BudgetResponse> GetAsync(int id, CancellationToken ct = default)
+    public async Task<BudgetResponse> GetAsync(int id, int userId, CancellationToken ct = default)
     {
-        var budget = await DbInEx.BudgetRepository.GetAsync(id, ct)
+        var budget = await DbInEx.BudgetRepository
+            .Get(false, i => i.Id == id && i.UserId == userId, i => i.BudgetCategories)
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Budget {id} was not found.", "Budget", id);
         return budget.ToResponse();
     }
@@ -51,6 +54,7 @@ public class BudgetService : InExService, IBudgetService
         if (budget.Year == 0) budget.Year = System.DateTime.Now.Year;
         if (budget.Month == 0) budget.Month = System.DateTime.Now.Month;
 
+        await EnsureCategoriesBelongToUserAsync(itemDTO.CategoryIds, userId, ct);
         ValidateCategoryUniqueness(userId, budget.Year, budget.Month, itemDTO.CategoryIds);
 
         // put information about created item to the database
@@ -90,12 +94,15 @@ public class BudgetService : InExService, IBudgetService
         }
 
         // get item to update with categories loaded
-        var source = await DbInEx.BudgetRepository.GetAsync(id, ct)
+        var source = await DbInEx.BudgetRepository
+            .Get(false, i => i.Id == id && i.UserId == userId, i => i.BudgetCategories)
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Budget {id} was not found.", "Budget", id);
         // update item with new details
         source = itemDTO.ApplyTo(source);
         source.UpdatedBy = userId;
 
+        await EnsureCategoriesBelongToUserAsync(itemDTO.CategoryIds, userId, ct);
         ValidateCategoryUniqueness(userId, source.Year, source.Month, itemDTO.CategoryIds, id);
 
         // Handle category assignments: unassign removed categories and assign new ones
@@ -133,9 +140,25 @@ public class BudgetService : InExService, IBudgetService
         return dest.Entity.ToResponse();
     }
 
-    public override async Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    public async Task DeleteAsync(int id, int userId, CancellationToken ct = default)
     {
-        var budgets = DbInEx.BudgetRepository.Get(false, i => ids.Contains(i.Id), i => i.BudgetCategories).ToList();
+        var budget = await DbInEx.BudgetRepository
+            .Get(false, i => i.Id == id && i.UserId == userId, i => i.BudgetCategories)
+            .SingleOrDefaultAsync(ct)
+            ?? throw new ResourceNotFoundException($"Budget {id} was not found.", "Budget", id);
+
+        if (budget.BudgetCategories != null && budget.BudgetCategories.Any())
+        {
+            DbInEx.BudgetCategoryRepository.Delete(budget.BudgetCategories);
+        }
+
+        DbInEx.BudgetRepository.Delete(budget);
+        await DbInEx.SaveAsync(ct);
+    }
+
+    public async Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default)
+    {
+        var budgets = DbInEx.BudgetRepository.Get(false, i => ids.Contains(i.Id) && i.UserId == userId, i => i.BudgetCategories).ToList();
 
         foreach (var budget in budgets)
         {
@@ -147,6 +170,11 @@ public class BudgetService : InExService, IBudgetService
 
         DbInEx.BudgetRepository.Delete(budgets);
         await DbInEx.SaveAsync(ct);
+    }
+
+    public override Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    {
+        throw new OperationNotSupportedException("Budget deletes require a current user id.");
     }
 
     public async Task CopyBudgetsAsync(int userId, int sourceYear, int sourceMonth, int targetYear, int targetMonth, CancellationToken ct = default)
@@ -245,6 +273,23 @@ public class BudgetService : InExService, IBudgetService
             throw new DomainRuleException(
                 "category-uniqueness",
                 $"Categories already assigned in this period: {string.Join(", ", categoryNames)}");
+        }
+    }
+
+    private async Task EnsureCategoriesBelongToUserAsync(IEnumerable<int>? categoryIds, int userId, CancellationToken ct)
+    {
+        var requestedIds = categoryIds?.Distinct().ToList() ?? [];
+        if (requestedIds.Count == 0) return;
+
+        var ownedIds = await DbInEx.CategoryRepository
+            .Get(true, i => requestedIds.Contains(i.Id) && i.UserId == userId)
+            .Select(i => i.Id)
+            .ToListAsync(ct);
+
+        var missingId = requestedIds.Except(ownedIds).FirstOrDefault();
+        if (missingId > 0)
+        {
+            throw new ResourceNotFoundException($"Category {missingId} was not found.", "Category", missingId);
         }
     }
 

--- a/inex.Services/Services/CategoryService.cs
+++ b/inex.Services/Services/CategoryService.cs
@@ -7,6 +7,7 @@ using inex.Services.Models.Records.Base;
 using inex.Services.Models.Records.Category;
 using inex.Services.Models.Records.Data;
 using inex.Services.Services.Base;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,9 +28,11 @@ public class CategoryService : InExService, ICategoryService
 
     #region Public Interface
 
-    public async Task<CategoryResponse> GetAsync(int id, CancellationToken ct = default)
+    public async Task<CategoryResponse> GetAsync(int id, int userId, CancellationToken ct = default)
     {
-        var category = await DbInEx.CategoryRepository.GetAsync(id, ct)
+        var category = await DbInEx.CategoryRepository
+            .Get(false, i => i.Id == id && i.UserId == userId)
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Category {id} was not found.", "Category", id);
         return category.ToResponse();
     }
@@ -68,7 +71,9 @@ public class CategoryService : InExService, ICategoryService
         }
 
         // get item to update
-        var source = await DbInEx.CategoryRepository.GetAsync(id, ct)
+        var source = await DbInEx.CategoryRepository
+            .Get(false, i => i.Id == id && i.UserId == userId)
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Category {id} was not found.", "Category", id);
         // update item with new details
         source = itemDTO.ApplyTo(source);
@@ -81,11 +86,29 @@ public class CategoryService : InExService, ICategoryService
         return dest.Entity.ToResponse();
     }
 
-    public override async Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    public async Task DeleteAsync(int id, int userId, CancellationToken ct = default)
+    {
+        var category = await DbInEx.CategoryRepository
+            .Get(false, i => i.Id == id && i.UserId == userId)
+            .SingleOrDefaultAsync(ct)
+            ?? throw new ResourceNotFoundException($"Category {id} was not found.", "Category", id);
+
+        if (category.IsSystem)
+        {
+            throw new DomainRuleException(
+                "system-category-delete",
+                $"System categories cannot be deleted: {category.Id}.");
+        }
+
+        DbInEx.CategoryRepository.Delete(category);
+        await DbInEx.SaveAsync(ct);
+    }
+
+    public async Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default)
     {
         var systemIds = DbInEx.CategoryRepository
             .Get(true)
-            .Where(i => ids.Contains(i.Id) && i.IsSystem)
+            .Where(i => ids.Contains(i.Id) && i.UserId == userId && i.IsSystem)
             .Select(i => i.Id)
             .ToList();
 
@@ -94,8 +117,13 @@ public class CategoryService : InExService, ICategoryService
                 "system-category-delete",
                 $"System categories cannot be deleted: {string.Join(", ", systemIds)}.");
 
-        DbInEx.CategoryRepository.Delete(DbInEx.CategoryRepository.Get(false).Where(i => ids.Contains(i.Id)));
+        DbInEx.CategoryRepository.Delete(DbInEx.CategoryRepository.Get(false).Where(i => ids.Contains(i.Id) && i.UserId == userId));
         await DbInEx.SaveAsync(ct);
+    }
+
+    public override Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    {
+        throw new OperationNotSupportedException("Category deletes require a current user id.");
     }
 
     #endregion Public Interface

--- a/inex.Services/Services/ReportService.cs
+++ b/inex.Services/Services/ReportService.cs
@@ -51,7 +51,7 @@ public class ReportService : Service, IReportService
         foreach (var r in rates) rateMap.TryAdd((r.CurrencyTo, r.Date.Date), r);
 
         // 3. Get Accounts (to know transaction currency)
-        var accounts = _accountService.Get(userId, ActivityMode.ALL).Data;
+        var accounts = _accountService.Get(userId, ActivityMode.ALL).Data.ToDictionary(a => a.Id);
 
         // 4. Get Categories (to exclude system transfers)
         var categories = _categoryService.Get(userId, ActivityMode.ALL).Data;
@@ -70,7 +70,7 @@ public class ReportService : Service, IReportService
             foreach (var t in monthTransactions)
             {
                 // Determine transaction currency
-                var account = accounts.FirstOrDefault(a => a.Id == t.AccountId);
+                accounts.TryGetValue(t.AccountId, out var account);
                 var tCurrency = account?.Currency ?? currency;
 
                 // Convert amount if needed
@@ -106,8 +106,9 @@ public class ReportService : Service, IReportService
         IEnumerable<ExchangeRateResponse> rates = (await _exchangeRateService.Get(userId, start, end, currency, ct)).Data;
         var rateMap = new Dictionary<(string, DateTime), ExchangeRateResponse>();
         foreach (var r in rates) rateMap.TryAdd((r.CurrencyTo, r.Date.Date), r);
-        IEnumerable<AccountResponse> accounts = _accountService.Get(userId, ActivityMode.ALL).Data;
-        IEnumerable<CategoryResponse> categories = _categoryService.Get(userId, ActivityMode.ACTIVE).Data.Where(i => !i.IsSystem);
+        var accounts = _accountService.Get(userId, ActivityMode.ALL).Data.ToDictionary(a => a.Id);
+        var categories = _categoryService.Get(userId, ActivityMode.ACTIVE).Data.Where(i => !i.IsSystem).ToList();
+        var categoryIds = categories.Select(c => c.Id).ToHashSet();
         IEnumerable<TransactionResponse> transactions = _transactionService.Get(userId, ActivityMode.ALL, filters).Data;
 
         PagedResponse<CategorySummary, ReportMetadata> resultDTO = BuildReportDataResponse<CategoryResponse, CategorySummary>(categories, "Расходы по категориям", currency, CategoryMapper.ToSummary, start, end);
@@ -115,12 +116,11 @@ public class ReportService : Service, IReportService
         var categoryValues = new Dictionary<int, decimal>();
         foreach (TransactionResponse transaction in transactions)
         {
-            var account = accounts.FirstOrDefault(i => i.Id == transaction.AccountId);
-            if (account == null) continue;
+            if (!accounts.TryGetValue(transaction.AccountId, out var account)) continue;
             rateMap.TryGetValue((account.Currency, transaction.Created.Date), out ExchangeRateResponse? rate);
-            if (categories.Any(i => i.Id == transaction.CategoryId))
+            if (categoryIds.Contains(transaction.CategoryId))
             {
-                decimal amount = rate != null ? transaction.Amount / rate.Rate : transaction.Amount;
+                decimal amount = rate != null && rate.Rate != 0 ? transaction.Amount / rate.Rate : transaction.Amount;
                 categoryValues[transaction.CategoryId] = categoryValues.GetValueOrDefault(transaction.CategoryId) + amount;
             }
         }

--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -13,6 +13,7 @@ using inex.Services.Services.Base;
 using inex.Services.Models.Enums;
 using inex.Services.Helpers;
 using inex.Services.Models.Mappers;
+using Microsoft.EntityFrameworkCore;
 
 namespace inex.Services.Services;
 
@@ -28,9 +29,11 @@ public class TransactionService : InExService, ITransactionService
 
     #region Public Interface
 
-    public async Task<TransactionResponse> GetAsync(int id, CancellationToken ct = default)
+    public async Task<TransactionResponse> GetAsync(int id, int userId, CancellationToken ct = default)
     {
-        var transaction = await DbInEx.TransactionRepository.GetAsync(id, ct)
+        var transaction = await DbInEx.TransactionRepository
+            .GetWithIncludePaths(false, i => i.Id == id && i.UserId == userId, "TransactionTagDetails.Tag")
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Transaction {id} was not found.", "Transaction", id);
         return transaction.ToResponse();
     }
@@ -49,6 +52,7 @@ public class TransactionService : InExService, ITransactionService
 
     public async Task<CreatedResponse> CreateAsync(CreateTransactionRequest itemDTO, int userId, CancellationToken ct = default)
     {
+        await EnsureTransactionRelationsBelongToUserAsync(itemDTO.AccountId, itemDTO.CategoryId, userId, ct);
 
         Transaction transaction = itemDTO.ToEntity();
         transaction.UserId = userId;
@@ -106,8 +110,12 @@ public class TransactionService : InExService, ITransactionService
         }
 
         // get item to update
-        var source = await DbInEx.TransactionRepository.GetAsync(id, ct)
+        var source = await DbInEx.TransactionRepository
+            .GetWithIncludePaths(false, i => i.Id == id && i.UserId == userId, "TransactionTagDetails.Tag")
+            .SingleOrDefaultAsync(ct)
             ?? throw new ResourceNotFoundException($"Transaction {id} was not found.", "Transaction", id);
+
+        await EnsureTransactionRelationsBelongToUserAsync(itemDTO.AccountId, itemDTO.CategoryId, userId, ct);
 
         // update item with new details
         source = itemDTO.ApplyTo(source);
@@ -122,9 +130,28 @@ public class TransactionService : InExService, ITransactionService
         return dest.Entity.ToResponse();
     }
 
-    public override async Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    public async Task DeleteAsync(int id, int userId, CancellationToken ct = default)
     {
-        await DbInEx.TransactionRepository.ExecuteDeleteAsync(i => ids.Contains(i.Id), ct);
+        var transaction = await DbInEx.TransactionRepository
+            .Get(false, i => i.Id == id && i.UserId == userId)
+            .SingleOrDefaultAsync(ct)
+            ?? throw new ResourceNotFoundException($"Transaction {id} was not found.", "Transaction", id);
+
+        DbInEx.TransactionRepository.Delete(transaction);
+        await DbInEx.SaveAsync(ct);
+    }
+
+    public async Task DeleteAsync(IEnumerable<int> ids, int userId, CancellationToken ct = default)
+    {
+        var transactions = DbInEx.TransactionRepository.Get(false, i => ids.Contains(i.Id) && i.UserId == userId).ToList();
+
+        DbInEx.TransactionRepository.Delete(transactions);
+        await DbInEx.SaveAsync(ct);
+    }
+
+    public override Task DeleteAsync(IEnumerable<int> ids, CancellationToken ct = default)
+    {
+        throw new OperationNotSupportedException("Transaction deletes require a current user id.");
     }
 
     public static IQueryable<Transaction> ApplyFilters(IQueryable<Transaction> items, IDictionary<string, string> filters)
@@ -243,6 +270,27 @@ public class TransactionService : InExService, ITransactionService
         foreach (string item in tagsRemove)
         {
             transaction.TransactionTagDetails.Remove(transaction.TransactionTagDetails.First(i => i.TagId == tagsAll.First(i => i.Key == item).Id));
+        }
+    }
+
+    private async Task EnsureTransactionRelationsBelongToUserAsync(int accountId, int categoryId, int userId, CancellationToken ct)
+    {
+        bool accountExists = await DbInEx.AccountRepository
+            .Get(true, i => i.Id == accountId && i.UserId == userId)
+            .AnyAsync(ct);
+
+        if (!accountExists)
+        {
+            throw new ResourceNotFoundException($"Account {accountId} was not found.", "Account", accountId);
+        }
+
+        bool categoryExists = await DbInEx.CategoryRepository
+            .Get(true, i => i.Id == categoryId && i.UserId == userId)
+            .AnyAsync(ct);
+
+        if (!categoryExists)
+        {
+            throw new ResourceNotFoundException($"Category {categoryId} was not found.", "Category", categoryId);
         }
     }
 

--- a/inex.Tests/Accounts/AccountsControllerTests.cs
+++ b/inex.Tests/Accounts/AccountsControllerTests.cs
@@ -80,6 +80,18 @@ public class AccountsControllerTests : IClassFixture<InExWebApplicationFactory>
     // ── PUT /api/accounts/{id} ────────────────────────────────────────────────
 
     [Fact]
+    public async Task Single_OtherUsersAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateAccountAsync(userB, "other-get");
+
+        var response = await userA.GetAsync($"/api/accounts/{id}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
     public async Task Update_ExistingAccount_Returns200WithUpdatedName()
     {
         var client = await _factory.CreateAuthenticatedClientAsync(
@@ -114,6 +126,25 @@ public class AccountsControllerTests : IClassFixture<InExWebApplicationFactory>
         Assert.Equal("Renamed", body.GetProperty("name").GetString());
     }
 
+    [Fact]
+    public async Task Update_OtherUsersAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateAccountAsync(userB, "other-put");
+
+        var response = await userA.PutAsJsonAsync($"/api/accounts/{id}", new
+        {
+            id,
+            key        = "other-put",
+            name       = "Attempted Rename",
+            currencyId = 1,
+            isEnabled  = true,
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
     // ── DELETE /api/accounts/{id} ─────────────────────────────────────────────
 
     [Fact]
@@ -140,6 +171,18 @@ public class AccountsControllerTests : IClassFixture<InExWebApplicationFactory>
     }
 
     [Fact]
+    public async Task Delete_OtherUsersAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateAccountAsync(userB, "other-delete");
+
+        var response = await userA.DeleteAsync($"/api/accounts/{id}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
     public async Task Delete_Unauthenticated_Returns401()
     {
         var client = _factory.CreateClient();
@@ -147,5 +190,25 @@ public class AccountsControllerTests : IClassFixture<InExWebApplicationFactory>
         var response = await client.DeleteAsync("/api/accounts/1");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private Task<HttpClient> CreateAuthenticatedClientAsync() =>
+        _factory.CreateAuthenticatedClientAsync(
+            email: $"{Guid.NewGuid()}@example.com",
+            username: $"user-{Guid.NewGuid():N}");
+
+    private static async Task<int> CreateAccountAsync(HttpClient client, string key)
+    {
+        var createResponse = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            key,
+            name       = key,
+            currencyId = 1,
+            isEnabled  = true,
+        });
+        createResponse.EnsureSuccessStatusCode();
+
+        var body = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
     }
 }

--- a/inex.Tests/Auth/AuthControllerTests.cs
+++ b/inex.Tests/Auth/AuthControllerTests.cs
@@ -1,5 +1,8 @@
 using System.Net.Http.Json;
+using inex.Data;
 using inex.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using static inex.Tests.Infrastructure.InExWebApplicationFactory;
 
 namespace inex.Tests.Auth;
@@ -256,6 +259,48 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
     // ── Me ────────────────────────────────────────────────────────────────────
 
     [Fact]
+    public async Task Refresh_WithSameCookieConcurrently_AllowsOnlyOneSuccessfulRotation()
+    {
+        var registerClient = _factory.CreateClient();
+        var registerResponse = await registerClient.PostAsJsonAsync("/api/auth/register", new
+        {
+            username    = $"user-{Guid.NewGuid():N}",
+            email       = $"{Guid.NewGuid()}@example.com",
+            password    = "Password1!",
+            inviteToken = TestInviteToken,
+            currencyId  = 1,
+        });
+        registerResponse.EnsureSuccessStatusCode();
+
+        var refreshToken = ExtractRefreshToken(registerResponse);
+        var firstClient = _factory.CreateClient();
+        var secondClient = _factory.CreateClient();
+        firstClient.DefaultRequestHeaders.Add("Cookie", $"refreshToken={refreshToken}");
+        secondClient.DefaultRequestHeaders.Add("Cookie", $"refreshToken={refreshToken}");
+
+        var responses = await Task.WhenAll(
+            firstClient.PostAsync("/api/auth/refresh", null),
+            secondClient.PostAsync("/api/auth/refresh", null));
+
+        Assert.Equal(1, responses.Count(r => r.StatusCode == HttpStatusCode.OK));
+        var nonSuccess = Assert.Single(responses, r => r.StatusCode != HttpStatusCode.OK);
+        Assert.Contains(nonSuccess.StatusCode, new[] { HttpStatusCode.Unauthorized, HttpStatusCode.Conflict });
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InExDbContext>();
+        var original = await db.RefreshTokens.SingleAsync(t => t.Token == refreshToken);
+        var replacements = await db.RefreshTokens
+            .Where(t => t.UserId == original.UserId && t.Token != refreshToken)
+            .ToListAsync();
+
+        Assert.NotNull(original.UsedAt);
+        Assert.False(string.IsNullOrEmpty(original.ReplacedByToken));
+        Assert.Single(replacements);
+        Assert.Equal(original.ReplacedByToken, replacements[0].Token);
+        Assert.Null(replacements[0].RevokedAt);
+    }
+
+    [Fact]
     public async Task Me_WithValidToken_Returns200WithUserProfile()
     {
         var email  = $"{Guid.NewGuid()}@example.com";
@@ -390,5 +435,22 @@ public class AuthControllerTests : IClassFixture<InExWebApplicationFactory>
         // now-revoked cookie, because the token is marked RevokedAt in the DB
         var refreshAfterLogout = await client.PostAsync("/api/auth/refresh", null);
         Assert.Equal(HttpStatusCode.Unauthorized, refreshAfterLogout.StatusCode);
+    }
+
+    private static string ExtractRefreshToken(HttpResponseMessage response)
+    {
+        var setCookie = response.Headers
+            .FirstOrDefault(h => h.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
+            .Value?.FirstOrDefault(h => h.StartsWith("refreshToken=", StringComparison.OrdinalIgnoreCase));
+
+        Assert.False(string.IsNullOrWhiteSpace(setCookie));
+
+        var tokenStart = "refreshToken=".Length;
+        var tokenEnd = setCookie.IndexOf(';', tokenStart);
+        var token = tokenEnd < 0
+            ? setCookie[tokenStart..]
+            : setCookie[tokenStart..tokenEnd];
+
+        return Uri.UnescapeDataString(token);
     }
 }

--- a/inex.Tests/Budgets/BudgetsControllerTests.cs
+++ b/inex.Tests/Budgets/BudgetsControllerTests.cs
@@ -1,0 +1,186 @@
+using System.Net.Http.Json;
+using inex.Tests.Infrastructure;
+
+namespace inex.Tests.Budgets;
+
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class BudgetsControllerTests : IClassFixture<InExWebApplicationFactory>
+{
+    private readonly InExWebApplicationFactory _factory;
+
+    public BudgetsControllerTests(InExWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Single_OwnerBudget_Returns200()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int id = await CreateBudgetAsync(client, "owner-get");
+
+        var response = await client.GetAsync($"/api/budgets/{id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Single_OtherUsersBudget_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateBudgetAsync(userB, "other-get");
+
+        var response = await userA.GetAsync($"/api/budgets/{id}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Update_OwnerBudget_Returns200()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int id = await CreateBudgetAsync(client, "owner-put");
+
+        var response = await client.PutAsJsonAsync($"/api/budgets/{id}", new
+        {
+            id,
+            key         = "owner-put",
+            name        = "Renamed Budget",
+            description = "Updated",
+            year        = 2026,
+            month       = 5,
+            value       = 250m,
+            categoryIds = Array.Empty<int>(),
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_OtherUsersBudget_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateBudgetAsync(userB, "other-put");
+
+        var response = await userA.PutAsJsonAsync($"/api/budgets/{id}", new
+        {
+            id,
+            key         = "other-put",
+            name        = "Attempted Rename",
+            description = "Updated",
+            year        = 2026,
+            month       = 5,
+            value       = 250m,
+            categoryIds = Array.Empty<int>(),
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Create_WithOtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int categoryId = await CreateCategoryAsync(userB, "other-create-category");
+
+        var response = await userA.PostAsJsonAsync("/api/budgets", new
+        {
+            key         = "cross-category-create",
+            name        = "Cross Category Create",
+            description = "Attempted",
+            year        = 2026,
+            month       = 5,
+            value       = 100m,
+            categoryIds = new[] { categoryId },
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Update_WithOtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int budgetId = await CreateBudgetAsync(userA, "cross-category-update-budget");
+        int categoryId = await CreateCategoryAsync(userB, "other-update-category");
+
+        var response = await userA.PutAsJsonAsync($"/api/budgets/{budgetId}", new
+        {
+            id          = budgetId,
+            key         = "cross-category-update-budget",
+            name        = "Cross Category Update",
+            description = "Attempted",
+            year        = 2026,
+            month       = 5,
+            value       = 250m,
+            categoryIds = new[] { categoryId },
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Delete_OwnerBudget_Returns200()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int id = await CreateBudgetAsync(client, "owner-delete");
+
+        var response = await client.DeleteAsync($"/api/budgets/{id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_OtherUsersBudget_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateBudgetAsync(userB, "other-delete");
+
+        var response = await userA.DeleteAsync($"/api/budgets/{id}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    private Task<HttpClient> CreateAuthenticatedClientAsync() =>
+        _factory.CreateAuthenticatedClientAsync(
+            email: $"{Guid.NewGuid()}@example.com",
+            username: $"user-{Guid.NewGuid():N}");
+
+    private static async Task<int> CreateBudgetAsync(HttpClient client, string key)
+    {
+        var createResponse = await client.PostAsJsonAsync("/api/budgets", new
+        {
+            key,
+            name        = key,
+            description = key,
+            year        = 2026,
+            month       = 5,
+            value       = 100m,
+            categoryIds = Array.Empty<int>(),
+        });
+        createResponse.EnsureSuccessStatusCode();
+
+        var body = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private static async Task<int> CreateCategoryAsync(HttpClient client, string key)
+    {
+        var createResponse = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key,
+            name      = key,
+            isEnabled = true,
+            isSystem  = false,
+        });
+        createResponse.EnsureSuccessStatusCode();
+
+        var body = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+}

--- a/inex.Tests/Categories/CategoriesControllerTests.cs
+++ b/inex.Tests/Categories/CategoriesControllerTests.cs
@@ -82,6 +82,18 @@ public class CategoriesControllerTests : IClassFixture<InExWebApplicationFactory
     // ── PUT /api/categories/{id} ──────────────────────────────────────────────
 
     [Fact]
+    public async Task Single_OtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateCategoryAsync(userB, "other-get");
+
+        var response = await userA.GetAsync($"/api/categories/{id}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
     public async Task Update_ExistingCategory_Returns200WithUpdatedName()
     {
         var client = await _factory.CreateAuthenticatedClientAsync(
@@ -112,6 +124,25 @@ public class CategoriesControllerTests : IClassFixture<InExWebApplicationFactory
 
         var body = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("Renamed", body.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task Update_OtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateCategoryAsync(userB, "other-put");
+
+        var response = await userA.PutAsJsonAsync($"/api/categories/{id}", new
+        {
+            id,
+            key       = "other-put",
+            name      = "Attempted Rename",
+            isEnabled = true,
+            isSystem  = false,
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
     }
 
     // ── DELETE /api/categories/{id} ───────────────────────────────────────────
@@ -169,6 +200,18 @@ public class CategoriesControllerTests : IClassFixture<InExWebApplicationFactory
     }
 
     [Fact]
+    public async Task Delete_OtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int id = await CreateCategoryAsync(userB, "other-delete");
+
+        var response = await userA.DeleteAsync($"/api/categories/{id}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
     public async Task Delete_Unauthenticated_Returns401()
     {
         var client = _factory.CreateClient();
@@ -176,5 +219,25 @@ public class CategoriesControllerTests : IClassFixture<InExWebApplicationFactory
         var response = await client.DeleteAsync("/api/categories/1");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private Task<HttpClient> CreateAuthenticatedClientAsync() =>
+        _factory.CreateAuthenticatedClientAsync(
+            email: $"{Guid.NewGuid()}@example.com",
+            username: $"user-{Guid.NewGuid():N}");
+
+    private static async Task<int> CreateCategoryAsync(HttpClient client, string key)
+    {
+        var createResponse = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key,
+            name      = key,
+            isEnabled = true,
+            isSystem  = false,
+        });
+        createResponse.EnsureSuccessStatusCode();
+
+        var body = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
     }
 }

--- a/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
+++ b/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.RateLimiting;
 using inex.Data;
+using inex.Data.Models;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.RateLimiting;
@@ -93,6 +94,23 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
         string username = "testuser",
         string password = "Password1!")
     {
+        using (var scope = Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<InExDbContext>();
+            if (!db.Set<Currency>().Any(c => c.Id == 1))
+            {
+                db.Set<Currency>().Add(new Currency
+                {
+                    Id = 1,
+                    Key = "USD",
+                    Name = "USD",
+                    Created = DateTime.UtcNow,
+                    Updated = DateTime.UtcNow
+                });
+                await db.SaveChangesAsync();
+            }
+        }
+
         var anonClient = CreateClient();
 
         var response = await anonClient.PostAsJsonAsync("/api/auth/register", new

--- a/inex.Tests/Infrastructure/ProblemDetailsAssertions.cs
+++ b/inex.Tests/Infrastructure/ProblemDetailsAssertions.cs
@@ -1,0 +1,15 @@
+namespace inex.Tests.Infrastructure;
+
+internal static class ProblemDetailsAssertions
+{
+    public static async Task AssertNotFoundProblemAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("owner", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("owned", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("forbidden", body, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/inex.Tests/Transactions/TransactionsControllerTests.cs
+++ b/inex.Tests/Transactions/TransactionsControllerTests.cs
@@ -1,0 +1,244 @@
+using System.Net.Http.Json;
+using inex.Tests.Infrastructure;
+
+namespace inex.Tests.Transactions;
+
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class TransactionsControllerTests : IClassFixture<InExWebApplicationFactory>
+{
+    private readonly InExWebApplicationFactory _factory;
+
+    public TransactionsControllerTests(InExWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Single_OwnerTransaction_Returns200()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(client, "owner-get");
+
+        var response = await client.GetAsync($"/api/transactions/{ids.TransactionId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Single_OtherUsersTransaction_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(userB, "other-get");
+
+        var response = await userA.GetAsync($"/api/transactions/{ids.TransactionId}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Update_OwnerTransaction_Returns200()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(client, "owner-put");
+
+        var response = await client.PutAsJsonAsync($"/api/transactions/{ids.TransactionId}", new
+        {
+            id         = ids.TransactionId,
+            accountId  = ids.AccountId,
+            categoryId = ids.CategoryId,
+            created    = DateTime.UtcNow,
+            amount     = 25m,
+            comment    = "updated #tag",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_OtherUsersTransaction_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(userB, "other-put");
+
+        var response = await userA.PutAsJsonAsync($"/api/transactions/{ids.TransactionId}", new
+        {
+            id         = ids.TransactionId,
+            accountId  = ids.AccountId,
+            categoryId = ids.CategoryId,
+            created    = DateTime.UtcNow,
+            amount     = 25m,
+            comment    = "attempted update",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Create_WithOtherUsersAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(userB, "other-create-account");
+        int categoryId = await CreateCategoryAsync(userA, "own-create-category");
+
+        var response = await userA.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId,
+            categoryId,
+            created = DateTime.UtcNow,
+            amount  = 10m,
+            comment = "attempted create",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Create_WithOtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(userA, "own-create-account");
+        int categoryId = await CreateCategoryAsync(userB, "other-create-category");
+
+        var response = await userA.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId,
+            categoryId,
+            created = DateTime.UtcNow,
+            amount  = 10m,
+            comment = "attempted create",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Update_WithOtherUsersAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(userA, "own-update-account");
+        int otherAccountId = await CreateAccountAsync(userB, "other-update-account");
+
+        var response = await userA.PutAsJsonAsync($"/api/transactions/{ids.TransactionId}", new
+        {
+            id         = ids.TransactionId,
+            accountId  = otherAccountId,
+            categoryId = ids.CategoryId,
+            created    = DateTime.UtcNow,
+            amount     = 25m,
+            comment    = "attempted update",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Update_WithOtherUsersCategory_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(userA, "own-update-category");
+        int otherCategoryId = await CreateCategoryAsync(userB, "other-update-category");
+
+        var response = await userA.PutAsJsonAsync($"/api/transactions/{ids.TransactionId}", new
+        {
+            id         = ids.TransactionId,
+            accountId  = ids.AccountId,
+            categoryId = otherCategoryId,
+            created    = DateTime.UtcNow,
+            amount     = 25m,
+            comment    = "attempted update",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task Delete_OwnerTransaction_Returns200()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(client, "owner-delete");
+
+        var response = await client.DeleteAsync($"/api/transactions/{ids.TransactionId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_OtherUsersTransaction_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(userB, "other-delete");
+
+        var response = await userA.DeleteAsync($"/api/transactions/{ids.TransactionId}");
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    private Task<HttpClient> CreateAuthenticatedClientAsync() =>
+        _factory.CreateAuthenticatedClientAsync(
+            email: $"{Guid.NewGuid()}@example.com",
+            username: $"user-{Guid.NewGuid():N}");
+
+    private static async Task<TransactionFixtureIds> CreateTransactionFixtureAsync(HttpClient client, string key)
+    {
+        int accountId = await CreateAccountAsync(client, $"{key}-account");
+        int categoryId = await CreateCategoryAsync(client, $"{key}-category");
+        int transactionId = await CreateTransactionAsync(client, accountId, categoryId);
+
+        return new TransactionFixtureIds(accountId, categoryId, transactionId);
+    }
+
+    private static async Task<int> CreateAccountAsync(HttpClient client, string key)
+    {
+        var response = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            key,
+            name       = key,
+            currencyId = 1,
+            isEnabled  = true,
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private static async Task<int> CreateCategoryAsync(HttpClient client, string key)
+    {
+        var response = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key,
+            name      = key,
+            isEnabled = true,
+            isSystem  = false,
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private static async Task<int> CreateTransactionAsync(HttpClient client, int accountId, int categoryId)
+    {
+        var response = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId,
+            categoryId,
+            created = DateTime.UtcNow,
+            amount  = 10m,
+            comment = "initial",
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private sealed record TransactionFixtureIds(int AccountId, int CategoryId, int TransactionId);
+}

--- a/inex/Controllers/AccountsController.cs
+++ b/inex/Controllers/AccountsController.cs
@@ -53,7 +53,7 @@ public class AccountsController : ApiControllerBase
     [ProducesResponseType(typeof(AccountResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Single(int id, CancellationToken ct)
     {
-        AccountResponse resultDTO = await _accountService.GetAsync(id, ct);
+        AccountResponse resultDTO = await _accountService.GetAsync(id, CurrentUserId, ct);
         return Ok(resultDTO);
     }
 
@@ -113,7 +113,7 @@ public class AccountsController : ApiControllerBase
     [Route(DeleteRoute)]
     public async Task<ActionResult> Delete(int id, CancellationToken ct)
     {
-        await _accountService.DeleteAsync(id, ct);
+        await _accountService.DeleteAsync(id, CurrentUserId, ct);
         return Ok();
     }
 
@@ -123,7 +123,7 @@ public class AccountsController : ApiControllerBase
     [Route(DeleteListRoute)]
     public async Task<ActionResult> DeleteList([FromQuery] IEnumerable<int> ids, CancellationToken ct)
     {
-        await _accountService.DeleteAsync(ids, ct);
+        await _accountService.DeleteAsync(ids, CurrentUserId, ct);
         return Ok();
     }
 

--- a/inex/Controllers/BudgetsController.cs
+++ b/inex/Controllers/BudgetsController.cs
@@ -51,7 +51,7 @@ public class BudgetsController : ApiControllerBase
     [ProducesResponseType(typeof(BudgetResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Single(int id, CancellationToken ct)
     {
-        BudgetResponse resultDTO = await _budgetService.GetAsync(id, ct);
+        BudgetResponse resultDTO = await _budgetService.GetAsync(id, CurrentUserId, ct);
         return Ok(resultDTO);
     }
 
@@ -107,7 +107,7 @@ public class BudgetsController : ApiControllerBase
     [Route(DeleteRoute)]
     public async Task<ActionResult> Delete(int id, CancellationToken ct)
     {
-        await _budgetService.DeleteAsync(id, ct);
+        await _budgetService.DeleteAsync(id, CurrentUserId, ct);
         return Ok();
     }
 
@@ -117,7 +117,7 @@ public class BudgetsController : ApiControllerBase
     [Route(DeleteListRoute)]
     public async Task<ActionResult> DeleteList([FromQuery] IEnumerable<int> ids, CancellationToken ct)
     {
-        await _budgetService.DeleteAsync(ids, ct);
+        await _budgetService.DeleteAsync(ids, CurrentUserId, ct);
         return Ok();
     }
 

--- a/inex/Controllers/CategoriesController.cs
+++ b/inex/Controllers/CategoriesController.cs
@@ -52,7 +52,7 @@ public class CategoriesController : ApiControllerBase
     [ProducesResponseType(typeof(CategoryResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Single(int id, CancellationToken ct)
     {
-        CategoryResponse resultDTO = await _categoryService.GetAsync(id, ct);
+        CategoryResponse resultDTO = await _categoryService.GetAsync(id, CurrentUserId, ct);
         return Ok(resultDTO);
     }
 
@@ -100,7 +100,7 @@ public class CategoriesController : ApiControllerBase
     [Route(DeleteRoute)]
     public async Task<ActionResult> Delete(int id, CancellationToken ct)
     {
-        await _categoryService.DeleteAsync(id, ct);
+        await _categoryService.DeleteAsync(id, CurrentUserId, ct);
         return Ok();
     }
 
@@ -110,7 +110,7 @@ public class CategoriesController : ApiControllerBase
     [Route(DeleteListRoute)]
     public async Task<ActionResult> DeleteList([FromQuery] IEnumerable<int> ids, CancellationToken ct)
     {
-        await _categoryService.DeleteAsync(ids, ct);
+        await _categoryService.DeleteAsync(ids, CurrentUserId, ct);
         return Ok();
     }
 

--- a/inex/Controllers/TransactionsController.cs
+++ b/inex/Controllers/TransactionsController.cs
@@ -55,7 +55,7 @@ public class TransactionsController : ApiControllerBase
     [ProducesResponseType(typeof(TransactionResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult> Single(int id, CancellationToken ct)
     {
-        TransactionResponse resultDTO = await _transactionService.GetAsync(id, ct);
+        TransactionResponse resultDTO = await _transactionService.GetAsync(id, CurrentUserId, ct);
         return Ok(resultDTO);
     }
 
@@ -119,7 +119,7 @@ public class TransactionsController : ApiControllerBase
     [Route(DeleteRoute)]
     public async Task<ActionResult> Delete(int id, CancellationToken ct)
     {
-        await _transactionService.DeleteAsync(id, ct);
+        await _transactionService.DeleteAsync(id, CurrentUserId, ct);
         return Ok();
     }
 
@@ -129,7 +129,7 @@ public class TransactionsController : ApiControllerBase
     [Route(DeleteListRoute)]
     public async Task<ActionResult> DeleteList([FromQuery] IEnumerable<int> ids, CancellationToken ct)
     {
-        await _transactionService.DeleteAsync(ids, ct);
+        await _transactionService.DeleteAsync(ids, CurrentUserId, ct);
         return Ok();
     }
 


### PR DESCRIPTION
## Problem

`BuildDataResponse` in `Service.cs` was changed to return a deferred `IEnumerable` in commit c0f5c02 (AutoMapper removal). Before that, `AutoMapper.Map<IEnumerable<K>>()` was eager — it materialized the collection immediately. After the change, `items.Select(map)` kept the underlying `IQueryable` alive.

Callers in `BudgetReportService` and `ReportService` stored `.Data` and then called `FirstOrDefault(...)` or `Any(...)` inside transaction loops, causing the full SQL query to re-execute on every loop iteration (N+1). With any meaningful transaction history, this causes a MySQL connection timeout → unhandled exception → 500 Internal Server Error.

This affected all report endpoints: `/api/reports/budget/comparison`, `/api/reports/category`, `/api/reports/history/{year}`.

## Changes

### `Service.cs`
- `BuildDataResponse`: `items.Select(map)` → `items.Select(map).ToList()` — restores the pre-c0f5c02 eager materialization behaviour

### `ReportService.cs`
- `GetMonthlyHistory`: build `accounts` as `Dictionary<int, AccountResponse>` for O(1) `TryGetValue` instead of O(n) `FirstOrDefault` per transaction
- `GetCategoriesReportData`: same dictionary pattern for `accounts`; extract `categoryIds` as `HashSet<int>` so `Contains` replaces `Any(...)` per transaction; add `rate.Rate != 0` guard before division

### `BudgetReportService.cs`
- Build `accounts` as `Dictionary<int, AccountResponse>` to eliminate `FirstOrDefault` in the transaction loop
- Add `rate.Rate != 0` guards on both the primary and fallback rate division paths to prevent `DivideByZeroException`

## Testing

All 122 tests pass (40 unit + 82 integration).

Closes #123 