### PR TITLE
Add NBRB BYN/RUB exchange rate client

### DIFF
--- a/docs/implementation/5-1-backend-nbrb-exchange-rate-client-for-byn-rub.md
+++ b/docs/implementation/5-1-backend-nbrb-exchange-rate-client-for-byn-rub.md
@@ -1,0 +1,182 @@
+# Story 5.1: Backend - NBRB Exchange Rate Client for BYN/RUB
+
+## Status
+
+review
+
+## Story
+
+As a user with BYN or RUB accounts,
+I want my BYN/RUB exchange rates sourced from the National Bank of the Republic of Belarus (NBRB),
+so that account and report calculations use the authoritative Belarusian central-bank rate instead of excluding or mispricing these currencies.
+
+## Acceptance Criteria
+
+1. Given `ExchangeRateService` needs rates for an inclusive date range containing BYN/RUB conversion, when the cache is cold, then it fetches NBRB data through a new `NbrbApiClient` using a range request for the whole missing range, not one HTTP call per date.
+2. Given NBRB is used for RUB, when the client calls the API, then it uses the official NBRB exchange-rate API documented at `https://www.nb-rb.by/apihelp/exrates.htm`, specifically `GET https://api.nbrb.by/exrates/rates/dynamics/{cur_id}?startdate={yyyy-MM-dd}&enddate={yyyy-MM-dd}` for range data and respects the documented 365-day maximum range.
+3. Given NBRB returns `RateShort` rows with `Cur_ID`, `Date`, and `Cur_OfficialRate`, when the app converts them to the existing exchange-rate model, then RUB rates account for NBRB scale: RUB is published as BYN per 100 RUB, so `RUB -> BYN = Cur_OfficialRate / 100` and `BYN -> RUB = 100 / Cur_OfficialRate`.
+4. Given BYN is the Belarusian base currency and is not a foreign-currency item in the NBRB API, when BYN is requested as either the base or target currency, then the implementation treats BYN identity rates as `1` and derives direct BYN/RUB conversion from the RUB NBRB series rather than trying to fetch a BYN currency code from NBRB.
+5. Given NBRB omits dates where no official rate is set or returns an empty array for missing data, when `ExchangeRateService` fills the requested range, then it carries forward the nearest prior non-temporary rate for missing dates using the existing carry-forward behavior; if no prior rate exists, it leaves the date unfetched and logs the gap without fabricating a rate.
+6. Given currencies other than the BYN/RUB path are requested, when `ExchangeRateService` processes them, then the existing Frankfurter range call plus CurrencyAPI supplement chain continues unchanged; NBRB is additive and must not replace or regress non-BYN/RUB rates.
+7. Given NBRB returns HTTP 404 for an invalid currency id and may return transient 5xx/408/429 failures, when the client is registered, then it uses the existing timeout pattern, handles transient failures, and honors `Retry-After` for 429 responses before retrying; failures are logged without exposing API keys, connection strings, JWTs, or sensitive values.
+8. Given a new external response type is needed, when it is named, then it is `NbrbRateResponse` or `NbrbRateShortResponse`, not `ExchangeRateResponse`, to avoid the existing `ExchangeRateResponse` naming collision in `inex.Services`.
+9. Given the story is complete, when unit tests run, then `inex.Services.Tests` covers NBRB URL formatting, response conversion, scale-aware RUB/BYN math, missing-date carry-forward, BYN/RUB routing through NBRB, non-BYN/RUB routing through the existing chain, cancellation-token propagation, and NBRB failure fallback behavior.
+10. Given the story is complete, when backend verification runs, then `dotnet build inex.sln` and the relevant `dotnet test` scope pass with no application-code changes outside this story's implementation scope.
+
+## Tasks / Subtasks
+
+- [x] Add an NBRB external client without changing public API contracts. (AC: 1, 2, 7, 8)
+  - [x] Add `NbrbApiClient` under `inex.Services/Infrastructure/ExternalClients/ExchangeRate/`.
+  - [x] Add a typed response named `NbrbRateResponse` or `NbrbRateShortResponse`; do not add another `ExchangeRateResponse` type.
+  - [x] Use `GetFromJsonAsync` or equivalent typed JSON deserialization with `CancellationToken`.
+  - [x] Format dates as `yyyy-MM-dd` in query strings.
+  - [x] Enforce/split NBRB requests so no single `dynamics` request exceeds 365 days.
+- [x] Register NBRB configuration and resilience consistently with existing clients. (AC: 2, 7)
+  - [x] Add `NbrbApiSettings` with `BaseUrl`, defaulting in tracked config to `https://api.nbrb.by/`; no API key is required.
+  - [x] Register `NbrbApiSettings` in `InExServicesExtensions`.
+  - [x] Register `HttpClient<NbrbApiClient>` with `Accept: application/json`, `Timeout.InfiniteTimeSpan`, the existing timeout policy, and an NBRB retry policy that preserves the existing transient failure coverage while honoring `Retry-After` for HTTP 429.
+  - [x] Add a keyed retry policy name such as `NbrbApiRetry` rather than reusing another client's label.
+- [x] Integrate NBRB into `ExchangeRateService` as an additive BYN/RUB path. (AC: 1, 3, 4, 5, 6)
+  - [x] Inject the NBRB client or a dedicated NBRB abstraction into `ExchangeRateService` without removing Frankfurter or CurrencyAPI.
+  - [x] Detect the direct BYN/RUB path case-insensitively and route it through NBRB range data.
+  - [x] Resolve RUB metadata before the dynamics call: use a documented constant only if the source and scale are proven, otherwise query `/exrates/currencies` and select the active currency where `Cur_Abbreviation == "RUB"`.
+  - [x] Convert NBRB RUB values with `Cur_OfficialRate / Cur_Scale` for `RUB -> BYN` and `Cur_Scale / Cur_OfficialRate` for `BYN -> RUB`; tests may use scale `100`.
+  - [x] Treat `BYN -> BYN` and `RUB -> RUB` as identity if such a path is encountered; do not persist redundant same-currency exchange-rate rows unless existing service behavior requires it.
+  - [x] Preserve existing Frankfurter-first range behavior for all non-BYN/RUB target currencies.
+  - [x] Preserve existing `CreateTemporaryRatesForTodayIfNeeded`, `UpsertRatesForDate`, and `CarryForwardRatesFromPriorDay` semantics unless a small signature change is required to merge NBRB responses.
+- [x] Add focused test coverage. (AC: 3, 5, 6, 7, 9)
+  - [x] Add external-client tests parallel to `FrankfurterApiClientTests` for URL path/query, date formatting, JSON mapping, 404/empty-array behavior, and cancellation token propagation.
+  - [x] Extend `ExchangeRateServiceTests` for BYN/RUB routing through NBRB and for non-BYN/RUB keeping the existing Frankfurter/CurrencyAPI chain.
+  - [x] Add tests proving RUB scale math and missing-date carry-forward.
+  - [x] Add failure tests showing NBRB exceptions leave BYN/RUB dates unfetched or carried forward from prior cached NBRB rates, and do not prevent non-BYN/RUB rates from being fetched through existing providers.
+- [x] Verify backend scope. (AC: 10)
+  - [x] Run focused service tests while iterating.
+  - [x] Run `dotnet build inex.sln`.
+  - [x] Run relevant `dotnet test` scope; full `dotnet test inex.sln` is preferred if time permits.
+
+## Dev Notes
+
+### Source Requirements
+
+- Epic 5 covers FR-RATE-4: "NBRB exchange rate client: BYN + RUB via single range call." [Source: `docs/planning/epics.md#Epic 5: Exchange Rate Expansion`]
+- Story 5.1 requires `ExchangeRateService` to call `NbrbApiClient` using a single range call, carry missing dates forward to the nearest prior rate, keep non-BYN/RUB currencies on the existing Frankfurter/CurrencyAPI chain, avoid a new `ExchangeRateResponse` naming collision, and cover BYN/RUB routing plus missing-date fallback in tests. [Source: `docs/planning/epics.md#Story 5.1: Backend - NBRB Exchange Rate Client for BYN/RUB`]
+- Epic 5 depends on Epic 2 because date-based rate logic must use injectable `IClock` for deterministic tests. Epic 2 is done and `ExchangeRateService` already receives `IClock`. [Source: `docs/planning/epics.md#Epic 5: Exchange Rate Expansion`; `docs/implementation/2-2-backend-injectable-clock-abstraction-and-utc-consistency.md`]
+- Epic 6 historical net worth depends on Epic 5 so BYN/RUB accounts are not excluded or treated as unsupported in multi-currency reporting. [Source: `docs/planning/epics.md#Epic 6: Dashboard & Spending Insights`]
+
+### NBRB API Contract
+
+- Official documentation: `https://www.nb-rb.by/apihelp/exrates.htm`.
+- Daily rates endpoint: `GET https://api.nbrb.by/exrates/rates[/{cur_id}]?ondate={date}&periodicity=0&parammode={mode}` returns full daily `Rate` rows. Do not use this endpoint in a per-date loop for this story's range fetch.
+- Range endpoint: `GET https://api.nbrb.by/exrates/rates/dynamics/{cur_id}?startdate={date}&enddate={date}` returns an array of `RateShort` objects and is limited to periods of no more than 365 days. `RateShort` contains `Cur_ID`, `Date`, and `Cur_OfficialRate`.
+- Invalid currency ids return 404. If no rate is established for a requested date, NBRB returns an empty array or omits that date from dynamics results. [Source: official NBRB API help, `https://www.nb-rb.by/apihelp/exrates.htm`]
+- RUB NBRB internal currency id must be determined from the official currency list endpoint or documented as a constant with a source comment. Prefer `GET /exrates/currencies` discovery in implementation if the current id cannot be proven stable for historical ranges.
+- NBRB publishes rates as BYN per `Cur_Scale` units of foreign currency. RUB commonly uses scale `100`; the implementation must not treat `Cur_OfficialRate` as BYN per 1 RUB unless `Cur_Scale` is 1.
+
+### Existing Exchange-Rate Architecture
+
+- Current `ExchangeRateService` constructor takes `IInExUnitOfWork`, primary `IExchangeRateClient` (`CurrencyApiClient`), fallback `IExchangeRateClient` (`FrankfurterApiClient`), `ILogger<ExchangeRateService>`, and `IClock`. `InExServicesExtensions` manually resolves both clients for `IExchangeRateService`. [Source: `inex.Services/Services/ExchangeRateService.cs`; `inex.Services/Extensions/InExServicesExtensions.cs`]
+- `ExchangeRateService.Get` resolves the user's base currency, loads all target currency codes except the base, checks cached non-temporary rates, fetches the min/max missing range, upserts actual rates, carries forward missing dates, and creates temporary rates for today from the most recent prior rates. Preserve that flow. [Source: `inex.Services/Services/ExchangeRateService.cs`]
+- Frankfurter already implements `GetRatesForRangeAsync` as one range HTTP call and maps external rates into the shared external model. CurrencyAPI intentionally returns an empty range dictionary and only supplements uncovered currencies per date. NBRB must not make the range path worse for RUB/BYN by falling back to the `IExchangeRateClient` default day loop. [Source: `inex.Services/Infrastructure/ExternalClients/ExchangeRate/IExchangeRateClient.cs`; `FrankfurterApiClient.cs`; `CurrencyApiClient.cs`]
+- Existing external-client resilience is in `HttpResiliencePolicyFactory`: 3 retries, exponential delay, transient HTTP errors, HTTP 429, and Polly timeout; timeout per attempt defaults to 10 seconds. NBRB needs the same timeout/transient coverage plus `Retry-After` handling for 429 responses because the Epic 5 acceptance criteria require it and the current shared factory does not read `Retry-After`. [Source: `docs/planning/epics.md#Story 5.1: Backend - NBRB Exchange Rate Client for BYN/RUB`; `inex.Services/Infrastructure/Resilience/HttpResiliencePolicyFactory.cs`]
+- Existing cache persistence stores rows in `exchange_rate` with `FromCode`, `ToCode`, `Rate`, `IsTemporary`, and `Created`. A unique constraint exists for date/from/to combinations; use upsert behavior rather than creating duplicate rows. [Source: `inex.Data/Models/ExchangeRate.cs`; `inex.Data/Migrations/20260424070214_AddExchangeRateUniqueConstraint.cs`]
+
+### BYN/RUB Conversion Rules
+
+- Direct `BYN -> RUB`: store `Rate = Cur_Scale / Cur_OfficialRate`.
+- Direct `RUB -> BYN`: store `Rate = Cur_OfficialRate / Cur_Scale`.
+- Do not request BYN from NBRB as a foreign currency; BYN is the domestic currency in NBRB rate publications.
+- Match currency codes case-insensitively for routing, but persist the existing uppercase currency keys (`BYN`, `RUB`) already seeded in `CurrencyConfiguration`.
+- RUB metadata must be resolved before rate conversion. Preferred implementation: query `GET https://api.nbrb.by/exrates/currencies`, deserialize at least `Cur_ID`, `Cur_Abbreviation`, `Cur_Scale`, `Cur_DateStart`, and `Cur_DateEnd`, then choose the row where `Cur_Abbreviation == "RUB"` and the requested range overlaps the row's effective dates. If more than one row overlaps because NBRB changed metadata over time, split the dynamics requests by metadata effective range. If no RUB row overlaps, log the failure and treat the affected BYN/RUB dates as unavailable.
+- A hardcoded RUB `Cur_ID` is acceptable only if the code comment cites the official NBRB currency-list source and tests still cover scale-aware conversion. Do not hardcode `Cur_Scale = 100` in conversion code if the metadata response includes scale.
+
+### NBRB Failure and Partial-Data Rules
+
+- NBRB is authoritative for the BYN/RUB path in this story. Do not silently supplement failed or missing BYN/RUB NBRB rates from CurrencyAPI or Frankfurter unless a later story explicitly changes the source-of-truth rule.
+- If NBRB fails for the requested range and a prior non-temporary BYN/RUB rate is already cached before a missing date, carry forward that prior cached rate using the existing carry-forward behavior.
+- If NBRB fails and no prior non-temporary BYN/RUB rate exists, leave the affected BYN/RUB dates absent from the cache and log a structured warning/error. Do not create temporary or fabricated actual rates for historical dates.
+- If Frankfurter returns non-BYN/RUB rates for a date but NBRB omits RUB for that same date, persist the non-BYN/RUB rates normally and handle the BYN/RUB gap independently through prior-rate carry-forward or absence. Cache completeness checks must not treat the entire date as fully cached until required target currencies for that base are present.
+- If NBRB returns some dates in a range and omits weekends/holidays, insert actual NBRB rates for returned dates first, then carry forward from the nearest prior non-temporary BYN/RUB rate for omitted dates.
+
+### Files Likely to Change
+
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiClient.cs` - new client.
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbRateResponse.cs` or `NbrbRateShortResponse.cs` - new response model.
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiSettings.cs` - new settings class.
+- `inex.Services/Extensions/InExServicesExtensions.cs` - options, retry policy, HTTP client registration, and `ExchangeRateService` factory update.
+- `inex.Services/Services/ExchangeRateService.cs` - BYN/RUB routing and NBRB merge logic.
+- `inex/appsettings.json` - non-secret `NbrbApiSettings:BaseUrl` only.
+- `inex.Tests/Infrastructure/InExWebApplicationFactory.cs` - test configuration for `NbrbApiSettings:BaseUrl`.
+- `inex.Services.Tests/Infrastructure/ExternalClients/NbrbApiClientTests.cs` - new client tests.
+- `inex.Services.Tests/Services/ExchangeRateServiceTests.cs` - service routing, conversion, and fallback tests.
+
+### Project Structure Notes
+
+- Keep service business logic in `inex.Services`; do not move exchange-rate orchestration into controllers or `inex.Data`.
+- Keep persistence behind existing repositories/unit of work. No schema change is expected for this story unless implementation discovers the existing unique constraint cannot support required upserts.
+- Do not add frontend work, report UI work, or Epic 6 historical net-worth implementation in this story.
+- Do not introduce new dependencies; current `HttpClient`, `System.Net.Http.Json`, Polly, xUnit, and Moq are sufficient.
+
+### Security, Configuration, and Environment
+
+- NBRB does not require an API key. Do not add secrets for it.
+- Tracked config may include only the public base URL. Keep real `CurrencyApiSettings:ApiKey`, connection strings, JWT secrets, and invite tokens out of docs/logs/tests.
+- Do not log full request URLs if future query strings could include secrets. NBRB URLs are currently non-secret, but follow the existing structured logging style.
+- Preserve cancellation token propagation through service and client calls.
+
+### Testing Requirements
+
+- Use `inex.Services.Tests` for `NbrbApiClient` and `ExchangeRateService` unit coverage.
+- Mock HTTP with `HttpMessageHandler` as in `FrankfurterApiClientTests`.
+- Mock repositories and clients as in `ExchangeRateServiceTests`; use `FakeClock` for date-sensitive tests.
+- Verify call counts explicitly: BYN/RUB cold-cache range uses NBRB range fetch once per required range segment, not `GetRatesAsync` per date; non-BYN/RUB behavior still calls Frankfurter range first and CurrencyAPI only for uncovered currencies.
+- Include edge cases: empty NBRB array, missing weekend/holiday date in returned series, invalid id/404, transient failure, `end < start` still throws existing validation exception, and future/today behavior remains unchanged.
+
+### Internal Checklist Validation
+
+- Acceptance criteria are concrete and testable.
+- Backend behavior and external API behavior are specified with source URLs and expected data shape.
+- BYN/RUB conversion math is explicit.
+- Caching, retry, timeout, missing-date, and failure behavior are specified.
+- Existing architecture, likely files, tests, security, configuration, and dependencies are referenced.
+- Story sequencing is correct: Epic 2 prerequisite is complete; Epic 6 depends on this story.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-06-01: `dotnet build .\inex.sln` initially failed while selecting the generic Polly retry overload; fixed by explicitly calling `AsyncRetryTResultSyntax.WaitAndRetryAsync`.
+- 2026-06-01: `dotnet test .\inex.Services.Tests\inex.Services.Tests.csproj` initially failed on an overly strict cancellation-token equality assertion because `HttpClient` wraps the token; adjusted to assert a cancellable token reaches the handler.
+
+### Completion Notes List
+
+- Added `NbrbApiClient` with `/exrates/currencies` RUB metadata discovery, `dynamics/{cur_id}` range calls, inclusive 365-day segmentation, typed JSON response models, and scale-aware BYN/RUB conversion.
+- Registered `NbrbApiSettings`, `INbrbApiClient`, an `NbrbApiRetry` policy, timeout handling, and public tracked NBRB base URL configuration.
+- Integrated NBRB as the authoritative direct BYN/RUB path in `ExchangeRateService` while preserving Frankfurter-first plus CurrencyAPI supplement behavior for all non-BYN/RUB paths.
+- Extended carry-forward to fill missing target currencies independently, so NBRB gaps do not block non-BYN/RUB rates and prior non-temporary BYN/RUB rates can be carried forward.
+- Added focused `NbrbApiClientTests` and `ExchangeRateServiceTests` coverage for URL formatting, date formatting, metadata and JSON mapping, scale math, 365-day splitting, empty/404 behavior, cancellation propagation, retry-after behavior, NBRB routing, missing-date carry-forward, failure behavior, and non-BYN/RUB regression behavior.
+- Verification passed: `dotnet test .\inex.Services.Tests\inex.Services.Tests.csproj`, `dotnet build .\inex.sln`, and `dotnet test .\inex.sln`.
+
+### File List
+
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/INbrbApiClient.cs`
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiClient.cs`
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiSettings.cs`
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbCurrencyResponse.cs`
+- `inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbRateResponse.cs`
+- `inex.Services/Infrastructure/Resilience/HttpResiliencePolicyFactory.cs`
+- `inex.Services/Extensions/InExServicesExtensions.cs`
+- `inex.Services/Services/ExchangeRateService.cs`
+- `inex/appsettings.json`
+- `inex.Tests/Infrastructure/InExWebApplicationFactory.cs`
+- `inex.Services.Tests/Infrastructure/ExternalClients/NbrbApiClientTests.cs`
+- `inex.Services.Tests/Services/ExchangeRateServiceTests.cs`
+- `docs/implementation/5-1-backend-nbrb-exchange-rate-client-for-byn-rub.md`
+- `docs/implementation/sprint-status.yaml`
+
+## Change Log
+
+- 2026-06-01: Implemented Story 5.1 NBRB BYN/RUB exchange-rate client, service integration, configuration, resilience, and tests.

--- a/docs/implementation/sprint-status.yaml
+++ b/docs/implementation/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-26T16:11:20.6477763+02:00
-# last_updated: 2026-05-31T00:00:00+02:00
+# last_updated: 2026-06-01T00:00:00+02:00
 # project: inex
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-05-26T16:11:20.6477763+02:00
-last_updated: 2026-06-01T07:09:43+02:00
+last_updated: 2026-06-01T12:33:53+02:00
 project: inex
 project_key: NOKEY
 tracking_system: file-system
@@ -63,8 +63,8 @@ development_status:
   4-2-backend-frontend-typed-transaction-filter-query-parameters: review
   4-3-frontend-active-filter-indicator-on-transaction-list: review
   epic-4-retrospective: optional
-  epic-5: backlog
-  5-1-backend-nbrb-exchange-rate-client-for-byn-rub: backlog
+  epic-5: in-progress
+  5-1-backend-nbrb-exchange-rate-client-for-byn-rub: review
   epic-5-retrospective: optional
   epic-6: backlog
   6-1-frontend-dashboard-home-page-and-navigation-restructure: backlog

--- a/inex.Services.Tests/Infrastructure/ExternalClients/NbrbApiClientTests.cs
+++ b/inex.Services.Tests/Infrastructure/ExternalClients/NbrbApiClientTests.cs
@@ -1,0 +1,261 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using inex.Services.Infrastructure.ExternalClients.ExchangeRate;
+using inex.Services.Infrastructure.Resilience;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq.Protected;
+
+namespace inex.Services.Tests.Infrastructure.ExternalClients;
+
+public class NbrbApiClientTests
+{
+    [Fact]
+    public async Task GetRatesForRangeAsync_BynToRub_FormatsUrlsAndConvertsScale()
+    {
+        var capturedUrls = new List<string>();
+        var httpClient = CreateMockHttpClient(request =>
+        {
+            capturedUrls.Add(request.RequestUri!.ToString());
+            if (request.RequestUri!.AbsolutePath.EndsWith("/exrates/currencies", StringComparison.OrdinalIgnoreCase))
+            {
+                return JsonResponse(new[]
+                {
+                    new
+                    {
+                        Cur_ID = 456,
+                        Cur_Abbreviation = "RUB",
+                        Cur_Scale = 100,
+                        Cur_DateStart = "2020-01-01T00:00:00",
+                        Cur_DateEnd = "2099-12-31T00:00:00"
+                    }
+                });
+            }
+
+            return JsonResponse(new[]
+            {
+                new { Cur_ID = 456, Date = "2026-03-15T00:00:00", Cur_OfficialRate = 3.2m }
+            });
+        });
+
+        var client = new NbrbApiClient(httpClient);
+
+        var result = await client.GetRatesForRangeAsync(new DateTime(2026, 3, 15), new DateTime(2026, 3, 15), "BYN", "RUB");
+
+        Assert.Equal(2, capturedUrls.Count);
+        Assert.Equal("https://api.nbrb.by/exrates/currencies", capturedUrls[0]);
+        Assert.Equal("https://api.nbrb.by/exrates/rates/dynamics/456?startdate=2026-03-15&enddate=2026-03-15", capturedUrls[1]);
+        Assert.Equal(31.25m, result[new DateTime(2026, 3, 15)].Data["RUB"].Value);
+    }
+
+    [Fact]
+    public async Task GetRatesForRangeAsync_RubToByn_ConvertsScaleInOppositeDirection()
+    {
+        var httpClient = CreateMockHttpClient(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/exrates/currencies", StringComparison.OrdinalIgnoreCase)
+                ? JsonResponse(new[]
+                {
+                    new
+                    {
+                        Cur_ID = 456,
+                        Cur_Abbreviation = "RUB",
+                        Cur_Scale = 100,
+                        Cur_DateStart = "2020-01-01T00:00:00",
+                        Cur_DateEnd = "2099-12-31T00:00:00"
+                    }
+                })
+                : JsonResponse(new[]
+                {
+                    new { Cur_ID = 456, Date = "2026-03-15T00:00:00", Cur_OfficialRate = 3.2m }
+                }));
+
+        var client = new NbrbApiClient(httpClient);
+
+        var result = await client.GetRatesForRangeAsync(new DateTime(2026, 3, 15), new DateTime(2026, 3, 15), "RUB", "BYN");
+
+        Assert.Equal(0.032m, result[new DateTime(2026, 3, 15)].Data["BYN"].Value);
+    }
+
+    [Fact]
+    public async Task GetRatesForRangeAsync_WhenRangeExceeds365Days_SplitsDynamicsRequests()
+    {
+        var capturedDynamicsUrls = new List<string>();
+        var httpClient = CreateMockHttpClient(request =>
+        {
+            if (request.RequestUri!.AbsolutePath.EndsWith("/exrates/currencies", StringComparison.OrdinalIgnoreCase))
+            {
+                return JsonResponse(new[]
+                {
+                    new
+                    {
+                        Cur_ID = 456,
+                        Cur_Abbreviation = "RUB",
+                        Cur_Scale = 100,
+                        Cur_DateStart = "2020-01-01T00:00:00",
+                        Cur_DateEnd = "2099-12-31T00:00:00"
+                    }
+                });
+            }
+
+            capturedDynamicsUrls.Add(request.RequestUri.ToString());
+            return JsonResponse(Array.Empty<object>());
+        });
+
+        var client = new NbrbApiClient(httpClient);
+
+        await client.GetRatesForRangeAsync(new DateTime(2026, 1, 1), new DateTime(2027, 1, 5), "BYN", "RUB");
+
+        Assert.Equal(2, capturedDynamicsUrls.Count);
+        Assert.Contains("startdate=2026-01-01&enddate=2026-12-31", capturedDynamicsUrls[0]);
+        Assert.Contains("startdate=2027-01-01&enddate=2027-01-05", capturedDynamicsUrls[1]);
+    }
+
+    [Fact]
+    public async Task GetRatesForRangeAsync_WhenNbrbReturnsEmptyArray_ReturnsEmptyDictionary()
+    {
+        var httpClient = CreateMockHttpClient(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/exrates/currencies", StringComparison.OrdinalIgnoreCase)
+                ? JsonResponse(new[]
+                {
+                    new
+                    {
+                        Cur_ID = 456,
+                        Cur_Abbreviation = "RUB",
+                        Cur_Scale = 100,
+                        Cur_DateStart = "2020-01-01T00:00:00",
+                        Cur_DateEnd = "2099-12-31T00:00:00"
+                    }
+                })
+                : JsonResponse(Array.Empty<object>()));
+
+        var client = new NbrbApiClient(httpClient);
+
+        var result = await client.GetRatesForRangeAsync(new DateTime(2026, 3, 15), new DateTime(2026, 3, 15), "BYN", "RUB");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetRatesForRangeAsync_WhenRubMetadataMissing_ReturnsEmptyDictionary()
+    {
+        var httpClient = CreateMockHttpClient(_ => JsonResponse(new[]
+        {
+            new
+            {
+                Cur_ID = 999,
+                Cur_Abbreviation = "USD",
+                Cur_Scale = 1,
+                Cur_DateStart = "2020-01-01T00:00:00",
+                Cur_DateEnd = "2099-12-31T00:00:00"
+            }
+        }));
+
+        var client = new NbrbApiClient(httpClient);
+
+        var result = await client.GetRatesForRangeAsync(new DateTime(2026, 3, 15), new DateTime(2026, 3, 15), "BYN", "RUB");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetRatesForRangeAsync_WhenDynamicsReturns404_ThrowsHttpRequestException()
+    {
+        var httpClient = CreateMockHttpClient(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/exrates/currencies", StringComparison.OrdinalIgnoreCase)
+                ? JsonResponse(new[]
+                {
+                    new
+                    {
+                        Cur_ID = 456,
+                        Cur_Abbreviation = "RUB",
+                        Cur_Scale = 100,
+                        Cur_DateStart = "2020-01-01T00:00:00",
+                        Cur_DateEnd = "2099-12-31T00:00:00"
+                    }
+                })
+                : new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var client = new NbrbApiClient(httpClient);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.GetRatesForRangeAsync(new DateTime(2026, 3, 15), new DateTime(2026, 3, 15), "BYN", "RUB"));
+    }
+
+    [Fact]
+    public async Task GetRatesForRangeAsync_PropagatesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var observedToken = CancellationToken.None;
+        var httpClient = CreateMockHttpClient((_, token) =>
+        {
+            observedToken = token;
+            return JsonResponse(Array.Empty<object>());
+        });
+
+        var client = new NbrbApiClient(httpClient);
+
+        await client.GetRatesForRangeAsync(new DateTime(2026, 3, 15), new DateTime(2026, 3, 15), "BYN", "RUB", cts.Token);
+
+        Assert.True(observedToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task NbrbRetryPolicy_When429HasRetryAfter_UsesRetryAfterDelay()
+    {
+        var attempts = 0;
+        var policy = HttpResiliencePolicyFactory.CreateRetryPolicyHonoringRetryAfter(
+            NullLogger.Instance,
+            "NbrbApiClient",
+            new HttpResiliencePolicyOptions(1, _ => TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10)));
+
+        var stopwatch = Stopwatch.StartNew();
+
+        var response = await policy.ExecuteAsync(() =>
+        {
+            attempts++;
+            if (attempts == 1)
+            {
+                var tooManyRequests = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                tooManyRequests.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromMilliseconds(1));
+                return Task.FromResult(tooManyRequests);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        stopwatch.Stop();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, attempts);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
+    }
+
+    private static HttpClient CreateMockHttpClient(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) =>
+        CreateMockHttpClient((request, _) => responseFactory(request));
+
+    private static HttpClient CreateMockHttpClient(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responseFactory)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken token) => responseFactory(request, token));
+
+        return new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri("https://api.nbrb.by/")
+        };
+    }
+
+    private static HttpResponseMessage JsonResponse<T>(T value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+}

--- a/inex.Services.Tests/Services/ExchangeRateServiceTests.cs
+++ b/inex.Services.Tests/Services/ExchangeRateServiceTests.cs
@@ -18,6 +18,7 @@ public class ExchangeRateServiceTests
     private readonly Mock<IInExUnitOfWork> _uowMock = new();
     private readonly Mock<IExchangeRateClient> _clientMock = new();
     private readonly Mock<IExchangeRateClient> _fallbackClientMock = new();
+    private readonly Mock<INbrbApiClient> _nbrbClientMock = new();
     private readonly Mock<IEditableRepository<ExchangeRate>> _exchangeRateRepoMock = new();
     private readonly Mock<IRepository<Currency>> _currencyRepoMock = new();
     private readonly Mock<IRepository<AppUser>> _userRepoMock = new();
@@ -35,7 +36,7 @@ public class ExchangeRateServiceTests
     // --- Helpers ---
 
     private ExchangeRateService CreateSut() =>
-        new ExchangeRateService(_uowMock.Object, _clientMock.Object, _fallbackClientMock.Object, NullLogger<ExchangeRateService>.Instance, _clock);
+        new ExchangeRateService(_uowMock.Object, _clientMock.Object, _fallbackClientMock.Object, _nbrbClientMock.Object, NullLogger<ExchangeRateService>.Instance, _clock);
 
     // AsAsyncQueryable() wraps a plain IEnumerable<T> so it satisfies both
     // IQueryable<T> (sync LINQ) and IAsyncEnumerable<T> (EF ToListAsync etc.).
@@ -357,5 +358,204 @@ public class ExchangeRateServiceTests
         _clientMock.Verify(c => c.GetRatesAsync(pastDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
         _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.ToCode == targetCode && !e.IsTemporary && e.Rate == 1.15m), It.IsAny<CancellationToken>()), Times.Once);
         _uowMock.Verify(u => u.SaveAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenBynRubPath_UsesNbrbAndPersistsScaleAwareRate()
+    {
+        var pastDate = new DateTime(2026, 3, 15);
+        var baseCurrency = "BYN";
+        var targetCode = "RUB";
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<System.Linq.Expressions.Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _currencyRepoMock.Setup(r => r.Get(true, null))
+            .Returns(CurrenciesFor(targetCode));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(EmptyRates());
+
+        _nbrbClientMock.Setup(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, targetCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>
+            {
+                [pastDate] = new()
+                {
+                    Data = new Dictionary<string, ExchangeDateData>
+                    {
+                        [targetCode] = new() { Code = targetCode, Value = 31.25m }
+                    }
+                }
+            });
+
+        var sut = CreateSut();
+
+        await sut.Get(1, pastDate, pastDate);
+
+        _nbrbClientMock.Verify(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, targetCode, It.IsAny<CancellationToken>()), Times.Once);
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _clientMock.Verify(c => c.GetRatesAsync(It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.FromCode == baseCurrency && e.ToCode == targetCode && e.Rate == 31.25m && !e.IsTemporary), It.IsAny<CancellationToken>()), Times.Once);
+        _uowMock.Verify(u => u.SaveAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenRubBynPath_UsesNbrbDirectly()
+    {
+        var pastDate = new DateTime(2026, 3, 15);
+        var baseCurrency = "RUB";
+        var targetCode = "BYN";
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<System.Linq.Expressions.Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _currencyRepoMock.Setup(r => r.Get(true, null))
+            .Returns(CurrenciesFor(targetCode));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(EmptyRates());
+
+        _nbrbClientMock.Setup(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, targetCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>
+            {
+                [pastDate] = new()
+                {
+                    Data = new Dictionary<string, ExchangeDateData>
+                    {
+                        [targetCode] = new() { Code = targetCode, Value = 0.032m }
+                    }
+                }
+            });
+
+        var sut = CreateSut();
+
+        await sut.Get(1, pastDate, pastDate, baseCurrency);
+
+        _nbrbClientMock.Verify(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, targetCode, It.IsAny<CancellationToken>()), Times.Once);
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.FromCode == baseCurrency && e.ToCode == targetCode && e.Rate == 0.032m), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenNbrbOmitsDate_CarriesForwardPriorRubRate()
+    {
+        var priorDate = new DateTime(2026, 3, 14);
+        var requestedDate = new DateTime(2026, 3, 15);
+        var baseCurrency = "BYN";
+        var targetCode = "RUB";
+        var priorRate = new ExchangeRate { FromCode = baseCurrency, ToCode = targetCode, Rate = 30m, Created = priorDate, IsTemporary = false };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<System.Linq.Expressions.Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _currencyRepoMock.Setup(r => r.Get(true, null))
+            .Returns(CurrenciesFor(targetCode));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(new[] { priorRate }.AsAsyncQueryable());
+        _nbrbClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, targetCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>());
+
+        var sut = CreateSut();
+
+        await sut.Get(1, requestedDate, requestedDate);
+
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == requestedDate && e.ToCode == targetCode && e.Rate == 30m && !e.IsTemporary), It.IsAny<CancellationToken>()), Times.Once);
+        _uowMock.Verify(u => u.SaveAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenNbrbFailsWithoutPriorRate_LeavesBynRubUnfetched()
+    {
+        var pastDate = new DateTime(2026, 3, 15);
+        var baseCurrency = "BYN";
+        var targetCode = "RUB";
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<System.Linq.Expressions.Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _currencyRepoMock.Setup(r => r.Get(true, null))
+            .Returns(CurrenciesFor(targetCode));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(EmptyRates());
+        _nbrbClientMock.Setup(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, targetCode, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("NBRB unavailable"));
+
+        var sut = CreateSut();
+
+        await sut.Get(1, pastDate, pastDate);
+
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(u => u.SaveAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _clientMock.Verify(c => c.GetRatesAsync(It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenNonBynRubCurrenciesRequested_KeepsFrankfurterCurrencyApiChain()
+    {
+        var pastDate = new DateTime(2026, 3, 15);
+        var baseCurrency = "EUR";
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<System.Linq.Expressions.Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _currencyRepoMock.Setup(r => r.Get(true, null))
+            .Returns(CurrenciesFor("USD", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(EmptyRates());
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, It.Is<string[]>(a => a.Contains("USD") && a.Contains("BYN")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>
+            {
+                [pastDate] = new()
+                {
+                    Data = new Dictionary<string, ExchangeDateData>
+                    {
+                        ["USD"] = new() { Code = "USD", Value = 1.2m }
+                    }
+                }
+            });
+        _clientMock.Setup(c => c.GetRatesAsync(pastDate, baseCurrency, It.Is<string[]>(a => a.SequenceEqual(new[] { "BYN" })), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExchangeRateResponse
+            {
+                Data = new Dictionary<string, ExchangeDateData>
+                {
+                    ["BYN"] = new() { Code = "BYN", Value = 3.5m }
+                }
+            });
+
+        var sut = CreateSut();
+
+        await sut.Get(1, pastDate, pastDate);
+
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(pastDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _nbrbClientMock.Verify(c => c.GetRatesForRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenFrankfurterHasUsdAndNbrbOmitsRub_PersistsUsdAndCarriesRubIndependently()
+    {
+        var priorDate = new DateTime(2026, 3, 14);
+        var requestedDate = new DateTime(2026, 3, 15);
+        var baseCurrency = "BYN";
+        var priorRubRate = new ExchangeRate { FromCode = baseCurrency, ToCode = "RUB", Rate = 30m, Created = priorDate, IsTemporary = false };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<System.Linq.Expressions.Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _currencyRepoMock.Setup(r => r.Get(true, null))
+            .Returns(CurrenciesFor("USD", "RUB"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(new[] { priorRubRate }.AsAsyncQueryable());
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.Is<string[]>(a => a.SequenceEqual(new[] { "USD" })), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>
+            {
+                [requestedDate] = new()
+                {
+                    Data = new Dictionary<string, ExchangeDateData>
+                    {
+                        ["USD"] = new() { Code = "USD", Value = 0.31m }
+                    }
+                }
+            });
+        _nbrbClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, "RUB", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>());
+
+        var sut = CreateSut();
+
+        await sut.Get(1, requestedDate, requestedDate);
+
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == requestedDate && e.ToCode == "USD" && e.Rate == 0.31m), It.IsAny<CancellationToken>()), Times.Once);
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == requestedDate && e.ToCode == "RUB" && e.Rate == 30m), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/inex.Services/Extensions/InExServicesExtensions.cs
+++ b/inex.Services/Extensions/InExServicesExtensions.cs
@@ -26,6 +26,7 @@ public static class InExServicesExtensions
         services.AddOptions<InviteOptions>().BindConfiguration(InviteOptions.SectionName).ValidateDataAnnotations().ValidateOnStart();
         services.AddOptions<CurrencyApiSettings>().BindConfiguration(CurrencyApiSettings.SectionName).ValidateDataAnnotations().ValidateOnStart();
         services.AddOptions<FrankfurterApiSettings>().BindConfiguration(FrankfurterApiSettings.SectionName).ValidateDataAnnotations().ValidateOnStart();
+        services.AddOptions<NbrbApiSettings>().BindConfiguration(NbrbApiSettings.SectionName).ValidateDataAnnotations().ValidateOnStart();
 
         services.AddInExData(inexConnectionString);
 
@@ -57,6 +58,13 @@ public static class InExServicesExtensions
                 var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("InEx.Resilience");
                 return HttpResiliencePolicyFactory.CreateRetryPolicy(logger, "FrankfurterApiClient");
             });
+        services.AddKeyedSingleton<IAsyncPolicy<HttpResponseMessage>>(
+            "NbrbApiRetry",
+            (sp, _) =>
+            {
+                var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("InEx.Resilience");
+                return HttpResiliencePolicyFactory.CreateRetryPolicyHonoringRetryAfter(logger, "NbrbApiClient");
+            });
 
         services.AddHttpClient<CurrencyApiClient>((serviceProvider, client) =>
         {
@@ -83,15 +91,29 @@ public static class InExServicesExtensions
         .AddPolicyHandler((sp, _) => sp.GetRequiredKeyedService<IAsyncPolicy<HttpResponseMessage>>("FrankfurterApiRetry"))
         .AddPolicyHandler(HttpResiliencePolicyFactory.CreateTimeoutPolicy());
 
+        services.AddHttpClient<NbrbApiClient>((serviceProvider, client) =>
+        {
+            var settings = serviceProvider.GetRequiredService<IOptions<NbrbApiSettings>>().Value;
+            if (string.IsNullOrEmpty(settings.BaseUrl))
+                throw new InvalidOperationException("NBRB API BaseUrl is not configured.");
+            client.BaseAddress = new Uri(settings.BaseUrl);
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+            client.Timeout = Timeout.InfiniteTimeSpan; // Rely on Polly timeout policy
+        })
+        .AddTypedClient<INbrbApiClient>((client, _) => new NbrbApiClient(client))
+        .AddPolicyHandler((sp, _) => sp.GetRequiredKeyedService<IAsyncPolicy<HttpResponseMessage>>("NbrbApiRetry"))
+        .AddPolicyHandler(HttpResiliencePolicyFactory.CreateTimeoutPolicy());
+
         // Register ExchangeRateService with manual resolution of both clients
         services.AddScoped<IExchangeRateService>(serviceProvider =>
         {
             var uow = serviceProvider.GetRequiredService<IInExUnitOfWork>();
             var primaryClient = serviceProvider.GetRequiredService<CurrencyApiClient>();
             var fallbackClient = serviceProvider.GetRequiredService<FrankfurterApiClient>();
+            var nbrbClient = serviceProvider.GetRequiredService<INbrbApiClient>();
             var logger = serviceProvider.GetRequiredService<ILogger<ExchangeRateService>>();
             var clock = serviceProvider.GetRequiredService<IClock>();
-            return new ExchangeRateService(uow, primaryClient, fallbackClient, logger, clock);
+            return new ExchangeRateService(uow, primaryClient, fallbackClient, nbrbClient, logger, clock);
         });
 
         return services;

--- a/inex.Services/Infrastructure/ExternalClients/ExchangeRate/INbrbApiClient.cs
+++ b/inex.Services/Infrastructure/ExternalClients/ExchangeRate/INbrbApiClient.cs
@@ -1,0 +1,11 @@
+namespace inex.Services.Infrastructure.ExternalClients.ExchangeRate;
+
+public interface INbrbApiClient
+{
+    Task<Dictionary<DateTime, ExchangeRateResponse>> GetRatesForRangeAsync(
+        DateTime start,
+        DateTime end,
+        string baseCurrency,
+        string targetCurrency,
+        CancellationToken ct = default);
+}

--- a/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiClient.cs
+++ b/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiClient.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Json;
+
+namespace inex.Services.Infrastructure.ExternalClients.ExchangeRate;
+
+public class NbrbApiClient : INbrbApiClient
+{
+    private const string DomesticCurrency = "BYN";
+    private const string RubCurrency = "RUB";
+    private const int MaxInclusiveRangeDays = 365;
+
+    private readonly HttpClient _httpClient;
+
+    public NbrbApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<Dictionary<DateTime, ExchangeRateResponse>> GetRatesForRangeAsync(
+        DateTime start,
+        DateTime end,
+        string baseCurrency,
+        string targetCurrency,
+        CancellationToken ct = default)
+    {
+        if (end < start)
+        {
+            throw new ArgumentException("End date must be on or after start date.", nameof(end));
+        }
+
+        if (!IsBynRubPath(baseCurrency, targetCurrency))
+        {
+            return new Dictionary<DateTime, ExchangeRateResponse>();
+        }
+
+        var currencies = await _httpClient.GetFromJsonAsync<List<NbrbCurrencyResponse>>("exrates/currencies", ct)
+                         ?? new List<NbrbCurrencyResponse>();
+
+        var metadataRanges = currencies
+            .Where(c => string.Equals(c.CurAbbreviation, RubCurrency, StringComparison.OrdinalIgnoreCase))
+            .Select(c => new
+            {
+                Currency = c,
+                Start = c.CurDateStart.Date > start.Date ? c.CurDateStart.Date : start.Date,
+                End = (c.CurDateEnd?.Date ?? DateTime.MaxValue.Date) < end.Date ? c.CurDateEnd!.Value.Date : end.Date
+            })
+            .Where(c => c.Start <= c.End && c.Currency.CurScale > 0)
+            .OrderBy(c => c.Start)
+            .ToList();
+
+        var result = new Dictionary<DateTime, ExchangeRateResponse>();
+        foreach (var metadataRange in metadataRanges)
+        {
+            for (var segmentStart = metadataRange.Start; segmentStart <= metadataRange.End; segmentStart = segmentStart.AddDays(MaxInclusiveRangeDays))
+            {
+                var segmentEnd = segmentStart.AddDays(MaxInclusiveRangeDays - 1);
+                if (segmentEnd > metadataRange.End)
+                {
+                    segmentEnd = metadataRange.End;
+                }
+
+                var url = $"exrates/rates/dynamics/{metadataRange.Currency.CurId}?startdate={segmentStart:yyyy-MM-dd}&enddate={segmentEnd:yyyy-MM-dd}";
+                var rates = await _httpClient.GetFromJsonAsync<List<NbrbRateResponse>>(url, ct)
+                            ?? new List<NbrbRateResponse>();
+
+                foreach (var rate in rates)
+                {
+                    if (rate.CurOfficialRate <= 0)
+                    {
+                        continue;
+                    }
+
+                    var date = rate.Date.Date;
+                    result[date] = new ExchangeRateResponse
+                    {
+                        Data = new Dictionary<string, ExchangeDateData>
+                        {
+                            [targetCurrency.ToUpperInvariant()] = new()
+                            {
+                                Code = targetCurrency.ToUpperInvariant(),
+                                Value = ConvertRate(baseCurrency, targetCurrency, rate.CurOfficialRate, metadataRange.Currency.CurScale)
+                            }
+                        }
+                    };
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsBynRubPath(string baseCurrency, string targetCurrency) =>
+        string.Equals(baseCurrency, DomesticCurrency, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(targetCurrency, RubCurrency, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(baseCurrency, RubCurrency, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(targetCurrency, DomesticCurrency, StringComparison.OrdinalIgnoreCase);
+
+    private static decimal ConvertRate(string baseCurrency, string targetCurrency, decimal officialRate, int scale)
+    {
+        if (string.Equals(baseCurrency, RubCurrency, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(targetCurrency, DomesticCurrency, StringComparison.OrdinalIgnoreCase))
+        {
+            return officialRate / scale;
+        }
+
+        return scale / officialRate;
+    }
+}

--- a/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiSettings.cs
+++ b/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbApiSettings.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace inex.Services.Infrastructure.ExternalClients.ExchangeRate;
+
+public class NbrbApiSettings
+{
+    public const string SectionName = "NbrbApiSettings";
+
+    [Required]
+    public string BaseUrl { get; set; } = string.Empty;
+}

--- a/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbCurrencyResponse.cs
+++ b/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbCurrencyResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace inex.Services.Infrastructure.ExternalClients.ExchangeRate;
+
+public class NbrbCurrencyResponse
+{
+    [JsonPropertyName("Cur_ID")]
+    public int CurId { get; set; }
+
+    [JsonPropertyName("Cur_Abbreviation")]
+    public string CurAbbreviation { get; set; } = string.Empty;
+
+    [JsonPropertyName("Cur_Scale")]
+    public int CurScale { get; set; }
+
+    [JsonPropertyName("Cur_DateStart")]
+    public DateTime CurDateStart { get; set; }
+
+    [JsonPropertyName("Cur_DateEnd")]
+    public DateTime? CurDateEnd { get; set; }
+}

--- a/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbRateResponse.cs
+++ b/inex.Services/Infrastructure/ExternalClients/ExchangeRate/NbrbRateResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace inex.Services.Infrastructure.ExternalClients.ExchangeRate;
+
+public class NbrbRateResponse
+{
+    [JsonPropertyName("Cur_ID")]
+    public int CurId { get; set; }
+
+    [JsonPropertyName("Date")]
+    public DateTime Date { get; set; }
+
+    [JsonPropertyName("Cur_OfficialRate")]
+    public decimal CurOfficialRate { get; set; }
+}

--- a/inex.Services/Infrastructure/Resilience/HttpResiliencePolicyFactory.cs
+++ b/inex.Services/Infrastructure/Resilience/HttpResiliencePolicyFactory.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Extensions.Http;
+using Polly.Retry;
 using Polly.Timeout;
+using System.Net;
 
 namespace inex.Services.Infrastructure.Resilience;
 
@@ -47,9 +49,67 @@ public static class HttpResiliencePolicyFactory
                 });
     }
 
+    public static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicyHonoringRetryAfter(
+        ILogger logger,
+        string clientName,
+        HttpResiliencePolicyOptions? options = null)
+    {
+        options ??= HttpResiliencePolicyOptions.Default;
+
+        var builder = HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .OrResult(msg => msg.StatusCode == HttpStatusCode.TooManyRequests)
+            .Or<TimeoutRejectedException>();
+
+        return AsyncRetryTResultSyntax.WaitAndRetryAsync(
+            builder,
+            retryCount: options.RetryCount,
+            sleepDurationProvider: (retryAttempt, outcome, _) =>
+                GetRetryAfterDelay(outcome.Result) ?? options.RetryDelayProvider(retryAttempt),
+            onRetryAsync: (outcome, timespan, retryCount, _) =>
+            {
+                logger.LogWarning(
+                    "Retry {RetryCount} for {ClientName} after {Delay}ms due to {Reason}. Status: {StatusCode}",
+                    retryCount,
+                    clientName,
+                    timespan.TotalMilliseconds,
+                    outcome.Exception?.Message ?? "HTTP error",
+                    outcome.Result?.StatusCode.ToString() ?? "N/A"
+                );
+                return Task.CompletedTask;
+            });
+    }
+
     public static IAsyncPolicy<HttpResponseMessage> CreateTimeoutPolicy(HttpResiliencePolicyOptions? options = null)
     {
         options ??= HttpResiliencePolicyOptions.Default;
         return Policy.TimeoutAsync<HttpResponseMessage>(options.TimeoutPerAttempt);
+    }
+
+    private static TimeSpan? GetRetryAfterDelay(HttpResponseMessage? response)
+    {
+        if (response?.StatusCode != HttpStatusCode.TooManyRequests)
+        {
+            return null;
+        }
+
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter is null)
+        {
+            return null;
+        }
+
+        if (retryAfter.Delta.HasValue)
+        {
+            return retryAfter.Delta.Value;
+        }
+
+        if (retryAfter.Date.HasValue)
+        {
+            var delay = retryAfter.Date.Value - DateTimeOffset.UtcNow;
+            return delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
+        }
+
+        return null;
     }
 }

--- a/inex.Services/Services/ExchangeRateService.cs
+++ b/inex.Services/Services/ExchangeRateService.cs
@@ -24,10 +24,17 @@ public class ExchangeRateService : Service, IExchangeRateService
 {
     #region Constructors
 
-    public ExchangeRateService(IInExUnitOfWork uowInEx, IExchangeRateClient apiClient, IExchangeRateClient fallbackClient, ILogger<ExchangeRateService> logger, IClock clock) : base(uowInEx)
+    public ExchangeRateService(
+        IInExUnitOfWork uowInEx,
+        IExchangeRateClient apiClient,
+        IExchangeRateClient fallbackClient,
+        INbrbApiClient nbrbClient,
+        ILogger<ExchangeRateService> logger,
+        IClock clock) : base(uowInEx)
     {
         _apiClient = apiClient;
         _fallbackClient = fallbackClient;
+        _nbrbClient = nbrbClient;
         _logger = logger;
         _clock = clock;
     }
@@ -92,20 +99,15 @@ public class ExchangeRateService : Service, IExchangeRateService
             if (hasChanges)
                 await DbInEx.SaveAsync(ct);
 
-            // Carry forward rates for non-trading days (weekends, holidays) from the nearest prior trading day.
-            var noDataDates = missingDates
-                .Where(d => !rangeRates.ContainsKey(d))
-                .OrderBy(d => d)
-                .ToList();
-
-            if (noDataDates.Count > 0)
+            // Carry forward missing currencies for non-trading days or partial provider data.
+            bool hasCarryForwardChanges = false;
+            foreach (var date in missingDates.OrderBy(d => d))
             {
-                bool hasCarryForwardChanges = false;
-                foreach (var date in noDataDates)
-                    hasCarryForwardChanges |= await CarryForwardRatesFromPriorDay(userId, date, baseCurrency, ct);
-                if (hasCarryForwardChanges)
-                    await DbInEx.SaveAsync(ct);
+                hasCarryForwardChanges |= await CarryForwardMissingRatesFromPriorDay(userId, date, baseCurrency, targetCurrencyCodes, ct);
             }
+
+            if (hasCarryForwardChanges)
+                await DbInEx.SaveAsync(ct);
         }
 
         if (endDate >= today)
@@ -163,60 +165,94 @@ public class ExchangeRateService : Service, IExchangeRateService
     private async Task<Dictionary<DateTime, ExchangeApiResponse>> FetchRatesForRange(
         DateTime start, DateTime end, string baseCurrency, string[] targetCurrencies, CancellationToken ct = default)
     {
-        // Pass 1: Frankfurter range call (single HTTP request).
-        var result = new Dictionary<DateTime, ExchangeApiResponse>();
-        try
-        {
-            result = await _fallbackClient.GetRatesForRangeAsync(start, end, baseCurrency, targetCurrencies, ct)
-                     ?? new Dictionary<DateTime, ExchangeApiResponse>();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Frankfurter range fetch failed for {Start}..{End}/{BaseCurrency}.", start, end, baseCurrency);
-        }
-
-        // Pass 2: supplement currencies not returned by Frankfurter (e.g. BYN) via CurrencyAPI.
-        var coveredCurrencies = result.Values
-            .SelectMany(r => r.Data.Keys)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var uncoveredCurrencies = targetCurrencies
-            .Where(c => !coveredCurrencies.Contains(c))
+        var nbrbTargetCurrencies = targetCurrencies
+            .Where(targetCurrency => IsBynRubPath(baseCurrency, targetCurrency))
             .ToArray();
 
-        if (uncoveredCurrencies.Length > 0)
-        {
-            // Only iterate dates Frankfurter returned (trading days); weekends/holidays get carry-forward.
-            // If Frankfurter returned nothing at all, fall back to all dates in range.
-            var datesToFetch = result.Count > 0
-                ? result.Keys.ToList()
-                : Enumerable.Range(0, (end.Date - start.Date).Days + 1).Select(i => start.Date.AddDays(i)).ToList();
+        var standardTargetCurrencies = targetCurrencies
+            .Where(targetCurrency => !nbrbTargetCurrencies.Contains(targetCurrency, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
 
-            foreach (var date in datesToFetch)
+        // Pass 1: Frankfurter range call (single HTTP request).
+        var result = new Dictionary<DateTime, ExchangeApiResponse>();
+        if (standardTargetCurrencies.Length > 0)
+        {
+            try
             {
-                try
+                result = await _fallbackClient.GetRatesForRangeAsync(start, end, baseCurrency, standardTargetCurrencies, ct)
+                         ?? new Dictionary<DateTime, ExchangeApiResponse>();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Frankfurter range fetch failed for {Start}..{End}/{BaseCurrency}.", start, end, baseCurrency);
+            }
+
+            // Pass 2: supplement currencies not returned by Frankfurter (e.g. BYN) via CurrencyAPI.
+            var coveredCurrencies = result.Values
+                .SelectMany(r => r.Data.Keys)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var uncoveredCurrencies = standardTargetCurrencies
+                .Where(c => !coveredCurrencies.Contains(c))
+                .ToArray();
+
+            if (uncoveredCurrencies.Length > 0)
+            {
+                // Only iterate dates Frankfurter returned (trading days); weekends/holidays get carry-forward.
+                // If Frankfurter returned nothing at all, fall back to all dates in range.
+                var datesToFetch = result.Count > 0
+                    ? result.Keys.ToList()
+                    : Enumerable.Range(0, (end.Date - start.Date).Days + 1).Select(i => start.Date.AddDays(i)).ToList();
+
+                foreach (var date in datesToFetch)
                 {
-                    var singleDay = await _apiClient.GetRatesAsync(date, baseCurrency, uncoveredCurrencies, ct);
-                    if (singleDay?.Data?.Count > 0)
+                    try
                     {
-                        if (result.TryGetValue(date, out var existing))
+                        var singleDay = await _apiClient.GetRatesAsync(date, baseCurrency, uncoveredCurrencies, ct);
+                        if (singleDay?.Data?.Count > 0)
                         {
-                            foreach (var kvp in singleDay.Data)
-                                existing.Data.TryAdd(kvp.Key, kvp.Value);
-                        }
-                        else
-                        {
-                            result[date] = singleDay;
+                            MergeRates(result, date, singleDay);
                         }
                     }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "CurrencyAPI fetch failed for {Date}/{BaseCurrency}/{Currencies}.", date, baseCurrency, string.Join(",", uncoveredCurrencies));
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "CurrencyAPI fetch failed for {Date}/{BaseCurrency}/{Currencies}.", date, baseCurrency, string.Join(",", uncoveredCurrencies));
+                    }
                 }
             }
         }
 
+        foreach (var nbrbTargetCurrency in nbrbTargetCurrencies)
+        {
+            try
+            {
+                var nbrbRates = await _nbrbClient.GetRatesForRangeAsync(start, end, baseCurrency, nbrbTargetCurrency, ct)
+                                ?? new Dictionary<DateTime, ExchangeApiResponse>();
+
+                foreach (var (date, response) in nbrbRates)
+                {
+                    MergeRates(result, date, response);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "NBRB range fetch failed for {Start}..{End}/{BaseCurrency}/{TargetCurrency}.", start, end, baseCurrency, nbrbTargetCurrency);
+            }
+        }
+
         return result;
+    }
+
+    private static void MergeRates(Dictionary<DateTime, ExchangeApiResponse> result, DateTime date, ExchangeApiResponse response)
+    {
+        if (result.TryGetValue(date.Date, out var existing))
+        {
+            foreach (var kvp in response.Data)
+                existing.Data[kvp.Key] = kvp.Value;
+        }
+        else
+        {
+            result[date.Date] = response;
+        }
     }
 
     /// <summary>
@@ -328,22 +364,24 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// fully cached and not re-queried on subsequent calls.
     /// Returns <see langword="true"/> if any records were created (caller must save).
     /// </summary>
-    private async Task<bool> CarryForwardRatesFromPriorDay(int userId, DateTime date, string baseCurrency, CancellationToken ct = default)
+    private async Task<bool> CarryForwardMissingRatesFromPriorDay(int userId, DateTime date, string baseCurrency, IList<string> targetCurrencyCodes, CancellationToken ct = default)
     {
-        bool alreadyExists = DbInEx.ExchangeRateRepository.Get(true)
-            .Any(r => r.Created == date.Date && r.FromCode == baseCurrency);
-        if (alreadyExists) return false;
+        var existingTargetCodes = DbInEx.ExchangeRateRepository.Get(true)
+            .Where(r => r.Created == date.Date && r.FromCode == baseCurrency)
+            .Select(r => r.ToCode)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        DateTime? priorDate = DbInEx.ExchangeRateRepository.Get(true)
-            .Where(r => r.Created < date.Date && r.FromCode == baseCurrency && !r.IsTemporary)
-            .OrderByDescending(r => r.Created)
-            .Select(r => (DateTime?)r.Created)
-            .FirstOrDefault();
-
-        if (!priorDate.HasValue) return false;
+        var missingTargetCodes = targetCurrencyCodes
+            .Where(targetCode => !existingTargetCodes.Contains(targetCode))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (missingTargetCodes.Count == 0) return false;
 
         var priorRates = DbInEx.ExchangeRateRepository.Get(true)
-            .Where(r => r.Created == priorDate.Value && r.FromCode == baseCurrency)
+            .Where(r => r.Created < date.Date && r.FromCode == baseCurrency && !r.IsTemporary)
+            .OrderByDescending(r => r.Created)
+            .Where(r => missingTargetCodes.Contains(r.ToCode))
+            .GroupBy(r => r.ToCode)
+            .Select(g => g.First())
             .ToList();
 
         foreach (var rate in priorRates)
@@ -362,12 +400,19 @@ public class ExchangeRateService : Service, IExchangeRateService
         return priorRates.Count > 0;
     }
 
+    private static bool IsBynRubPath(string baseCurrency, string targetCurrency) =>
+        string.Equals(baseCurrency, "BYN", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(targetCurrency, "RUB", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(baseCurrency, "RUB", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(targetCurrency, "BYN", StringComparison.OrdinalIgnoreCase);
+
     #endregion Private Methods
 
     #region Private Fields
 
     private readonly IExchangeRateClient _apiClient;
     private readonly IExchangeRateClient _fallbackClient;
+    private readonly INbrbApiClient _nbrbClient;
     private readonly ILogger<ExchangeRateService> _logger;
     private readonly IClock _clock;
 

--- a/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
+++ b/inex.Tests/Infrastructure/InExWebApplicationFactory.cs
@@ -39,6 +39,7 @@ public class InExWebApplicationFactory : WebApplicationFactory<Program>
                 ["CurrencyApiSettings:BaseUrl"]       = "https://dummy.invalid/",
                 ["CurrencyApiSettings:ApiKey"]        = "test-key",
                 ["FrankfurterApiSettings:BaseUrl"]    = "https://dummy.invalid/",
+                ["NbrbApiSettings:BaseUrl"]           = "https://dummy.invalid/",
                 // Provide a real secret so JWT middleware can sign and validate tokens
                 ["JwtOptions:Secret"]                 = TestJwtSecret,
                 ["JwtOptions:Issuer"]                 = "inex-api",

--- a/inex/appsettings.json
+++ b/inex/appsettings.json
@@ -57,5 +57,8 @@
   },
   "FrankfurterApiSettings": {
     "BaseUrl": "https://api.frankfurter.dev/"
+  },
+  "NbrbApiSettings": {
+    "BaseUrl": "https://api.nbrb.by/"
   }
 }


### PR DESCRIPTION
## Summary
- add an NBRB exchange-rate client for direct BYN/RUB and RUB/BYN conversion
- route BYN/RUB through NBRB while preserving Frankfurter plus CurrencyAPI behavior for other rates
- add NBRB config, retry-after-aware 429 handling, carry-forward support for partial missing rates, and focused tests

## Validation
- dotnet test .\inex.Services.Tests\inex.Services.Tests.csproj
- dotnet build .\inex.sln
- dotnet test .\inex.sln