### PR TITLE
Docs: add Epic 6 stories and Epic 10 readiness updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ docs/*
 !docs/planning/**
 !docs/implementation/
 !docs/implementation/**
+!docs/operations/
+!docs/operations/**
 **/logs/
 *.pem
 *.stackdump

--- a/docs/design/docs/design-implementation-guide.md
+++ b/docs/design/docs/design-implementation-guide.md
@@ -1,0 +1,673 @@
+# InEx Design Implementation Guide
+
+Status: baseline documentation for implementing the mockup layouts in a production React app.
+Source of truth: the running mockup in this repository, verified in the Codex browser on 2026-05-26.
+Planning companion: `docs/planning/design-update-plan.md`.
+
+## 1. Purpose
+
+This document translates the current InEx mockup into implementation guidance for a real React web app. It is not a new design proposal. Use it to preserve layout intent, component behavior, visual hierarchy, responsive behavior, and future rebranding flexibility while rebuilding the UI in production-grade React.
+
+The implementation plan and backlog mapping live in `docs/planning/design-update-plan.md` and `docs/planning/epics.md` (Epic 10). Keep this guide focused on the design contract; use the planning docs for sequencing, story scope, and sprint placement.
+
+The mockup represents a personal finance platform with these product areas:
+
+- Transactions
+- Accounts
+- Categories
+- Budgets
+- Reports
+- Profile and settings
+- Authentication
+
+## 2. Current Mockup Sources
+
+Use these files as the baseline design references:
+
+| Area | File |
+| --- | --- |
+| App routing and page defaults | `src/main.jsx` |
+| Legacy component load order | `src/legacy-loader.jsx` |
+| Global design tokens | `tokens.css` |
+| Responsive behavior | `responsive.css` |
+| Top nav, bottom nav, page header | `Shell.jsx` |
+| Shared primitives | `Primitives.jsx` |
+| Seed data model | `data.js` |
+| Empty states | `EmptyState.jsx` |
+| Auth screens | `Auth.jsx` |
+| Transactions | `Transactions.jsx` |
+| Accounts | `Accounts.jsx` |
+| Categories | `Categories.jsx` |
+| Budgets | `Budgets.jsx` |
+| Reports hub and core reports | `Reports.jsx` |
+| Extra report views | `ReportsExtra.jsx` |
+| Profile and settings | `Profile.jsx` |
+
+The current mockup uses browser globals through `window.*`. The production app should convert these to explicit React modules, but the visual and interaction contracts below should remain stable unless a product decision changes them.
+
+## 3. Route Map
+
+| Route | Page title | Header subtitle | Primary action |
+| --- | --- | --- | --- |
+| `#/transactions` | Transactions | Overview | Add transaction |
+| `#/accounts` | Accounts | Manage | Add account |
+| `#/categories` | Categories | Manage | Add category |
+| `#/budgets` | Budgets | Plan | Copy from March, Add budget |
+| `#/reports` | Reports | Analyze | Date period, Configure |
+| `#/profile` | Profile & Settings | Account | Sign out |
+| `#/login` | Sign in to InEx | none | Sign in |
+| `#/register` | Create your InEx account | none | Create account |
+
+Production routing should use real React Router or framework routes, but keep the same top-level information architecture unless the product IA is redesigned.
+
+## 4. Brand And Visual Language
+
+### Design Personality
+
+InEx should feel like a quiet finance operations tool: dense, readable, precise, and calm. The interface should not look like a marketing landing page. The strongest visual signals should be financial state, not decoration.
+
+Key traits:
+
+- Dense but not cramped.
+- Table-first for operational screens.
+- Strong numeric alignment.
+- Restrained cards and shadows.
+- Semantic color for money movement.
+- Minimal decorative imagery outside authentication and empty states.
+
+### Token Contract
+
+The current token file defines the core rebranding surface. In production, these should become design-system tokens, theme variables, or CSS custom properties.
+
+| Token group | Current intent |
+| --- | --- |
+| `--brand-ink` | Primary brand text, navigation active state, avatar background |
+| `--income-*` | Positive money, primary CTA, active indicator |
+| `--expense-*` | Negative money, destructive state, expense category emphasis |
+| `--transfer-*` | Neutral money movement |
+| `--warn-*` | Over-budget or caution state |
+| `--fg-*` | Text hierarchy |
+| `--bg-*` | App canvas, surfaces, muted fills, stripes |
+| `--border-*` | Hairlines, input borders, focus/pressed borders |
+| `--shadow-*` | Surface elevation |
+| `--radius-*` | Shape scale |
+| `--space-*` | 4px spacing scale |
+| `--fs-*`, `--fw-*`, `--lh-*` | Type scale |
+
+Current primary colors observed in the browser:
+
+| Role | Value |
+| --- | --- |
+| App background | `#F5F7FA` |
+| Brand ink | `#0F1E2E` |
+| Income primary | `#2F8F82` |
+| Expense primary | `#C35A4A` |
+| Default border | `#E5EAF1` |
+| Standard panel radius | `10px` token, often implemented as `8px` in page cards |
+
+### Rebranding Rule
+
+Future rebrands should change tokens first, then component variants, then page-specific layouts. Avoid page-level one-off colors unless they encode product meaning that cannot be expressed through tokens.
+
+## 5. Typography And Numerics
+
+Current fonts:
+
+- UI: Inter
+- Numerics: JetBrains Mono
+
+Production requirements:
+
+- Use tabular numerals for every amount, balance, percentage, count, and chart axis label.
+- Keep money values visually stable across sorting, filtering, and live updates.
+- Use compact type in tables and controls. Reserve larger headings for page titles and hero metrics.
+- Current page title size is 28px desktop and 22px mobile.
+- Current body default is 14px.
+- Avoid negative letter spacing in compact controls and dense panels.
+
+Numeric signage is configurable in the mockup through `window.__INEX_SIGNAGE`:
+
+| Mode | Meaning |
+| --- | --- |
+| `color-only` | Use color for income/expense distinction |
+| `signed` | Prefix positive and negative amounts |
+| `arrows` | Use directional cues for neutral movement |
+
+Production should make signage an accessibility/user preference, not a page-local tweak.
+
+## 6. Application Shell
+
+### Desktop Shell
+
+Observed desktop viewport: 1740 x 1270.
+
+The shell consists of:
+
+- Sticky top navigation, 60px high.
+- White nav background.
+- 40px horizontal nav padding.
+- Brand mark and wordmark on the left.
+- Main sections as horizontal nav tabs.
+- Active tab uses brand ink text and a 2px income-green bottom border.
+- User pill on the right.
+- Page header below nav with 40px gutters.
+- Main page content with 40px gutters.
+
+### Page Header
+
+Desktop:
+
+- Padding: `28px 40px 20px`
+- Layout: flex row, title block left, actions right.
+- Header aligns to bottom.
+- Subtitle: uppercase, 12px, semibold, secondary text, letter spacing.
+- Title: 28px, semibold, tight line-height.
+
+Mobile:
+
+- Padding: `20px 16px 12px`
+- Direction: column.
+- Actions wrap and may fill available width.
+- Title: 22px.
+
+### Mobile Shell
+
+Breakpoint: `max-width: 768px`.
+
+Observed mobile viewport: 390 x 844.
+
+Mobile shell behavior:
+
+- Top nav remains sticky but hides horizontal nav items.
+- Top nav height becomes 56px.
+- Page gutters become 16px.
+- Bottom nav appears fixed at the bottom.
+- Content gets bottom padding, typically 96px, to avoid bottom nav overlap.
+- User name hides inside the user pill.
+
+## 7. Shared Components
+
+### Buttons
+
+Current variants:
+
+- `primary`: income-green background, white text.
+- `danger`: expense-red background, white text.
+- `default`: white background, border.
+- `ghost`: transparent background, border.
+- `soft`: muted background.
+- `link`: text-style green action.
+
+Button implementation requirements:
+
+- Radius: 6px.
+- Use inline icon plus label where the action is not obvious.
+- Primary action per page should be green unless destructive.
+- Do not overuse primary buttons in toolbars.
+- Disabled state should reduce opacity and remove pointer affordance.
+
+### Icon Buttons
+
+Use icon-only buttons for compact row actions, disclosure, settings, close, and utility controls. Icons are currently Lucide via `data-lucide`. Production should use the real React icon package, not DOM post-processing.
+
+### Tags And Chips
+
+Use small chips for status, scope, and category metadata.
+
+Current visual contract:
+
+- Tight padding: `2px 8px`.
+- Radius: 4px or pill for compact status.
+- Uppercase or semibold compact labels.
+- Color maps to semantic role.
+
+### Segmented Controls
+
+Segmented controls are used for scopes and view modes:
+
+- Active/All
+- Tree/By spend
+- By currency/Flat list
+- Month chips
+- Report intervals
+
+Current pattern:
+
+- Muted container.
+- 3px inner padding.
+- Active item white with subtle `shadow-1`.
+- Radius: container 8px, active item 6px.
+
+### Inputs And Selects
+
+Current controls:
+
+- Border: `--border-2`.
+- Radius: 6px.
+- Focus: income-green focus ring.
+- Selects use a custom chevron background.
+- Addons use muted fill and mono text for currency or units.
+
+Production should use accessible native controls or design-system controls with equivalent keyboard and screen-reader behavior.
+
+### Drawers
+
+Drawers are used for create/edit flows and advanced filters.
+
+Current behavior:
+
+- Fixed overlay with navy translucent backdrop.
+- Panel slides in from right.
+- Default width: 440px.
+- Header includes title, optional subtitle, and close icon.
+- Mobile breakpoint makes drawer full width.
+
+Production requirements:
+
+- Trap focus inside drawer.
+- Close on Escape.
+- Return focus to triggering control.
+- Preserve scroll inside drawer body.
+
+### Progress And Distribution Bars
+
+Use progress bars for budgets, burn rate, and category distribution.
+
+Current behavior:
+
+- Green under normal use.
+- Amber when approaching threshold.
+- Red when over limit.
+- Bars use pill radius and muted track.
+
+## 8. Page Layout Specifications
+
+### Transactions
+
+Purpose: operational ledger and short-term financial overview.
+
+Desktop layout:
+
+- KPI strip at top with three equal columns.
+- Main content uses a table-like ledger.
+- Content padding: `0 40px 20px` for KPI strip, then `0 40px 32px`.
+- Ledger grid columns: `1.8fr 1fr 1fr 180px`.
+- Day headers separate groups.
+- Row density supports compact and comfortable modes.
+- Filters and type tabs sit above the ledger.
+
+Mobile behavior:
+
+- KPI strip collapses to one column.
+- Ledger header hides.
+- Ledger rows stack into one-column card-like blocks.
+- Amount moves above supporting metadata.
+- No horizontal overflow observed at 390px.
+
+Implementation notes:
+
+- Keep transaction amount right-aligned on desktop.
+- Use tabular numerics for all amount cells.
+- Preserve income, expense, and transfer distinction.
+- Filtering should keep visible counts in the control labels.
+
+### Accounts
+
+Purpose: account inventory, balances, and currency grouping.
+
+Desktop layout:
+
+- Workspace padding: `0 40px 32px`.
+- Hero card uses two-column layout: `320px 1fr`.
+- Hero includes net worth summary and supporting account metrics.
+- Account rows use grid: `1.8fr 100px 130px 130px 28px`.
+- Grouping supports currency groups and flat list.
+
+Mobile behavior:
+
+- Workspace padding: `0 16px 96px`.
+- Hero stacks.
+- Rows stack into one-column blocks.
+- Toolbar and filter bar stack.
+- No horizontal overflow observed at 390px.
+
+Implementation notes:
+
+- Currency badges should remain deterministic and compact.
+- Liability/credit account values must use negative or semantic styling consistently.
+- Expanded inline edit should remain visually attached to the row.
+
+### Categories
+
+Purpose: category management, hierarchy, and spend signal.
+
+Desktop layout:
+
+- Workspace padding: `0 40px 32px`.
+- Hero card uses `320px 1fr`.
+- Summary contains April spend, active category count, budgeted categories, top category, and distribution cue.
+- Category rows use grid: `minmax(260px, 1fr) 150px 130px 34px`.
+- Parent and child categories have distinct row treatment.
+- Tree and By spend views are available.
+
+Mobile behavior:
+
+- Hero compresses, then metric grid becomes smaller.
+- Category rows use two columns: main content plus compact amount/action area.
+- Chevron becomes absolute on the right.
+- Parent rows get a left accent rail.
+- Inline edit becomes one column.
+- No horizontal overflow observed at 390px.
+
+Implementation notes:
+
+- Preserve ancestor visibility when search matches a child.
+- Parent rows should be scannable as group headers without becoming separate cards.
+- Child indentation must not create mobile overflow.
+
+### Budgets
+
+Purpose: monthly budget planning and burn-rate tracking.
+
+Desktop layout:
+
+- Workspace padding: `0 40px 32px`.
+- Hero card uses `340px 1fr`.
+- Burn list rows use `110px 1fr 90px`.
+- Budget table uses `1.8fr 1.5fr 1.6fr 110px 110px 28px`.
+- Header actions include Copy from March and Add budget.
+- Month switcher is prominent in the toolbar.
+
+Mobile behavior:
+
+- Hero stacks.
+- Month switcher scrolls horizontally.
+- Filter bar wraps.
+- Budget rows stack into one-column blocks.
+- Burn rows compress to `90px 1fr 60px`.
+- No horizontal overflow observed at 390px.
+
+Implementation notes:
+
+- Burn rate and remaining amounts should be the strongest scan targets.
+- Over-budget state must use expense red and should not rely on color alone.
+- Copy-from-previous-month action should remain secondary to creating a budget.
+
+### Reports
+
+Purpose: analytical hub and drill-down report views.
+
+Desktop layout:
+
+- Hub content padding: `0 40px 40px`.
+- Report hub uses auto-fill cards with `minmax(280px, 1fr)`.
+- Cards use white surface, border, 12px radius, and `shadow-1`.
+- Header actions are date period and Configure on hub.
+- Drill-down reports replace subtitle with an All reports back affordance.
+- Drill-down actions are Share, Export, Print.
+
+Mobile behavior:
+
+- Report hub becomes one column.
+- Stat rows become two columns.
+- Bottom nav remains visible.
+- No horizontal overflow observed at 390px for hub.
+
+Implementation notes:
+
+- Report cards should read as launch points, not dashboard widgets.
+- Heavy chart views need responsive chart containers and accessible data summaries.
+- Keep export/print actions out of the hub unless a specific report is open.
+
+### Profile And Settings
+
+Purpose: user profile, preferences, account configuration.
+
+Desktop layout:
+
+- Settings container padding: `0 40px 40px`.
+- Grid: `240px 1fr`.
+- Sidebar is sticky under the top nav.
+- Main content uses two-column cards where appropriate.
+- Cards use 12px radius and `shadow-1`.
+
+Mobile behavior:
+
+- Intended behavior: settings grid collapses to one column.
+- Sidebar becomes horizontal scroll tabs.
+- Internal settings grids collapse to one column.
+- Content receives bottom nav padding.
+
+Observed issue:
+
+- At 390px, the profile page currently has horizontal overflow. The computed settings grid was wider than the viewport. Treat this as a production fix requirement.
+
+Implementation notes:
+
+- Make settings sidebar scroll horizontally without forcing page width.
+- Apply `min-width: 0` to grid children.
+- Audit all two-column inner grids and wide form controls at mobile widths.
+
+### Authentication
+
+Purpose: sign in and account creation.
+
+Desktop layout:
+
+- Full-height two-column grid: `1fr 1fr`.
+- Left brand panel carries product positioning.
+- Right panel contains the form.
+- Social auth buttons appear on login.
+- Register form focuses on account creation.
+
+Mobile behavior:
+
+- Brand panel hides.
+- Single-column form.
+- Mobile logo appears.
+- No bottom nav.
+- No horizontal overflow observed at 390px.
+
+Implementation notes:
+
+- Keep auth separate from the app shell.
+- Production forms need validation, error summaries, loading state, and password-manager-friendly fields.
+- Avoid rebuilding the auth screen as a marketing page.
+
+## 9. Empty And Filter-Empty States
+
+Empty states exist for:
+
+- Transactions
+- Accounts
+- Categories
+- Budgets
+- Reports
+
+Current pattern:
+
+- White surface.
+- Dashed border.
+- 14px radius.
+- Large centered icon tile.
+- 22px title.
+- Descriptive 14px copy.
+- Primary and secondary actions.
+- Optional suggestion list.
+
+Production requirements:
+
+- Empty states should explain the next useful action.
+- Filter-empty states should be smaller and preserve page context.
+- Empty copy should be product-specific, not generic system copy.
+
+## 10. Responsive Rules
+
+Use `768px` as the first production breakpoint unless the real product has stronger device analytics.
+
+Current mobile transformations:
+
+| Component | Desktop | Mobile |
+| --- | --- | --- |
+| Top nav | horizontal section tabs | tabs hidden |
+| Bottom nav | hidden | fixed bottom nav |
+| Page header | row | column |
+| Gutters | 40px | 16px |
+| Workspace | wide content | one column, 96px bottom padding |
+| Ledger header | visible | hidden |
+| Ledger row | multi-column grid | stacked block |
+| KPI strip | multi-column | one column |
+| Hero two-column | side-by-side | stacked |
+| Auth | two-column | single-column |
+| Settings sidebar | sticky side nav | horizontal scroll nav |
+| Drawer | fixed right width | full width |
+
+Mobile QA checklist:
+
+- No horizontal overflow at 390px.
+- Bottom nav does not cover the final row or footer.
+- Header actions wrap without overlapping title.
+- Long amounts keep tabular alignment but do not force overflow.
+- Search inputs can shrink with `min-width: 0`.
+- Horizontal controls such as month switchers scroll internally, not at page level.
+
+## 11. Production React Architecture Recommendation
+
+The mockup should be migrated from browser globals to explicit modules.
+
+Recommended structure:
+
+```text
+src/
+  app/
+    routes/
+    AppShell.tsx
+    routeConfig.ts
+  design-system/
+    tokens.css
+    Button.tsx
+    IconButton.tsx
+    Field.tsx
+    Select.tsx
+    Tabs.tsx
+    Drawer.tsx
+    EmptyState.tsx
+    Money.tsx
+    Progress.tsx
+  features/
+    transactions/
+    accounts/
+    categories/
+    budgets/
+    reports/
+    profile/
+    auth/
+  data/
+    fixtures.ts
+    types.ts
+```
+
+Migration priorities:
+
+1. Extract tokens unchanged.
+2. Convert primitives to typed React components.
+3. Convert shell and route config.
+4. Convert one feature page at a time.
+5. Replace inline styles with component props, CSS modules, or theme-aware styling.
+6. Add visual regression coverage after each page is converted.
+
+## 12. Rebranding Workflow
+
+Use this order for future rebranding work:
+
+1. Define brand goals and constraints.
+2. Update token palette, typography, logo assets, and icon rules.
+3. Verify money semantics remain accessible and unambiguous.
+4. Update shared primitives.
+5. Review shell, auth, and empty states.
+6. Review each feature page.
+7. Run responsive and visual regression checks.
+8. Document before/after token decisions.
+
+Do not start rebranding by editing individual page cards. That creates drift and makes future rebrands expensive.
+
+## 13. Accessibility Requirements
+
+Production implementation must add accessibility behavior that the mockup only approximates:
+
+- Real buttons for clickable controls.
+- Real links for navigation.
+- Keyboard support for all segmented controls and tabs.
+- Focus states matching `--focus-ring`.
+- Drawer focus trap and Escape close.
+- Screen-reader labels for icon-only actions.
+- Color-independent income/expense signage option.
+- Proper headings hierarchy per route.
+- Form labels connected to inputs.
+- Error messages associated with fields.
+- Chart data available as text or table summaries.
+
+## 14. Visual Regression Coverage
+
+Minimum screenshot set for future implementation:
+
+Desktop widths:
+
+- 1440px: all top-level pages.
+- 1024px: operational pages with tables.
+
+Mobile widths:
+
+- 390px: all top-level pages.
+- 360px: categories and budgets.
+
+States:
+
+- Default populated data.
+- Empty mode via `?empty=1`.
+- Filter-empty state.
+- Drawer open.
+- Expanded row.
+- Report drill-down.
+- Long translated labels and long amounts.
+
+## 15. Known Implementation Risks
+
+| Risk | Impact | Recommendation |
+| --- | --- | --- |
+| Inline styles dominate page code | Harder theming and rebranding | Move repeated patterns into shared components and CSS tokens |
+| Browser globals | Hard to test and type | Convert to module exports |
+| Icon rendering via DOM scan | Fragile in React updates | Use React Lucide components |
+| Mobile profile overflow | Broken mobile settings page | Fix grid min-width and sidebar overflow during migration |
+| Color-only money semantics | Accessibility risk | Support signed or icon-assisted mode |
+| Charts are visual-first | Accessibility and export risk | Provide tabular summaries and export-ready data |
+| Mock forms lack production validation | Runtime errors and weak UX | Add schema validation, loading, disabled, and error states |
+
+## 16. Acceptance Criteria For Production Rebuild
+
+A production implementation preserves the mockup when:
+
+- Top-level routes match the route map.
+- Desktop shell, page header, gutters, and nav behavior match the baseline.
+- Mobile shell hides top tabs, shows bottom nav, and uses 16px gutters.
+- Core token roles are implemented through theme variables.
+- Money values use tabular numerics and semantic styling.
+- Operational pages retain table-like scanning on desktop and stacked rows on mobile.
+- Drawers, filters, expanded rows, empty states, and report drill-downs are implemented.
+- Pages pass visual checks at 1440px and 390px.
+- Future brand changes can be made primarily through tokens and shared primitives.
+
+## 17. Migration Notes For The Current App
+
+The current production frontend under `inex/ClientApp/src` already has the correct product routes and data-loading shape, but it is still mostly Ant Design layout and table chrome. The design update should bridge from the existing app rather than replacing the app wholesale.
+
+Recommended migration order:
+
+1. Add token CSS and shared design-system components without changing feature behavior.
+2. Replace `BasicPage` with the new shell/page-header contract, preserving route protection and logout behavior.
+3. Convert Transactions first to validate ledger density, filter chips, drawer behavior, amount formatting, and mobile navigation.
+4. Convert Accounts, Categories, and Budgets using the same management-page primitives.
+5. Convert Reports/Dashboard after the route IA decision is implemented.
+6. Convert Profile and Auth, including mobile overflow and form-state fixes.
+
+During migration, keep authenticated API calls on the existing `apiClient`, keep Redux data ownership unchanged until the RTK Query story, and put every new visible string into the EN/RU locale files.

--- a/docs/implementation/10-1a-frontend-ux-design-tokens-and-theme-bridge.md
+++ b/docs/implementation/10-1a-frontend-ux-design-tokens-and-theme-bridge.md
@@ -216,7 +216,7 @@ return (
 - **Do NOT add** Google Fonts loading — 10.1a and 10.1b use CSS font-family stacks and fallbacks only; explicit Inter / JetBrains Mono loading requires a separate task
 - **Do NOT introduce** any new npm dependencies — this story uses only existing packages
 - **Do NOT use** CSS variable references as Ant Design token values — AntD v5 needs raw values
-- **Do NOT break** the existing `anytype` behavior or introduce `@ts-ignore` suppressors
+- **Do NOT break** existing behavior or introduce `@ts-ignore` suppressors
 
 ---
 
@@ -257,7 +257,7 @@ Before marking this story complete:
 
 **TypeScript:** `ThemeConfig` is exported from `'antd'` — import it as a type. The `inexTheme` constant should satisfy TypeScript strict mode without any type assertions.
 
-**Import location:** Importing `tokens.css` in `index.tsx` (rather than `App.tsx`) ensures it loads before React renders anything, including the AntD reset. This is the correct placement for a global CSS baseline.
+**Import location:** Importing `tokens.css` in `index.tsx` (rather than `App.tsx`) ensures it loads before React renders anything. Because `App.tsx` imports `antd/dist/reset.css`, verify the final CSS order keeps the Ant Design reset and token layer predictable for the global baseline.
 
 **No visual regression expected:** The AntD theme change will shift primary button color from AntD's default blue (`#1677ff`) to InEx income-teal (`#2F8F82`). This is intentional and correct. All other AntD component colors (error red, warning amber) will also align with InEx semantics. This is a visual improvement, not a regression.
 

--- a/docs/implementation/10-1b-frontend-ux-shared-primitives.md
+++ b/docs/implementation/10-1b-frontend-ux-shared-primitives.md
@@ -40,7 +40,7 @@ This story (10.1b) creates the component library that stories 10.1c through 10.5
 
 **Dependencies from epics.md:**
 
-- Epic 1 must complete before broad UI rollout (auth/data-isolation safety). Epic 1 is **done**.
+- Epic 1 must complete before broad UI rollout (auth/data-isolation safety). If `docs/implementation/sprint-status.yaml` still shows Epic 1 work as not `done`, do not treat this prerequisite as satisfied without an explicit delivery decision.
 - Epic 4 should complete before the Transactions redesign (not this story).
 - Epic 7 Story 7.1 should complete before this story or before the first TypeScript-heavy Epic 10 page rebuild. Regardless of 7.1 status, this story must be `any`-free and must not weaken strict typing.
 
@@ -143,7 +143,7 @@ inex/ClientApp/src/components/primitives/
 | --------------------------------- | ---------------------------------------------------------------- |
 | `inex/ClientApp/src/App.tsx`      | Wrap app in `<SignageProvider>`                                  |
 | `inex/ClientApp/package.json`     | Add `lucide-react` dependency after `npm install`                |
-| `inex/ClientApp/package-lock.json` | Commit lockfile changes produced by `npm install lucide-react`    |
+| `inex/ClientApp/package-lock.json` | Include lockfile changes produced by `npm install lucide-react`    |
 
 ### Files to NOT Touch
 
@@ -318,12 +318,14 @@ export type TagKind =
 
 export interface TagProps {
   kind?: TagKind;
-  onClick?: React.MouseEventHandler<HTMLSpanElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
 }
 ```
 
 Padding: `2px 8px`, radius: `var(--radius-1)` (4px), fontSize: 10.5px, fontWeight: 600, letterSpacing: `0.04em`.
+
+Clickable tags must render as `<button type="button">` with visible focus styles. Non-clickable tags may render as `<span>`. Do not attach `onClick` to a non-focusable `span`; keyboard activation and focus visibility are part of the shared primitive contract.
 
 **`KindChip` props:**
 
@@ -475,6 +477,7 @@ export interface BudgetProgressProps {
   max: number; // budget limit
   height?: number; // default 6px
   showLabel?: boolean; // show percentage label
+  overBudgetLabel: string; // localized screen-reader label from i18next
 }
 ```
 
@@ -488,7 +491,7 @@ Track: `var(--bg-muted)`, radius `var(--radius-pill)`. Bar: same radius, transit
 
 Clamp filled width at 100% (do not overflow bar on over-budget).
 
-When over budget, add `aria-label` with "Over budget" text.
+When over budget, add an `aria-label` using localized EN/RU copy. Either pass `overBudgetLabel={t("budgets.overBudget")}` from the consumer or add a primitive-level translation key consumed through `react-i18next`; do not hardcode English screen-reader text.
 
 ### `EmptyState.tsx` (exports `EmptyState` and `FilterEmpty`)
 
@@ -496,7 +499,6 @@ When over budget, add `aria-label` with "Over budget" text.
 
 ```tsx
 export interface EmptyStateProps {
-  icon?: string; // Lucide icon name string — render via dynamic import or pass React node
   iconNode?: React.ReactNode; // preferred: pass <WalletIcon size={26} /> directly
   title: string;
   description: string;
@@ -528,6 +530,16 @@ export interface FilterEmptyProps {
 
 Smaller inline variant. Padding `48px 24px`. SearchX icon (40×40px container, `var(--bg-stripe)` fill). Uses `InExButton kind="ghost" size="sm"` with a Lucide `<X>` icon for the clear action.
 
+### Responsive Primitive Ownership
+
+Story 10.1b owns shared responsive helpers that page stories can reuse without creating page-local design-system replacements. Add these exports under `src/components/primitives`:
+
+- `PageSection` or equivalent spacing wrapper for tokenized vertical rhythm.
+- `ResponsiveStack` for row-to-column collapse using the Epic 10 breakpoints.
+- `ResponsiveGrid` for repeatable card/list layouts with stable gaps.
+
+Story 10.1c owns shell-level responsive behavior, including top navigation, bottom navigation, safe-area padding, and route chrome. Page stories may add page-specific CSS, but must consume 10.1b/10.1c responsive contracts instead of inventing alternate shared layout primitives.
+
 ## i18n Keys Required
 
 Add these keys to both `inex/ClientApp/public/locales/en/translation.json` and `inex/ClientApp/public/locales/ru/translation.json`:
@@ -553,6 +565,9 @@ Add these keys to both `inex/ClientApp/public/locales/en/translation.json` and `
       "transfer": "Transfer",
       "neutral": "Amount",
       "warn": "Warning amount"
+    },
+    "progress": {
+      "overBudget": "Over budget"
     }
   }
 }
@@ -560,7 +575,7 @@ Add these keys to both `inex/ClientApp/public/locales/en/translation.json` and `
 
 **Russian (`ru/translation.json`):** add equivalent keys with Russian translations.
 
-**Important:** `Num` uses `t('primitives.kindLabel.income')` etc. for `aria-label` text. `FilterEmpty` uses `t('primitives.filterEmpty.*')` for its text. Other primitives use prop-driven strings so callers provide translated text.
+**Important:** `Num` uses `t('primitives.kindLabel.income')` etc. for `aria-label` text. `FilterEmpty` uses `t('primitives.filterEmpty.*')` for its text. `BudgetProgress` uses localized over-budget copy either from `t('primitives.progress.overBudget')` or a required `overBudgetLabel` prop. Other primitives use prop-driven strings so callers provide translated text.
 
 ## Barrel Export (`index.ts`)
 
@@ -710,7 +725,7 @@ This is the **only** change to `App.tsx`. Do not touch routing, session restore,
 - [ ] **Create `Progress.tsx`** (AC: 1)
   - [ ] Three color thresholds: green/amber/red based on `value / max` ratio
   - [ ] Bar width clamped at 100% for over-budget state
-  - [ ] `aria-label` includes "Over budget" text when `value >= max`
+  - [ ] `aria-label` uses localized EN/RU over-budget text when `value >= max`; do not hardcode English screen-reader text
   - [ ] Track + fill use pill radius (`var(--radius-pill)`)
 
 - [ ] **Create `EmptyState.tsx`** (AC: 1)
@@ -730,7 +745,7 @@ This is the **only** change to `App.tsx`. Do not touch routing, session restore,
 - [ ] **Verify build and lint** (AC: 4)
   - [ ] Run `npm run build` from `inex/ClientApp/` — must pass with no new TypeScript errors
   - [ ] Run `npm run lint` from `inex/ClientApp/` — must pass with no new `any` violations
-  - [ ] Confirm no bundle size regressions (Vite will warn if new `any` types are introduced or if lucide-react is not tree-shaken)
+  - [ ] Confirm no bundle size regressions and no new `any` in touched TypeScript files; TypeScript/lint should catch typing regressions, while Vite should only be treated as a bundle/build signal
   - [ ] Verify Ant Design drawer in Transactions page still opens correctly
 
 - [ ] **Manual smoke tests** (AC: 3)
@@ -770,7 +785,7 @@ The following are explicitly excluded from this story:
 
 - Story 10.1a already defines the token contract and Ant Design bridge through `src/styles/tokens.css` and `src/styles/antd-theme.ts`; this story must consume those tokens instead of introducing new color/radius constants.
 - `App.tsx` currently wraps routes in `ConfigProvider` and has critical bootstrap effects (session restore + initial data fetches). Only the `SignageProvider` wrapper is allowed here; all auth/data effects must remain untouched.
-- Story 10.1a intentionally avoided new dependencies. Story 10.1b may add only `lucide-react`, must commit the matching `package-lock.json` update, and should avoid any additional package churn.
+- Story 10.1a intentionally avoided new dependencies. Story 10.1b may add only `lucide-react`, must include the matching `package-lock.json` update, and should avoid any additional package churn.
 
 ## Git Intelligence Summary
 

--- a/docs/implementation/10-1c-frontend-ux-app-shell-and-navigation.md
+++ b/docs/implementation/10-1c-frontend-ux-app-shell-and-navigation.md
@@ -35,7 +35,7 @@ so that desktop and mobile navigation are predictable across authenticated workf
 - [ ] Wire pages to the new shell with minimal blast radius (AC: 1, 4)
   - [ ] Choose either direct import migration or `BasicPage` re-export shim
   - [ ] Update only files that currently import `BasicPage`
-  - [ ] Do not modify route definitions except optional `SignageProvider` wrap if still missing
+  - [ ] Do not modify route definitions; `SignageProvider` is owned by Story 10.1b and must already be present before this story starts
 - [ ] Validate localization and quality gates (AC: 5, 6)
   - [ ] Add missing nav keys in EN/RU locale files if needed
   - [ ] Run `npm run build` and `npm run lint` from `inex/ClientApp`
@@ -65,7 +65,7 @@ Implementation sequence:
 
 **Do not rebuild any page content in this story.** Shell scope = `BasicPage.tsx`, routing structure in `App.tsx`, and the new shell CSS file. Page interiors are 10.2 through 10.5b scope.
 
-**Epic 1 is done**, so the auth/data-isolation prerequisite is satisfied.
+Epic 1 must be complete before broad UI rollout. If `docs/implementation/sprint-status.yaml` still shows `epic-1` or any Epic 1 story as not `done`, do not treat this prerequisite as satisfied; either complete Epic 1 first or record the explicit delivery decision before starting this story.
 
 ## Design References
 

--- a/docs/implementation/10-2-frontend-ux-transactions-ledger-redesign.md
+++ b/docs/implementation/10-2-frontend-ux-transactions-ledger-redesign.md
@@ -80,6 +80,10 @@ so that I can scan recent movement, filter quickly, and understand cash flow wit
   - Uses legacy filter DSL (`filter=accountIds:...;categoryIds:...;start:...;end:...;tags:...;refs:...;`).
   - Maintains canonical Redux filter state (`transactions.filter`) and URL sync.
   - Redesign should keep compatibility while adding explicit chips and indicator UX.
+- `inex/ClientApp/src/pages/Transactions/TransactionSummary.tsx`
+  - Existing summary/KPI behavior must be reviewed before rebuilding the ledger KPI strip so totals remain compatible with current Redux data.
+- `inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts`
+  - Existing filter URL compatibility must be preserved while exposing redesigned filter chips and drawer affordances.
 - `inex/ClientApp/src/pages/Transactions/TransactionCreate.tsx` and `TransactionEditForm.tsx`
   - Existing create/edit flows and action dispatch wiring are working and should be preserved.
   - These flows are candidates for visual wrapper updates, not business-logic rewrites.
@@ -166,9 +170,9 @@ Files to avoid changing unless required:
 
 ### Previous Story Intelligence
 
-- Story 10.1a (tokens/theme bridge) established tokenized color/typography contracts that this story must consume, not override with ad hoc palette constants.
-- Story 10.1b (shared primitives) established shared money and drawer contracts; this story should reuse those primitives and avoid duplicating control patterns.
-- Story 10.1c (app shell/navigation) established top-nav/bottom-nav behavior and mobile safe-area rules; this story must preserve bottom-nav compatibility and content padding.
+- After Story 10.1a is done, consume its tokenized color/typography contracts instead of ad hoc palette constants.
+- After Story 10.1b is done, reuse its shared money and drawer contracts and avoid duplicating control patterns.
+- After Story 10.1c is done, preserve its top-nav/bottom-nav behavior and mobile safe-area rules.
 
 ### Git Intelligence Summary (Recent Repository History)
 

--- a/docs/implementation/10-3a-frontend-ux-accounts-management-redesign.md
+++ b/docs/implementation/10-3a-frontend-ux-accounts-management-redesign.md
@@ -21,6 +21,8 @@ so that account balances are easy to compare on desktop and mobile.
   - [ ] Story 10.1a token/theme bridge is complete and page styles consume those tokens instead of hardcoded palette constants.
   - [ ] Story 10.1b shared primitives are complete for drawer, segmented controls, empty/filter-empty states, money/signage rendering, and form fields.
   - [ ] Story 10.1c app shell/bottom navigation is complete so Accounts spacing and mobile safe-area behavior are implemented against the final shell.
+  - [ ] Story 10.2 Transactions redesign is complete or explicitly waived for this management-page wave, preserving the fixed Epic 10 order.
+  - [ ] If 10.3a, 10.3b, and 10.3c run in parallel, coordinate shared EN/RU locale files and shared primitive assumptions before editing.
 - [ ] Rebuild `/accounts` as a management workspace while preserving existing data contracts and route ownership. (AC: 1)
   - [ ] Replace the current table-first composition in `inex/ClientApp/src/pages/Accounts.tsx` with the design-system workspace flow: hero, toolbar/filter bar, grouped/flat list, and inline-edit or drawer interactions.
   - [ ] Keep route path, auth guarding (`ProtectedRoute`), and shell integration from Story 10.1c unchanged.

--- a/docs/implementation/10-3b-frontend-ux-categories-management-redesign.md
+++ b/docs/implementation/10-3b-frontend-ux-categories-management-redesign.md
@@ -40,7 +40,7 @@ So that category structure and spend signals remain clear.
 
 8. **Given** the story is complete
    **When** `npm run build`, `npm run lint`, and visual QA run from `inex/ClientApp`
-   **Then** all pass with no new `any` in touched files, and screenshots cover: desktop populated (tree mode), desktop populated (by-spend mode), mobile populated, filter-active/no-results, empty first-use, and inline-edit-open states.
+   **Then** all pass with no new `any` in touched files, and screenshots cover: desktop populated (tree mode), desktop populated (by-spend mode), mobile populated, filter-active/no-results, empty first-use, add-drawer-open, and inline-edit-open states.
 
 ---
 
@@ -49,17 +49,16 @@ So that category structure and spend signals remain clear.
 This story **must** be implemented after:
 
 - **Story 10.1a** вЂ” design tokens (`--brand-ink`, `--income-*`, `--expense-*`, `--fg-*`, `--bg-stripe`, `--border-1`, `--shadow-1`, `--font-num`, etc.) are available as CSS custom properties.
-- **Story 10.1b** вЂ” shared primitive components are available: `Button`, `IconButton`, `Drawer`, `MoneyValue`, `EmptyState`, `FilterEmpty`, `SegmentedControl`, `Field`, `Input`, `Select`, `Progress`.
-- **Story 10.1c** вЂ” `InExShell` app shell is in place; `BasicPage` is replaced; route `/categories` is already wired.
+- **Story 10.1b** вЂ” shared primitive components are available from `src/components/primitives`: `InExButton`, `IconBtn`, `InExDrawer`, `Num`, `EmptyState`, `FilterEmpty`, `SegmentedControl`, `Field`, `Input`, `Select`, and `BudgetProgress`.
+- **Story 10.1c** вЂ” `AppShell` / `BasicPage` compatibility shell contract is in place; route `/categories` is already wired.
 
-The `Drawer`, `Button`, `EmptyState`, `FilterEmpty`, and `SegmentedControl` components are consumed from `src/components/` as established by 10.1b вЂ” do **not** rebuild them here.
+The `InExDrawer`, `InExButton`, `EmptyState`, `FilterEmpty`, and `SegmentedControl` components are consumed from `src/components/primitives` as established by 10.1b. Do **not** rebuild them here.
 
 ---
 
 ## Files To Create
 
 ```
-inex/ClientApp/src/pages/Categories.tsx                    (replace entirely)
 inex/ClientApp/src/pages/Categories/CategoryRow.tsx        (new)
 inex/ClientApp/src/pages/Categories/CategoryInlineEdit.tsx (new)
 inex/ClientApp/src/pages/Categories/CategoriesHero.tsx     (new)
@@ -71,6 +70,7 @@ inex/ClientApp/src/pages/Categories/categories.css         (new)
 ### Files To Modify
 
 ```
+inex/ClientApp/src/pages/Categories.tsx                    (replace existing page implementation)
 inex/ClientApp/public/locales/en/translation.json   (add new keys under "categories")
 inex/ClientApp/public/locales/ru/translation.json   (add Russian equivalents)
 ```
@@ -93,7 +93,7 @@ inex/ClientApp/src/pages/Categories/CategoryEditForm.tsx      (replace via Categ
 
 The current file uses:
 
-- `BasicPage` layout wrapper (being replaced by `InExShell` from 10.1c).
+- `BasicPage` layout wrapper (being replaced by the Story 10.1c `AppShell` / `BasicPage` compatibility contract).
 - Ant Design `Table` with `expandable.expandedRowRender` for inline edit.
 - `getCategoriesTree(filteredCategories, true)` to get a flat list with `depth` field.
 - `showOnlyEnabled` checkbox filter.
@@ -254,7 +254,7 @@ Left column shows:
 Right column shows:
 
 - "By Category" label.
-- `DistributionBar` (shared primitive from 10.1b) with top-5 expense parents and an "Other" segment.
+- Shared distribution visualization for top-5 expense parents and an "Other" segment. Use `DistributionBar` only if Story 10.1b has been updated to own it as a shared primitive; otherwise use an existing shared primitive and keep this page from creating a local design-system replacement.
 - Legend grid: 8px color square + name + percentage.
 
 > **Data source:** Hero uses `state.categories.items` (flat list) and `state.transactions` (if available from Redux). If transactions slice is not available, render a loading/empty-data treatment rather than crashing. The design reference computes spend from transaction data вЂ” only show real spend if transaction data is loaded; otherwise show zero/empty hero. Do **not** fetch transactions just for this page вЂ” check if they already exist in the store.
@@ -584,14 +584,15 @@ Required RU key groups mirror the EN structure above:
 
 | Component                    | Location                              | Usage in this story                             |
 | ---------------------------- | ------------------------------------- | ----------------------------------------------- |
-| `Button`                     | `src/components/Button.tsx`           | Save, Cancel, Delete, "Add category" CTA        |
-| `IconButton`                 | `src/components/IconButton.tsx`       | Settings icon in leaf rows                      |
-| `Drawer`                     | `src/components/Drawer.tsx`           | "Add category" drawer, Escape close, focus trap |
-| `EmptyState`                 | `src/components/EmptyState.tsx`       | First-use empty page                            |
-| `FilterEmpty`                | `src/components/FilterEmpty.tsx`      | Filter-active no-results state                  |
-| `SegmentedControl`           | `src/components/SegmentedControl.tsx` | Active/All scope, Tree/By-spend view            |
-| `DistributionBar`            | `src/components/DistributionBar.tsx`  | Hero spend distribution                         |
-| `Field` + `Input` + `Select` | `src/components/`                     | Inline edit form fields                         |
+| `InExButton`                 | `src/components/primitives/Button.tsx`           | Save, Cancel, Delete, "Add category" CTA        |
+| `IconBtn`                    | `src/components/primitives/IconBtn.tsx`          | Settings icon in leaf rows                      |
+| `InExDrawer`                 | `src/components/primitives/InExDrawer.tsx`       | "Add category" drawer, Escape close, focus trap |
+| `EmptyState`                 | `src/components/primitives/EmptyState.tsx`       | First-use empty page                            |
+| `FilterEmpty`                | `src/components/primitives/EmptyState.tsx`       | Filter-active no-results state                  |
+| `SegmentedControl`           | `src/components/primitives/SegmentedControl.tsx` | Active/All scope, Tree/By-spend view            |
+| `Field` + `Input` + `Select` | `src/components/primitives/`                     | Inline edit form fields                         |
+
+`DistributionBar` is not part of the original 10.1b primitive surface. Resolve this before implementation by either adding it to Story 10.1b as a shared primitive or replacing the hero distribution treatment with an already-established shared primitive. Do not create a page-local `DistributionBar` in this story.
 
 > If any of these components are not yet available (e.g., Story 10.1b is incomplete), **do not inline-create them**. Block on the dependency and note which component is missing.
 

--- a/docs/implementation/10-3c-frontend-ux-budgets-management-redesign.md
+++ b/docs/implementation/10-3c-frontend-ux-budgets-management-redesign.md
@@ -13,7 +13,7 @@ so that monthly budget health is easy to compare.
 1. Given the Budgets design reference, when /budgets is rebuilt, then it includes a month switcher, burn-rate summary, copy-from-previous-month action, add budget action, budget rows, progress bars, over-budget state, and remaining/spent scan targets.
 2. Given empty or filter-empty states on Budgets, when no data or no matching results are shown, then the page uses shared InEx empty-state patterns with product-specific EN/RU copy and useful primary actions.
 3. Given 390px and 360px mobile viewports, when Budgets is opened with populated data, then toolbars wrap, wide controls scroll internally, rows stack cleanly, and no page-level horizontal overflow appears.
-4. Given the story is complete, when npm run build, npm run lint, and visual QA run from inex/ClientApp, then all pass and screenshots cover populated, empty, and drawer-open states.
+4. Given the story is complete, when npm run build, npm run lint, and visual QA run from inex/ClientApp, then all pass with no new `any` in touched TypeScript files and screenshots/checks cover populated, empty, and drawer-open states at 1440px, 1024px, 390px, and 360px where applicable.
 
 ## Tasks / Subtasks
 

--- a/docs/implementation/10-4-frontend-ux-reports-hub-dashboard-landing-and-drill-down-chrome.md
+++ b/docs/implementation/10-4-frontend-ux-reports-hub-dashboard-landing-and-drill-down-chrome.md
@@ -21,11 +21,11 @@ so that quick financial status and deeper analysis are separated but connected.
 ## Tasks / Subtasks
 
 - [ ] Add dashboard landing route and preserve existing route protections. (AC: 1, 5)
-  - [ ] Add a protected dashboard page route (`/dashboard`) and update post-login default redirect from `/` to `/dashboard`.
+  - [ ] Finalize the protected dashboard page route (`/dashboard`) and update post-login default redirect from `/` to `/dashboard` by consuming the route/data work delivered by Epic 6; do not recreate Epic 6 functional implementation here.
   - [ ] Keep `/reports` nested report routes intact (`index`, `category`, `budget`, `history`) with no behavior regression.
   - [ ] Keep `ProtectedRoute` ownership unchanged; do not move auth routes.
 - [ ] Build dashboard month-summary landing surface. (AC: 1, 5)
-  - [ ] Implement month summary cards (income, expenses, net savings, MoM delta) on dashboard using existing report/state data flows.
+  - [ ] Apply final Epic 10 visual/chrome treatment to month summary cards (income, expenses, net savings, MoM delta) on dashboard using existing Epic 6 report/state data flows.
   - [ ] Provide no-data neutral state (0 values + explanatory copy), not blank or error-only UI.
   - [ ] Keep all visible strings in EN/RU locale files.
 - [ ] Rebuild reports hub as launch-card navigation, not table rows. (AC: 2, 5)
@@ -54,6 +54,8 @@ so that quick financial status and deeper analysis are separated but connected.
 - Story 10.1a (tokens/theme bridge) is mandatory before starting this story so dashboard/reports chrome uses token contracts, not ad hoc colors.
 - Story 10.1b (shared primitives) is mandatory before starting this story so button, icon, action, empty-state, and card treatments use the shared Epic 10 primitives.
 - Story 10.1c (app shell/navigation) is mandatory before starting this story. Build 10.4 against the implemented authenticated shell/navigation contract, then add `/dashboard` navigation and default-landing behavior as this story's route ownership.
+- Epic 6 dashboard/report data work is mandatory before starting this story. Story 6.1 must provide the dashboard route/navigation restructure baseline, Story 6.2 must provide the month-summary card data behavior, and Story 6.5 must be complete before any category-report preview metric is shown from category report data.
+- If the branch lacks the Epic 6 `/dashboard` route, month-summary data surface, or required report data fixes, block this story and send the missing functional work back to Epic 6. Story 10.4 owns final visual design, Reports hub/drill-down chrome, action placement, and chart accessibility polish; it does not create backend reporting endpoints or duplicate dashboard/report data flows.
 - If a branch still has `BasicPage` as the only available shell, do not start 10.4 as a fallback implementation. Merge or rebase the 10.1c shell/navigation work first, then implement dashboard/reports chrome on that baseline.
 
 ## Anti-Patterns / Guardrails
@@ -62,7 +64,7 @@ so that quick financial status and deeper analysis are separated but connected.
 | --- | --- |
 | Keep `/` redirecting to `/transactions` after adding dashboard | Move protected default landing to `/dashboard` while preserving all existing protected routes |
 | Put Share/Export/Print buttons on `/reports` hub | Keep those actions on drill-down routes only (`/reports/category`, `/reports/budget`, `/reports/history`) |
-| Build dashboard cards from new backend endpoints | Reuse existing report/transaction data contracts and thunks |
+| Build dashboard cards from new backend endpoints or recreate Epic 6 dashboard data logic | Reuse existing Epic 6 report/transaction data contracts and thunks; block if the functional data surface is missing |
 | Treat hub cards as static marketing tiles | Make cards route launch points with meaningful metric/context copy |
 | Expose chart visuals without accessible summary | Add text/table summary adjacent to each dashboard/drill-down chart |
 | Introduce new `any` while refactoring reports pages | Narrow existing types where possible and avoid adding any new untyped surface |

--- a/docs/implementation/10-5a-frontend-ux-profile-and-settings-redesign.md
+++ b/docs/implementation/10-5a-frontend-ux-profile-and-settings-redesign.md
@@ -54,6 +54,7 @@ so that profile, currency, language, and password changes are easy to complete o
 - Story 10.1a (tokens/theme bridge) is mandatory before starting this story so profile/settings surfaces use the Epic 10 CSS variable and Ant Design theme bridge instead of local color constants.
 - Story 10.1b (shared primitives) is mandatory before starting this story so settings actions, empty/help states, error banners, and icon buttons align with the shared primitive contracts.
 - Story 10.1c (app shell/navigation) is mandatory before starting this story. `/profile` must be rebuilt inside the implemented authenticated app shell/navigation contract, including mobile bottom-nav spacing and no page-level horizontal overflow at 390px and 360px.
+- Story 10.4 is a sequencing prerequisite for this story unless the team explicitly waives the fixed Epic 10 order in the story handoff. Profile/settings should be rebuilt after dashboard/reports route chrome is stable so app-shell navigation and `/dashboard` landing behavior are not reworked in parallel.
 
 ## Profile/Settings Validation Matrix
 
@@ -71,6 +72,7 @@ so that profile, currency, language, and password changes are easy to complete o
 ### Story Intelligence From Planning Artifacts
 
 - Epic 10 covers FR-UX-001 through FR-UX-007 and this story maps directly to FR-UX-006 (profile/settings + auth redesign quality requirements). [Source: `docs/planning/epics.md`]
+- Visual QA must explicitly cover 1440px desktop and 390px/360px mobile checks for profile/settings. Use shared primitives from Story 10.1b; do not create profile-local replacements for shared action, empty/help, icon-button, or error-banner contracts.
 - The design update plan identifies profile as a known gap with explicit mobile overflow risk; this story is responsible for eliminating that risk in production UI, not mockup only. [Source: `docs/planning/design-update-plan.md`]
 - UX planning explicitly points to three sources to combine for implementation quality: design implementation guide, design update plan, and Epic 10 story criteria. [Source: `docs/planning/ux-design.md`]
 - PRD aligns FR-UX-006 with production validation/loading/error state expectations and i18n correctness, so redesign is not visual-only. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]

--- a/docs/implementation/10-5b-frontend-ux-login-and-registration-redesign.md
+++ b/docs/implementation/10-5b-frontend-ux-login-and-registration-redesign.md
@@ -542,6 +542,14 @@ import { AlertCircle } from "lucide-react";
 
 **Add these keys inside the `"auth"` object:**
 
+The auth story must also add EN/RU keys for every visible `AuthShell` string, not only form headings. Required coverage includes:
+
+- Brand panel copy: tagline, highlighted phrase, and any supporting microcopy.
+- Feature bullets: title and description for multi-currency/accounts, privacy/invite-only access, and reports/reflection.
+- Footer copy and auth route links.
+- Placeholders, including username and email placeholder text. If `you@example.com` is kept as an email-format example, document it as an intentional placeholder exception; otherwise localize it.
+- API/banner error mappings: invalid credentials, generic login failure, generic registration failure, duplicate email, invalid/expired invite token, and unknown fallback error.
+
 ```json
 "welcomeBack": "Welcome back",
 "signInTitle": "Sign in to InEx",
@@ -565,7 +573,7 @@ import { AlertCircle } from "lucide-react";
 
 ### `inex/ClientApp/public/locales/ru/translation.json`
 
-**Add the matching Russian keys inside `"auth"`:**
+**Add the matching Russian keys inside `"auth"`**, including the full AuthShell, footer, placeholder, and API/banner error mapping coverage listed above. Do not add English-only screen text and do not rely on backend English messages for known auth errors.
 
 ```json
 "welcomeBack": "С возвращением",
@@ -610,8 +618,8 @@ The auth thunks currently store `error.response?.data?.detail ?? error.message ?
 Resolve the localized-error requirement at the display boundary:
 
 - Add a small mapper near the auth form/ErrorBanner layer that receives `auth.error` and `t`.
-- If `auth.error` matches a known backend detail or fallback string, render the mapped locale key (for example invalid credentials, invite token invalid/expired, duplicate email, generic login failure, generic registration failure).
-- If the backend detail is unknown and user-actionable, display the backend detail verbatim so diagnostics are not lost.
+- If `auth.error` matches a known backend detail or fallback string, render the mapped locale key (for example invalid credentials, invite token invalid/expired, duplicate email, generic login failure, generic registration failure). These known cases must never display raw English backend/fallback text.
+- If the backend detail is unknown and user-actionable, display the backend detail verbatim only after the mapper fails to classify it; this is an intentional diagnostics fallback, not the normal localization path.
 - If there is no usable backend detail, render localized fallback copy from `translation.json`.
 - Keep field-level `Form.Item` validation messages fully localized via `t()` and separate from API/banner errors.
 
@@ -627,11 +635,7 @@ Story 10.1b installs and establishes `lucide-react` as the icon library. Use nam
 import { AlertCircle, Wallet, Target, BarChart3 } from "lucide-react";
 ```
 
-If story 10.1b is not yet done and `lucide-react` is not installed, run from `inex/ClientApp/`:
-
-```bash
-npm install lucide-react
-```
+If Story 10.1b is not done or `lucide-react` is not installed, block this story and complete/fix Story 10.1b first. This story must not run `npm install`, edit `package.json`, or edit `package-lock.json`.
 
 Do **not** use `<i data-lucide="..." />` DOM attribute syntax — that requires a global DOM scan and is a mockup-only pattern.
 
@@ -708,6 +712,7 @@ Before marking this story done, verify:
 - [ ] Currency dropdown on register still pre-selects EUR from the API response
 - [ ] EN ↔ RU locale switch shows all new `auth.*` keys in both languages (no missing translation fallback to key names)
 - [ ] At 390px: no horizontal overflow, brand panel hidden, mobile logo visible, form accessible
+- [ ] At 360px: no horizontal overflow, brand panel hidden, mobile logo visible, form accessible
 - [ ] At 1440px: two-column grid renders, brand panel visible
 
 ## Visual QA Spec
@@ -722,6 +727,8 @@ Before marking this story done, verify:
 | register-api-error         | 1440px   | ErrorBanner showing API error (e.g., duplicate email)                  |
 | login-mobile               | 390px    | Default state, brand panel hidden, mobile logo visible                 |
 | register-mobile            | 390px    | Default state, single-column                                           |
+| login-mobile-narrow        | 360px    | Default state, no horizontal overflow                                  |
+| register-mobile-narrow     | 360px    | Default state, no horizontal overflow                                  |
 
 ## Dev Agent Record
 

--- a/docs/implementation/10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist.md
+++ b/docs/implementation/10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist.md
@@ -71,11 +71,11 @@ Epic 10 rebuilds the production React app to implement the `docs/design` visual 
 10.1a → 10.1b → 10.1c → 10.2 → 10.3a/b/c → 10.4 → 10.5a/b → 10.6 (this story)
 ```
 
-**Dashboard route:** Per Epic 6 Story 6.1 and Epic 10 Story 10.4, the dashboard/home route is `/dashboard`. `/` may redirect there, but QA must capture `/dashboard` directly so the baseline matches the implemented landing route.
+**Dashboard route:** QA verifies `/dashboard` as delivered by Story 10.4 on top of completed Epic 6 dashboard/report data work. `/` may redirect there, but QA must capture `/dashboard` directly so the baseline matches the implemented landing route. Story 10.6 must not implement or duplicate Epic 6 dashboard/report data or API behavior.
 
 **Dependencies from epics.md:**
 
-- Epic 1 is **done** — data isolation is safe for QA runs with test accounts.
+- Epic 1 must be complete before broad UI rollout. If `docs/implementation/sprint-status.yaml` still shows `epic-1` or any Epic 1 story as not `done`, record that as a preflight blocker or obtain an explicit delivery decision before running the final Epic 10 QA gate.
 - Epic 4 should be done before Transactions QA (filter chips bind to database-side filtering).
 - This story has no backend changes. All work is documentation, visual inspection, and regression fixes.
 
@@ -427,6 +427,23 @@ Design guide reference: docs/design/docs/design-implementation-guide.md Section 
 - ⚠️ EXCEPTION — accepted known issue with rationale
 - ➖ SKIPPED — story not done yet or state unavailable
 
+## QA Commands / Screenshot Capture
+
+Record the exact commands and workflow used for this run. Include both manual browser steps and any Playwright-assisted commands.
+
+```bash
+# Example only; replace with the actual commands used for this run.
+npm run build
+npm run lint
+node qa-screenshots.mjs
+```
+
+- Browser/tool used:
+- Local URL:
+- Viewports captured: 1440px, 1024px, 390px, 360px
+- Screenshot output folder:
+- Notes for Windows/macOS/Linux differences:
+
 ## Desktop QA Results
 
 | Route                   | State                | 1440px | 1024px | Screenshot | Notes |
@@ -579,7 +596,13 @@ Any of the following findings is a build-blocking regression, not a cosmetic fol
 - Chart blankness (chart container with height 0)
 - Long translated label overflow at any production breakpoint
 
-Known exceptions must be accepted explicitly in the Exceptions table of `visual-qa-checklist.md` with owner, rationale, and date.
+### Known Exceptions
+
+Known exceptions must be listed here and in the Exceptions table of `visual-qa-checklist.md` with owner-visible rationale and date. If no exceptions are accepted, write: `None accepted as of {date}`.
+
+| Route | Viewport | Issue | Rationale | Accepted by | Date |
+| ----- | -------- | ----- | --------- | ----------- | ---- |
+| None accepted as of {date} | | | | | |
 ```
 
 ## Regression Fix Workflow

--- a/docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md
+++ b/docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md
@@ -1,0 +1,195 @@
+# Story 6.1: Frontend - Dashboard Home Page and Navigation Restructure
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run bmad-create-story validate before dev-story. -->
+
+## Story
+
+As a user opening the app,
+I want to land on a meaningful home dashboard,
+So that I see my financial overview immediately rather than navigating blind.
+
+## Acceptance Criteria
+
+1. Given the app currently lands on `/transactions` after login, When this story is complete, Then the default post-login route is `/dashboard` (or `/`) and the navigation menu reflects the new structure.
+
+2. Given the Reports section in the navigation, When this story is complete, Then Reports is reorganized as a top-level nav item (or submenu) clearly separate from the dashboard - no functional regression on existing report pages.
+
+3. Given the new `/dashboard` route, When it renders, Then it displays a placeholder layout ready to receive the month summary cards and charts from subsequent stories - the shell is wired, not empty.
+
+4. Given all navigation label strings, When reviewed, Then every label is in `en/translation.json` and `ru/translation.json`.
+
+5. Given `npm run build` and `npm run lint`, When run after this change, Then both pass with no regressions on existing routes (`/transactions`, `/accounts`, `/categories`, `/budgets`, `/reports`).
+
+## Tasks / Subtasks
+
+- [ ] Add the dashboard route and landing redirect. (AC: 1, 3)
+  - [ ] Create a lightweight protected dashboard page component, likely `inex/ClientApp/src/pages/Dashboard.tsx`.
+  - [ ] Register `/dashboard` inside the existing `ProtectedRoute` route tree in `inex/ClientApp/src/App.tsx`.
+  - [ ] Change the protected `/` redirect from `/transactions` to `/dashboard`.
+  - [ ] Preserve public `/login` and `/register` routes and all existing protected route boundaries.
+
+- [ ] Wire dashboard into the existing navigation without redesigning the app shell. (AC: 1, 2, 4)
+  - [ ] Add a dashboard navigation item to `BasicPage` using existing Ant Design menu patterns and current icon dependency.
+  - [ ] Keep Reports visible as a distinct top-level navigation item unless a minimal submenu is required by the implementation; do not merge Reports into Dashboard.
+  - [ ] Ensure selected navigation state works for `/dashboard`, `/reports`, and nested report paths.
+  - [ ] Add `nav.dashboard` and dashboard page labels to both EN and RU locale files.
+
+- [ ] Build a functional dashboard placeholder, not final dashboard UI. (AC: 3, 4)
+  - [ ] Render a non-empty dashboard page using existing layout/page patterns.
+  - [ ] Include clearly separated placeholder regions for upcoming Epic 6 widgets: month summary cards, spending heatmap, and historical net worth chart.
+  - [ ] Use localized EN/RU strings for all visible dashboard text.
+  - [ ] Do not fetch new data, calculate summary metrics, render charts, or introduce widget-specific business logic in this story.
+
+- [ ] Preserve Reports behavior. (AC: 2, 5)
+  - [ ] Keep `/reports`, `/reports/category`, `/reports/budget`, and `/reports/history` route targets unchanged.
+  - [ ] Keep `ReportList` launch behavior and existing drill-down components working.
+  - [ ] Keep Reports page title/back-button behavior stable unless a minimal adjustment is required by route selection or dashboard separation.
+
+- [ ] Verify frontend quality gates. (AC: 5)
+  - [ ] From `inex/ClientApp`, run `npm run build`.
+  - [ ] From `inex/ClientApp`, run `npm run lint`.
+  - [ ] Manually smoke-check navigation to `/dashboard`, `/transactions`, `/accounts`, `/categories`, `/budgets`, `/reports`, and existing report drill-down routes.
+
+## Dev Notes
+
+### Source Requirements
+
+- Story 6.1 implements FR-FE-003: dashboard home page established as app landing and Reports navigation restructured. [Source: `docs/planning/epics.md`, Story 6.1]
+- Epic 6 is a functional dashboard/reporting scaffold before Epic 10. This story establishes the route and navigation foundation for Story 6.2, Story 6.3, and Story 6.4. [Source: `docs/planning/epics.md`, Epic 6]
+- The PRD places FR-FE-003 under frontend core UX, not under the final design-system rebuild. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]
+- The sprint change proposal and readiness report require Epic 6 report/data work to stay clearly bounded and prevent later design scope from leaking into functional dashboard stories. [Source: `docs/planning/sprint-change-proposal-2026-05-26.md`; `docs/planning/implementation-readiness-report-2026-05-26.md`]
+- `ux-design.md` is an index pointing at the design-system sources for Epic 10. For this Epic 6 story, use those sources only to understand out-of-scope boundaries, not to implement the final visual system. [Source: `docs/planning/ux-design.md`; `docs/planning/design-update-plan.md`]
+
+### Dependencies
+
+- Epic 2 is a prerequisite for Epic 6 overall because later time-series dashboard work depends on UTC-normalized timestamps. Story 6.1 itself is frontend route/navigation scaffolding and should not add time-series calculations.
+- Story 6.5 report correctness is intentionally separate from this dashboard UI scaffold. Do not change category report backend behavior in this story.
+- Story 6.2 depends on this story for the dashboard route/home page where month summary cards will be added.
+- Story 6.3 and Story 6.4 can use the route/navigation foundation from this story but must own their own widgets/data requirements.
+- Epic 10 owns the final dashboard/report visual design and app-shell/navigation redesign. Do not pull Epic 10 prerequisites into this story.
+
+### Current State Analysis
+
+`inex/ClientApp/src/App.tsx`
+
+- Public routes are `/login` and `/register`.
+- Protected routes are wrapped by `ProtectedRoute`.
+- The protected root route currently redirects `/` to `/transactions`.
+- Existing protected pages are `/transactions`, `/accounts`, `/categories`, `/budgets`, `/profile`, and nested `/reports` routes.
+- Reports routes are currently:
+  - `/reports` -> `ReportList`
+  - `/reports/category` -> `ReportCategory`
+  - `/reports/budget` -> `ReportBudgetSpending`
+  - `/reports/history` -> `ReportMonthlyHistory`
+- No `Dashboard` page is currently present under `src/pages`.
+
+`inex/ClientApp/src/layouts/BasicPage.tsx`
+
+- Authenticated pages use the current Ant Design shell with desktop horizontal menu, mobile drawer menu, profile affordance, logout affordance, and footer.
+- Navigation items currently include Transactions, Accounts, Categories, Budgets, and Reports.
+- `currentPage` is derived from the first URL segment, which should support `/dashboard` naturally once a matching nav key exists.
+- The component uses `props: any` and `handleNavSelect(e: any)`. This story should not expand typing debt; minor local typing cleanup is acceptable only if needed while touching the file.
+
+`inex/ClientApp/src/pages/Reports.tsx`
+
+- Reports page is already distinct from other top-level routes.
+- It wraps nested report pages in `BasicPage`, maps report route titles, and shows a Back button on drill-down paths.
+- This story must preserve those nested route behaviors. A full Reports hub redesign is Epic 10 scope, not Story 6.1 scope.
+
+`inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json`
+
+- `nav` currently has no dashboard label.
+- `reports` already has labels for existing report routes.
+- Add new labels under stable namespaces such as `nav.dashboard` and `dashboard.*`; update both language files in the same implementation.
+
+### Implementation Guidance
+
+- Keep the implementation minimal and additive:
+  - add a `Dashboard` page,
+  - add a `/dashboard` protected route,
+  - redirect `/` to `/dashboard`,
+  - add a dashboard nav item,
+  - add localized placeholder copy.
+- The dashboard placeholder should be useful as a scaffold for developers, not a marketing page. Prefer compact sections or simple panels that identify future widget slots.
+- Use existing React Router 6 route composition. Do not introduce data loaders/actions or a router upgrade.
+- Use existing Ant Design components and current local styling conventions. Do not add a CSS token system, shared primitive layer, new icon package, or custom shell.
+- Keep all authenticated API behavior untouched. This story should not call backend APIs or change Redux thunks/slices.
+- Do not add frontend tests; the committed frontend quality gate is currently build plus lint.
+
+### Epic 6 / Epic 10 Guardrails
+
+- This story is Epic 6 functional dashboard/reporting scaffold work only.
+- Keep scope to the functional dashboard route/home page and minimal navigation restructure required by the source acceptance criteria.
+- Do not implement month summary cards, spending heatmap, historical net worth chart, category report fixes, or report drill-down redesign in this story.
+- Do not take final design-system scope: no tokens, theme bridge, shared primitives, finance money primitives, visual QA baseline, or Epic 10 shell replacement.
+- Do not take Reports hub redesign scope: no launch-card hub, report preview metrics, Share/Export/Print action placement, or drill-down chrome rebuild.
+- Do not take mobile navigation scope beyond preserving the current `BasicPage` drawer behavior after adding the dashboard nav item.
+- Do not create shared primitives.
+- Do not own responsive visual QA baseline. Basic smoke checks for no obvious route/navigation breakage are enough for this story.
+- Do not add chart accessibility polish; no charts should be implemented here.
+- Do not create Epic 10 stories or modify existing Epic 10 story files.
+
+### Files Likely to Change
+
+- `inex/ClientApp/src/App.tsx` - import/register `Dashboard`, add `/dashboard`, redirect `/` to `/dashboard`.
+- `inex/ClientApp/src/layouts/BasicPage.tsx` - add dashboard nav item and icon using current Ant Design menu pattern.
+- `inex/ClientApp/src/pages/Dashboard.tsx` - new minimal dashboard placeholder page.
+- `inex/ClientApp/public/locales/en/translation.json` - add dashboard nav/page labels.
+- `inex/ClientApp/public/locales/ru/translation.json` - add dashboard nav/page labels.
+
+Files to avoid unless an implementation blocker requires them:
+
+- `inex/ClientApp/src/pages/Reports/**` - preserve existing report behavior; do not redesign hub/drill-down UX.
+- `inex/ClientApp/src/store/**` - no new data fetching or Redux state is required.
+- `inex/ClientApp/src/components/ProtectedRoute.tsx` - route protection should remain unchanged.
+- `inex/ClientApp/package.json` and `package-lock.json` - no dependency changes.
+- Backend projects (`inex`, `inex.Services`, `inex.Data`) - no backend work belongs in this story.
+- `docs/implementation/10-*.md` - Epic 10 story files are out of scope.
+
+### Testing Requirements
+
+- Required commands from `inex/ClientApp`:
+  - `npm run build`
+  - `npm run lint`
+- Manual smoke checks:
+  - Login/restored-session flow reaches `/dashboard` via protected `/` redirect.
+  - Desktop navigation can open Dashboard, Transactions, Accounts, Categories, Budgets, and Reports.
+  - Current mobile drawer navigation still opens and includes Dashboard without breaking existing items.
+  - Existing report routes still render: `/reports`, `/reports/category`, `/reports/budget`, `/reports/history`.
+- No backend tests are required because this story does not change backend behavior.
+
+### References
+
+- `docs/planning/epics.md` - Epic 6 Story 6.1 source of record.
+- `docs/planning/prds/prd-inex-2026-05-20/prd.md` - FR-FE-003 and frontend core UX roadmap context.
+- `docs/planning/sprint-change-proposal-2026-05-26.md` - Epic 6 boundary and report-integrity separation.
+- `docs/planning/implementation-readiness-report-2026-05-26.md` - Epic 6 ready with story-boundary caution.
+- `docs/planning/design-update-plan.md` - Epic 10 design sequencing and scope boundaries.
+- `docs/planning/ux-design.md` - UX source index; design details are not Story 6.1 implementation scope.
+- `docs/planning/architecture.md` - frontend stack, routing, i18n, and Epic 10 boundary guidance.
+- `docs/project-context.md` - frontend route, API-client, i18n, build/lint, and no-new-dependency rules.
+- `inex/ClientApp/src/App.tsx` - current route tree and `/` redirect.
+- `inex/ClientApp/src/layouts/BasicPage.tsx` - current authenticated navigation shell.
+- `inex/ClientApp/src/pages/Reports.tsx` - current reports nesting/chrome behavior.
+- `inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json` - current locale baseline.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+### Completion Notes List
+
+- Story context created via bmad-create-story workflow for key `6-1-frontend-dashboard-home-page-and-navigation-restructure`.
+- Story status set to `ready-for-dev`.
+- Story intentionally limits scope to functional dashboard route/navigation scaffold before Epic 10.
+- Sprint status was not updated because this orchestration run was constrained to create exactly one story file.
+
+### File List
+
+- docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md

--- a/docs/implementation/6-2-frontend-month-summary-cards.md
+++ b/docs/implementation/6-2-frontend-month-summary-cards.md
@@ -1,0 +1,228 @@
+# Story 6.2: Frontend - Month Summary Cards
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run bmad-create-story validate before dev-story. -->
+
+## Story
+
+As a user on the dashboard,
+I want to see this month's income, expenses, and net savings at a glance,
+So that I can quickly assess my financial health without running a report.
+
+## Acceptance Criteria
+
+1. Given the dashboard home page (from Story 4.1), When it loads, Then three summary cards are displayed: Total Income, Total Expenses, Net Savings - each showing the current month's figure in the user's base currency.
+
+2. Given a previous month exists with transaction data, When the cards render, Then each card shows a MoM delta (e.g. +12% vs last month) with directional color coding (green for positive savings/income trend, red for negative).
+
+3. Given no transactions exist for the current month, When the cards render, Then each card shows 0 with a neutral state - no errors or blank space.
+
+4. Given the data is fetched from the existing reports API, When the API call is made, Then it reuses an existing endpoint - no new backend endpoint required for this story.
+
+5. Given all card labels and delta text, When reviewed, Then all strings are in `en/translation.json` and `ru/translation.json`.
+
+## Tasks / Subtasks
+
+- [ ] Add month summary cards to the existing dashboard scaffold. (AC: 1, 3, 5)
+  - [ ] Update the dashboard page created by Story 6.1, likely `inex/ClientApp/src/pages/Dashboard.tsx`.
+  - [ ] Replace or fill the Story 6.1 month-summary placeholder with three functional cards only: Total Income, Total Expenses, and Net Savings.
+  - [ ] Use existing Ant Design layout/card/statistic patterns; do not create shared card primitives or a final design-system component.
+  - [ ] Keep the dashboard route and navigation behavior from Story 6.1 intact.
+
+- [ ] Fetch the current and previous month totals through an existing reports API. (AC: 1, 2, 3, 4)
+  - [ ] Reuse an existing report endpoint; do not add or modify backend endpoints.
+  - [ ] Prefer `GET /api/reports/budget/comparison?year={year}&month={month}&currency={currency}` because its response metadata already exposes `totalIncome` and `totalOutcome`.
+  - [ ] Fetch the current month and previous month for MoM comparison.
+  - [ ] Use the shared authenticated `apiClient`; do not create a raw Axios client or `fetch` call.
+  - [ ] Keep the fetch isolated to the dashboard widget so existing Reports pages and report Redux state are not reset or polluted by dashboard loading.
+
+- [ ] Resolve and display the user's base currency. (AC: 1)
+  - [ ] Derive the target currency from existing frontend/backend data, not a hardcoded `USD`.
+  - [ ] `auth.user.currencyId` identifies the preferred currency but does not currently include the currency key; map it to a code through existing currency data or an existing `/api/currencies` call if needed.
+  - [ ] If using already-loaded exchange-rate state as a fallback, ensure the displayed suffix and report `currency` query param match the actual base currency.
+  - [ ] Document any temporary fallback in completion notes if the current frontend lacks a reliable currency-code source.
+
+- [ ] Calculate and render MoM deltas. (AC: 2, 3, 5)
+  - [ ] Total Income comes from `metadata.totalIncome`.
+  - [ ] Total Expenses comes from `metadata.totalOutcome`.
+  - [ ] Net Savings is `metadata.totalIncome - metadata.totalOutcome`.
+  - [ ] For each card, compare current month value to the same metric from the previous month.
+  - [ ] Show a localized neutral state when the previous month baseline is zero or absent, rather than rendering `Infinity`, `NaN`, blank text, or an error.
+  - [ ] Apply directional color coding locally on the cards: positive income trend is positive, lower expenses are positive, and higher net savings is positive.
+
+- [ ] Add localized dashboard summary strings. (AC: 5)
+  - [ ] Add keys under a dashboard namespace such as `dashboard.summary.*` in both locale files.
+  - [ ] Include labels for Total Income, Total Expenses, Net Savings, current month, previous month comparison, neutral/no-change state, loading, and error/empty states as needed.
+  - [ ] Preserve existing `reports.*`, `transactions.*`, and `nav.*` keys.
+
+- [ ] Verify frontend quality gates. (AC: 1-5)
+  - [ ] From `inex/ClientApp`, run `npm run build`.
+  - [ ] From `inex/ClientApp`, run `npm run lint`.
+  - [ ] Manually smoke-check `/dashboard` with normal data, no current-month transactions, and a previous-month baseline where possible.
+  - [ ] Confirm `/reports`, `/reports/category`, `/reports/budget`, and `/reports/history` still behave as before.
+
+## Dev Notes
+
+### Source Requirements
+
+- Story 6.2 implements FR-FE-002: month summary cards on the dashboard. [Source: `docs/planning/epics.md`, Story 6.2]
+- The source acceptance criteria require three current-month summary cards, MoM deltas, zero-data handling, existing reports API reuse, and EN/RU localization. [Source: `docs/planning/epics.md`, Story 6.2]
+- The PRD tracks FR-FE-002 as covered by Epic 6, separate from the Epic 10 design-system rebuild. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]
+- The implementation readiness report marks Epic 6 ready only with story-boundary caution. Keep this story focused on functional dashboard reporting value. [Source: `docs/planning/implementation-readiness-report-2026-05-26.md`]
+- The design update plan and UX index reserve final dashboard/report visual design, shell behavior, shared primitives, responsive visual QA, and chart accessibility polish for Epic 10. [Source: `docs/planning/design-update-plan.md`; `docs/planning/ux-design.md`]
+
+### Dependencies
+
+- Depends on Story 6.1 for the authenticated `/dashboard` route, dashboard page file, and navigation scaffold.
+- Depends on the existing reports API and shared `apiClient` behavior.
+- Depends on the current authenticated profile/currency data enough to render values in the user's base currency. If the frontend cannot map `auth.user.currencyId` to a currency key without an existing call, use the existing `/api/currencies` endpoint rather than adding a new backend endpoint.
+- Does not depend on Story 6.3 heatmap, Story 6.4 historical net worth chart, or Story 6.5 category report fixes.
+- Epic 5 exchange-rate work improves base-currency conversion reliability, but this story should not implement new exchange-rate providers or historical net-worth calculations.
+
+### Current State Analysis
+
+`docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md`
+
+- Story 6.1 creates the dashboard route and placeholder regions for Epic 6 widgets.
+- Story 6.2 should fill only the month-summary region and preserve route/navigation behavior from 6.1.
+- If Story 6.1 implementation is not yet merged when this story starts, implement after rebasing onto 6.1 or stop and report the missing scaffold.
+
+`inex/ClientApp/src/App.tsx`
+
+- Before Story 6.1, protected `/` redirects to `/transactions` and no dashboard route exists.
+- Story 6.2 should not change route protection, public auth routes, or Reports nested routes beyond what Story 6.1 already established.
+- Existing app startup loads accounts, categories, budgets, and rates after auth session restore.
+
+`inex/ClientApp/src/store/auth/auth-slice.ts`
+
+- Auth state includes `user.currencyId`, but not the currency key string needed for report `currency` query parameters.
+- The developer must resolve the currency code through existing currency data or an existing API call. Do not silently treat `currencyId` as a currency code.
+
+`inex/ClientApp/src/store/report/report-actions.ts` and `report-slice.ts`
+
+- `fetchReport(type, filter)` calls `/reports/{type}` and stores shared report-page state.
+- Dashboard summary cards should avoid reusing this shared slice if doing so would overwrite Report Category state, title, currency, loading, or filters.
+- Any new dashboard-specific state should be scoped to the dashboard page or dashboard-specific store module, not a shared primitive layer.
+
+`inex/ClientApp/src/store/budgetReport/budgetReport-actions.ts` and `budgetReport-slice.ts`
+
+- `fetchBudgetReport(year, month, currency)` calls `/reports/budget/comparison?year={year}&month={month}&currency={currency}`.
+- The response metadata includes `totalIncome` and `totalOutcome`, which can satisfy the current-month income/expense inputs without backend changes.
+- Existing `budgetReport` Redux state is used by `ReportBudgetSpending`. Avoid dispatching its actions from Dashboard if that causes report-page state changes or stale selected-period behavior.
+
+`inex/Controllers/ReportBudgetController.cs`
+
+- Existing endpoint: `GET /api/reports/budget/comparison`.
+- Parameters: `year`, `month`, and optional `currency`, currently defaulting to `USD`.
+- Story 6.2 must pass the user's base currency explicitly once resolved.
+
+`inex/ClientApp/src/pages/Reports/ReportBudgetSpending.tsx`
+
+- Already demonstrates current report metadata usage for income, expenses, savings, loading, and Ant Design `Card`/`Statistic` layout.
+- Reuse its calculation semantics where appropriate, but do not move its UI into a shared card primitive.
+
+`inex/ClientApp/src/pages/Transactions/TransactionSummary.tsx`
+
+- Existing account-summary logic derives a base currency from loaded exchange rates and computes a month-to-date net change.
+- This is useful context only; Story 6.2 must show income, expenses, and net savings from the reports API per the source AC, not from account balance summary data.
+
+`inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json`
+
+- `reports.totalIncome`, `reports.totalExpense`, and `reports.savings` already exist.
+- Add dashboard-specific labels/delta text under a dashboard namespace instead of overloading report-specific wording if the dashboard copy differs.
+
+### Implementation Guidance
+
+- Keep the implementation small and functional:
+  - render three dashboard cards,
+  - fetch current and previous month totals from an existing report endpoint,
+  - compute net savings and MoM deltas in frontend code,
+  - localize all visible strings.
+- Use Day.js for month calculations because the app already uses it.
+- Use decimal-safe display formatting at two fractional digits, matching existing frontend report display.
+- Treat missing API data as zero only after the request succeeds. Loading and error states should be visible and localized, but not visually elaborate.
+- Preserve current report pages. Dashboard fetches should not change `/reports/budget` selected month, `report.items`, category report filters, or history report state.
+- Do not add frontend test infrastructure in this story. The current project quality gate is build plus lint.
+- Do not add dependencies. Ant Design, Redux Toolkit, Axios via `apiClient`, i18next, and Day.js are already available.
+
+### Epic 6 / Epic 10 Guardrails
+
+- This story is Epic 6 functional dashboard/reporting scaffold work only.
+- Keep scope to the month summary cards/widgets required by the source acceptance criteria.
+- Do not introduce shared card primitives, money primitives, token files, theme bridge work, or final dashboard visual design.
+- Do not redesign Reports hub, report drill-down chrome, shell/navigation behavior, or mobile navigation.
+- Do not own responsive visual QA baseline. Basic smoke checks for the dashboard cards and route regressions are enough.
+- Do not add chart accessibility polish; this story has no chart.
+- Do not implement Story 6.3 heatmap, Story 6.4 historical net worth chart, or Story 6.5 category report fixes.
+- Do not create Epic 10 stories or modify existing Epic 10 story files.
+
+### Files Likely to Change
+
+- `inex/ClientApp/src/pages/Dashboard.tsx` - add functional month summary cards to the 6.1 dashboard scaffold.
+- `inex/ClientApp/public/locales/en/translation.json` - add dashboard summary labels and delta/empty/error text.
+- `inex/ClientApp/public/locales/ru/translation.json` - add matching Russian dashboard summary labels and delta/empty/error text.
+
+Files that may change only if needed:
+
+- `inex/ClientApp/src/store/dashboard/*` - optional dashboard-specific Redux state if local component state is not enough.
+- `inex/ClientApp/src/model/Report/*` - optional explicit TypeScript response type for budget comparison metadata if reusing an existing type is insufficient.
+
+Files to avoid unless an implementation blocker requires them:
+
+- `inex/ClientApp/src/App.tsx` and `inex/ClientApp/src/layouts/BasicPage.tsx` - Story 6.1 owns route/navigation scaffold.
+- `inex/ClientApp/src/pages/Reports/**` - preserve existing Reports behavior; do not redesign report pages.
+- `inex/ClientApp/src/store/report/*` and `inex/ClientApp/src/store/budgetReport/*` - avoid shared report-state side effects unless deliberately adding isolated support.
+- Backend projects (`inex`, `inex.Services`, `inex.Data`) - no backend work belongs in this story.
+- `inex/ClientApp/package.json` and `package-lock.json` - no dependency changes.
+- `docs/implementation/10-*.md` - Epic 10 story files are out of scope.
+
+### Testing Requirements
+
+- Required commands from `inex/ClientApp`:
+  - `npm run build`
+  - `npm run lint`
+- Manual smoke checks:
+  - `/dashboard` renders three summary cards after auth.
+  - Current-month income, expenses, and net savings display in the user's base currency.
+  - Previous-month data produces finite localized MoM deltas.
+  - No current-month transactions produces zero values with neutral state.
+  - Existing Reports routes still render and keep their own state behavior: `/reports`, `/reports/category`, `/reports/budget`, `/reports/history`.
+- No backend tests are required because this story must not change backend behavior.
+
+### References
+
+- `docs/planning/epics.md` - Epic 6 Story 6.2 source of record.
+- `docs/planning/prds/prd-inex-2026-05-20/prd.md` - FR-FE-002 and frontend roadmap context.
+- `docs/planning/sprint-change-proposal-2026-05-26.md` - Epic 6 report-integrity and scope-boundary guardrails.
+- `docs/planning/implementation-readiness-report-2026-05-26.md` - Epic 6 ready with story-boundary caution.
+- `docs/planning/design-update-plan.md` - Epic 10 design sequencing and scope boundaries.
+- `docs/planning/ux-design.md` - UX source index; final design-system details are not Story 6.2 implementation scope.
+- `docs/planning/architecture.md` - frontend stack, route, i18n, and Epic 10 boundary guidance.
+- `docs/project-context.md` - frontend `apiClient`, Redux, i18n, build/lint, and no-new-dependency rules.
+- `docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md` - required dashboard scaffold dependency.
+- `inex/ClientApp/src/App.tsx` - current route tree and startup data loading.
+- `inex/ClientApp/src/store/auth/auth-slice.ts` - current profile currency state.
+- `inex/ClientApp/src/store/budgetReport/budgetReport-actions.ts` - existing budget comparison endpoint call pattern.
+- `inex/Controllers/ReportBudgetController.cs` - existing reports API endpoint available for reuse.
+- `inex/ClientApp/src/pages/Reports/ReportBudgetSpending.tsx` - existing report metadata and summary-card rendering pattern.
+- `inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json` - locale baseline.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+### Completion Notes List
+
+- Story context created via bmad-create-story workflow for key `6-2-frontend-month-summary-cards`.
+- Story status set to `ready-for-dev`.
+- Story intentionally limits scope to functional month summary cards on the dashboard scaffold before Epic 10.
+- Sprint status was not updated because this orchestration run was constrained to create exactly one story file.
+
+### File List
+
+- docs/implementation/6-2-frontend-month-summary-cards.md

--- a/docs/implementation/6-3-frontend-spending-heatmap-calendar.md
+++ b/docs/implementation/6-3-frontend-spending-heatmap-calendar.md
@@ -1,0 +1,238 @@
+# Story 6.3: Frontend - Spending Heatmap Calendar
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run bmad-create-story validate before dev-story. -->
+
+## Story
+
+As a user wanting to understand my spending patterns,
+I want a GitHub-style daily spend heatmap on the Reports page,
+So that I can see at a glance which days I spend the most.
+
+## Acceptance Criteria
+
+1. Given the Reports section, When a user navigates to the heatmap view, Then a calendar grid is displayed showing the last 12 months, with each day cell colored by spend intensity (darker = higher spend).
+
+2. Given a day with no transactions, When it renders in the grid, Then the cell shows the lowest intensity color - not blank or broken.
+
+3. Given a day with transactions, When the user hovers over or taps the cell, Then a tooltip shows the date and total spend amount in the user's base currency.
+
+4. Given the heatmap is built using the `recharts` library (already in the project), When `npm run build` completes, Then no new charting dependencies are added.
+
+5. Given all labels and tooltip text, When reviewed, Then all strings are in `en/translation.json` and `ru/translation.json`.
+
+## Tasks / Subtasks
+
+- [ ] Add the heatmap view to the existing Reports route surface. (AC: 1, 5)
+  - [ ] Add a protected nested Reports route for the heatmap, likely `/reports/heatmap`.
+  - [ ] Add a heatmap row to `ReportList` using the current table/list launch pattern.
+  - [ ] Add the heatmap route title to `Reports.tsx` without changing existing category, budget, or history report routes.
+  - [ ] Keep the Reports top-level navigation separation established by Story 6.1.
+
+- [ ] Build a functional last-12-month daily spend grid. (AC: 1, 2, 4)
+  - [ ] Create a new Reports page component, likely `inex/ClientApp/src/pages/Reports/ReportSpendingHeatmap.tsx`.
+  - [ ] Render one cell per day for the last 12 months, including zero-spend days.
+  - [ ] Use deterministic date boundaries from Day.js: include today and the prior 12-month window, normalized to local display dates.
+  - [ ] Use existing Ant Design layout/tooltip patterns and the existing `recharts` library where the heatmap visualization is rendered; do not add a new charting or calendar dependency.
+  - [ ] Use a small fixed intensity scale so zero-spend days always render with the lowest visible intensity.
+
+- [ ] Source and aggregate spending data without backend scope. (AC: 1, 3)
+  - [ ] Reuse existing authenticated API access through `apiClient`; do not create a raw Axios client or `fetch` call.
+  - [ ] Prefer the existing typed transaction list API, `GET /api/transactions`, with `mode=all`, `startDate`, `endDate`, `pageSize`, and `page`.
+  - [ ] Page through results using response pagination metadata until all transactions in the 12-month range are loaded; do not rely on a single arbitrary page size if total items exceed the first page.
+  - [ ] Aggregate only expense transactions into daily totals. Treat negative amounts as spend using `Math.abs(amount)`; exclude income and neutral transfer rows from spend totals.
+  - [ ] Preserve user ownership by relying on the backend-authenticated transactions endpoint. Do not add client-supplied user IDs.
+
+- [ ] Display tooltip values in the user's base currency. (AC: 3, 5)
+  - [ ] Derive the user's base currency through existing frontend state/API patterns; do not hardcode `USD`.
+  - [ ] Use each transaction's `accountCurrency` and available exchange-rate data to convert totals when the account currency differs from the base currency.
+  - [ ] If exact historical per-day base-currency conversion cannot be satisfied through existing APIs without a backend change or excessive per-day calls, stop and report the gap instead of adding a backend endpoint in this frontend story.
+  - [ ] Format tooltip amounts with localized labels and stable two-decimal display, matching current report conventions where possible.
+
+- [ ] Add localized heatmap copy. (AC: 5)
+  - [ ] Add keys under `reports.heatmap*` or another stable Reports namespace in both EN and RU locale files.
+  - [ ] Include labels for the Reports list row, route title, legend, zero-spend state, loading/error state, and tooltip date/spend text.
+  - [ ] Preserve existing `reports.categoryReport`, `reports.budgetReport`, `reports.historyReport`, `nav.*`, and dashboard keys from Stories 6.1 and 6.2.
+
+- [ ] Verify frontend quality gates. (AC: 1-5)
+  - [ ] From `inex/ClientApp`, run `npm run build`.
+  - [ ] From `inex/ClientApp`, run `npm run lint`.
+  - [ ] Manually smoke-check `/reports/heatmap` with spend data, no-spend days, and mixed account currencies where available.
+  - [ ] Confirm `/reports`, `/reports/category`, `/reports/budget`, `/reports/history`, and `/dashboard` still behave as before.
+
+## Dev Notes
+
+### Source Requirements
+
+- Story 6.3 implements FR-FE-004: spending heatmap calendar, a GitHub-style daily spend grid on Reports. [Source: `docs/planning/epics.md`, Story 6.3]
+- The source acceptance criteria require the last 12 months, spend-intensity cell coloring, a nonblank zero-spend state, hover/tap tooltip with date and base-currency spend, Recharts reuse with no new charting dependency, and EN/RU localization. [Source: `docs/planning/epics.md`, Story 6.3]
+- The PRD tracks FR-FE-004 under frontend core UX, not under the final design-system rebuild. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]
+- The sprint change proposal and readiness report allow Epic 6 dashboard/reporting work to proceed only when Story 6.5 remains separate and Epic 10 scope does not leak into functional stories. [Source: `docs/planning/sprint-change-proposal-2026-05-26.md`; `docs/planning/implementation-readiness-report-2026-05-26.md`]
+- `ux-design.md` and `design-update-plan.md` reserve final Reports hub, dashboard visual design, shell/navigation behavior, shared primitives, responsive visual QA baseline, and chart accessibility polish for Epic 10. Use them only as boundary context for this story. [Source: `docs/planning/ux-design.md`; `docs/planning/design-update-plan.md`]
+
+### Dependencies
+
+- Depends on Story 6.1 for the functional dashboard route/navigation scaffold and clear separation between Dashboard and Reports.
+- Does not depend on Story 6.2 month summary cards or Story 6.4 historical net worth chart.
+- Does not depend on Story 6.5 implementation, and must not change category report backend behavior.
+- Depends on existing authenticated transaction/report frontend architecture: React Router 6, Ant Design, Redux Toolkit, shared `apiClient`, i18next, Day.js, and Recharts.
+- Depends on existing data being sufficient to compute daily spend totals in the user's base currency. If existing APIs cannot supply accurate base-currency conversion for historical daily spend, this story must surface that as a planning/API gap rather than adding backend work.
+
+### Current State Analysis
+
+`docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md`
+
+- Story 6.1 creates the `/dashboard` route and separates Dashboard from Reports.
+- Story 6.3 should preserve that route/navigation scaffold and add only the heatmap report view.
+- If Story 6.1 implementation is not present when this story starts, implement after rebasing onto 6.1 or stop and report the missing scaffold.
+
+`inex/ClientApp/src/App.tsx`
+
+- Current protected routes include `/transactions`, `/accounts`, `/categories`, `/budgets`, `/profile`, and nested `/reports` routes.
+- Current Reports nested routes are `category`, `budget`, and `history`; no heatmap route exists yet.
+- Add the heatmap as a nested Reports route. Do not alter public `/login` and `/register`, `ProtectedRoute`, or existing report route paths.
+
+`inex/ClientApp/src/pages/Reports.tsx`
+
+- Reports wraps nested report pages in `BasicPage`, derives a title from `location.pathname`, and shows a Back button on drill-down routes.
+- Add a heatmap title mapping and preserve the current Back button behavior.
+- Do not rebuild Reports hub chrome, report cards, Share/Export/Print placement, or drill-down layout.
+
+`inex/ClientApp/src/pages/Reports/ReportList.tsx`
+
+- The Reports index is currently an Ant Design `Table` with rows for category, budget, and history reports.
+- Add a heatmap row using the same launch pattern. Do not replace the table with Epic 10 report cards.
+
+`inex/ClientApp/src/pages/Reports/ReportMonthlyHistory.tsx`
+
+- Existing chart usage already imports Recharts components and renders inside `ResponsiveContainer`.
+- The heatmap visualization must use the existing `recharts` library to satisfy source AC 4, while still avoiding any new charting or calendar dependency.
+- This file hardcodes some currency formatting assumptions today; do not copy hardcoded currency behavior into the heatmap.
+
+`inex/ClientApp/src/store/transactions/transactions-actions.ts`
+
+- `fetchTransactions` calls `GET /api/transactions` with typed query params: `mode`, `pageSize`, `page`, `accountId`, `categoryId`, `tag`, `ref`, `startDate`, and `endDate`.
+- The shared transactions slice is used by the Transactions page. Avoid dispatching `fetchTransactions` from the heatmap if it would overwrite the user's transaction-list state, pagination, or filters.
+- Prefer a heatmap-local API helper or page-local loader through `apiClient` if reusing the shared slice would cause cross-page state side effects.
+
+`inex/Controllers/TransactionsController.cs`
+
+- `GET /api/transactions` is authenticated and scoped by `CurrentUserId`.
+- The endpoint returns paginated data with metadata, so the heatmap must page through the range if it needs all 12-month transactions.
+- The typed date filters are `startDate` and `endDate`. Do not use the legacy report filter DSL for this story unless an existing report endpoint is intentionally reused for a narrow reason.
+
+`inex.Services/Models/Records/Transaction/TransactionResponse.cs`
+
+- Transaction responses include `AccountCurrency`.
+- Tags and refs are derived from comments on read and are irrelevant for the heatmap.
+- The story needs only date, amount, account currency, and enough transaction/category information to identify expenses and exclude transfers. If the response shape is insufficient, report the gap instead of changing backend contracts in this frontend story.
+
+`inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json`
+
+- `reports` already contains category, budget, history, amount, income, expense, savings, and related report labels.
+- Add heatmap-specific keys in both files and preserve existing keys.
+
+### Implementation Guidance
+
+- Keep the implementation small and additive:
+  - add a Reports heatmap route,
+  - add a Reports list entry,
+  - fetch existing transaction data for the last 12 months,
+  - aggregate expense totals per day,
+  - render the heatmap and localized tooltips.
+- Use existing Day.js and report date conventions. Avoid adding date/calendar libraries.
+- Use a fixed-size intensity scale based on the maximum daily spend in the loaded period. Handle all-zero data with a stable neutral scale.
+- Tooltip content should include a localized date and total spend amount in the user's base currency.
+- Loading and error states should be present and localized, but visually simple.
+- Avoid shared Redux state changes if the heatmap data is not reused elsewhere.
+- Do not add frontend test infrastructure in this story. The current frontend gate is build plus lint.
+- Do not add dependencies. Existing React, Ant Design, Recharts, Day.js, i18next, Redux Toolkit, and `apiClient` are enough for the functional scaffold.
+
+### Epic 6 / Epic 10 Guardrails
+
+- This story is Epic 6 functional reporting scaffold work only.
+- Keep scope to the functional spending heatmap calendar required by the source acceptance criteria.
+- Do not redesign the Reports hub, report drill-down chrome, app shell, desktop navigation, or mobile navigation.
+- Do not introduce final dashboard/report visual design, design tokens, theme bridge, shared primitives, money primitives, or an accessibility summary system.
+- Do not own the responsive visual QA baseline. Basic smoke checks for the heatmap route and existing Reports routes are enough.
+- Do not add chart accessibility polish beyond functional labels and tooltip text required by the source acceptance criteria.
+- Do not implement Story 6.2 month cards, Story 6.4 historical net worth chart, or Story 6.5 category report fixes.
+- Do not create Epic 10 stories or modify existing Epic 10 story files.
+
+### Files Likely to Change
+
+- `inex/ClientApp/src/App.tsx` - register the nested `/reports/heatmap` route.
+- `inex/ClientApp/src/pages/Reports.tsx` - add heatmap route title mapping.
+- `inex/ClientApp/src/pages/Reports/ReportList.tsx` - add heatmap launch row.
+- `inex/ClientApp/src/pages/Reports/ReportSpendingHeatmap.tsx` - new heatmap page component.
+- `inex/ClientApp/public/locales/en/translation.json` - add heatmap labels, legend, tooltip, loading/error text.
+- `inex/ClientApp/public/locales/ru/translation.json` - add matching Russian heatmap labels.
+
+Files that may change only if needed:
+
+- `inex/ClientApp/src/model/Transaction/*` - optional explicit transaction response type if current typed models are insufficient.
+- `inex/ClientApp/src/store/dashboard/*` or `src/store/reports/*` - only if page-local state is insufficient; avoid shared primitive or broad report-state refactors.
+
+Files to avoid unless an implementation blocker requires them:
+
+- Backend projects (`inex`, `inex.Services`, `inex.Data`) - this is a frontend story and must not add a backend endpoint or change backend contracts.
+- `inex/ClientApp/src/pages/Dashboard.tsx` - dashboard widgets are not owned by this Reports heatmap story unless Story 6.1 explicitly left a nonfunctional heatmap placeholder that needs a link-only update.
+- `inex/ClientApp/src/pages/Reports/ReportCategory.tsx`, `ReportBudgetSpending.tsx`, and `ReportMonthlyHistory.tsx` - preserve existing reports.
+- `inex/ClientApp/src/layouts/BasicPage.tsx` - Story 6.1 owns minimal navigation scaffold; Epic 10 owns shell/navigation redesign.
+- `inex/ClientApp/package.json` and `package-lock.json` - no dependency changes.
+- `docs/implementation/10-*.md` - Epic 10 story files are out of scope.
+
+### Testing Requirements
+
+- Required commands from `inex/ClientApp`:
+  - `npm run build`
+  - `npm run lint`
+- Manual smoke checks:
+  - `/reports` lists the heatmap view alongside category, budget, and history reports.
+  - `/reports/heatmap` renders a last-12-month grid with one visible cell per day.
+  - Zero-spend days render with the lowest intensity state, not blank cells.
+  - Hover and tap interaction shows localized date and spend amount in the user's base currency.
+  - Mixed spend amounts produce visible intensity differences without adding a new charting dependency.
+  - Existing routes still render: `/reports`, `/reports/category`, `/reports/budget`, `/reports/history`, and `/dashboard`.
+- No backend tests are required because this story must not change backend behavior.
+
+### References
+
+- `docs/planning/epics.md` - Epic 6 Story 6.3 source of record.
+- `docs/planning/prds/prd-inex-2026-05-20/prd.md` - FR-FE-004 and frontend core UX roadmap context.
+- `docs/planning/sprint-change-proposal-2026-05-26.md` - Epic 6 report-integrity and scope-boundary guardrails.
+- `docs/planning/implementation-readiness-report-2026-05-26.md` - Epic 6 ready with story-boundary caution.
+- `docs/planning/design-update-plan.md` - Epic 10 design sequencing and scope boundaries.
+- `docs/planning/ux-design.md` - UX source index; final design-system details are not Story 6.3 implementation scope.
+- `docs/planning/architecture.md` - frontend stack, route, i18n, and Epic 10 boundary guidance.
+- `docs/project-context.md` - frontend `apiClient`, Redux, i18n, build/lint, no-new-dependency, and ownership rules.
+- `docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md` - required dashboard/report navigation scaffold dependency.
+- `docs/implementation/6-2-frontend-month-summary-cards.md` - adjacent dashboard widget scope to avoid.
+- `docs/implementation/6-5-backend-fix-category-report-data-gaps-and-localization.md` - separate report-correctness scope to avoid.
+- `inex/ClientApp/src/App.tsx` - current route tree and Reports nested routes.
+- `inex/ClientApp/src/pages/Reports.tsx` - current Reports wrapper, title mapping, and Back button.
+- `inex/ClientApp/src/pages/Reports/ReportList.tsx` - current Reports launch list.
+- `inex/ClientApp/src/store/transactions/transactions-actions.ts` - existing transaction API query pattern.
+- `inex/Controllers/TransactionsController.cs` - authenticated typed transaction list endpoint.
+- `inex.Services/Models/Records/Transaction/TransactionResponse.cs` - transaction response fields relevant to aggregation.
+- `inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json` - locale baseline.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+### Completion Notes List
+
+- Story context created via bmad-create-story workflow for key `6-3-frontend-spending-heatmap-calendar`.
+- Story status set to `ready-for-dev`.
+- Story intentionally limits scope to a functional Reports heatmap before Epic 10.
+- Sprint status was not updated because this orchestration run was constrained to create exactly one story file.
+
+### File List
+
+- docs/implementation/6-3-frontend-spending-heatmap-calendar.md

--- a/docs/implementation/6-4-backend-frontend-historical-net-worth-chart.md
+++ b/docs/implementation/6-4-backend-frontend-historical-net-worth-chart.md
@@ -1,0 +1,272 @@
+# Story 6.4: Backend + Frontend - Historical Net Worth Chart
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run bmad-create-story validate before dev-story. -->
+
+## Story
+
+As a user wanting to track my financial progress over time,
+I want a chart showing my total net worth by month,
+So that I can see whether I'm accumulating or losing wealth over time.
+
+## Acceptance Criteria
+
+1. Given a user with accounts in multiple currencies, When `GET /api/reports/net-worth?months=12` is called, Then the response returns a monthly series of total net worth values converted to the user's base currency using period-accurate exchange rates.
+
+2. Given the NBRB exchange rate client is available (Epic 5), When the net worth calculation includes BYN or RUB accounts, Then NBRB rates are used for those currencies; Frankfurter rates used for all others.
+
+3. Given an account that was closed mid-period, When the net worth for months before closure is calculated, Then the account's balance at that time is included - closed accounts do not retroactively disappear from history.
+
+4. Given the injectable `IClock` abstraction (from Epic 2), When "current month" is calculated, Then it uses the clock abstraction - deterministically testable.
+
+5. Given the frontend dashboard, When the chart renders, Then a line chart (using `recharts`) shows net worth by month for the selected period with axis labels in the user's locale.
+
+6. Given the story is complete, When `dotnet test` runs, Then unit tests cover the multi-currency aggregation logic and period-accurate rate selection.
+
+## Tasks / Subtasks
+
+- [ ] Add a backend net-worth report contract and service method. (AC: 1, 3, 4, 6)
+  - [ ] Add a typed response record for monthly net-worth points, likely under `inex.Services/Models/Records/Report/`.
+  - [ ] Add `IReportService.GetNetWorthHistory(int userId, int months, string currency = "", CancellationToken ct = default)` or an equivalent report-service method.
+  - [ ] Use `IClock.UtcNow` to determine the current month and the inclusive month window.
+  - [ ] Normalize `months` to a safe supported range; default to 12 at the controller boundary and reject or clamp invalid values consistently with existing validation patterns.
+  - [ ] Return month identifiers and values that the frontend can render without parsing localized month names as data keys.
+
+- [ ] Implement period-accurate net-worth aggregation. (AC: 1, 2, 3, 4, 6)
+  - [ ] For each month in the selected window, calculate account balances as of that month end from historical transactions, not from only current active accounts.
+  - [ ] Include all user-owned accounts through `ActivityMode.ALL`; inactive or closed accounts with historical balances must remain represented for months where they had value.
+  - [ ] Convert each account balance using the period-end exchange rate for that month, or the closest existing carry-forward behavior provided by `ExchangeRateService`.
+  - [ ] Resolve the user's base currency through existing backend user/currency behavior when `currency` is omitted; do not hardcode `USD`.
+  - [ ] Keep all aggregation scoped by authenticated `userId`; do not trust client-supplied ownership fields.
+  - [ ] Preserve decimal precision and avoid double/float conversion for financial values.
+
+- [ ] Add an authenticated API endpoint. (AC: 1, 4)
+  - [ ] Add `GET /api/reports/net-worth?months=12` to the existing reports controller surface or a narrowly scoped reports controller.
+  - [ ] Use `ApiControllerBase.CurrentUserId` and keep controller logic thin.
+  - [ ] Keep existing report routes unchanged: `/api/reports/category`, `/api/reports/history/{year}`, and `/api/reports/budget/comparison`.
+  - [ ] Preserve RFC 7807/validation behavior for invalid query parameters.
+
+- [ ] Cover backend behavior with focused tests. (AC: 1, 2, 3, 4, 6)
+  - [ ] Add service/unit tests in `inex.Services.Tests` for multi-currency monthly aggregation.
+  - [ ] Use `FakeClock` or an equivalent test clock to prove deterministic current-month boundaries.
+  - [ ] Cover BYN/RUB rate selection through the existing Epic 5 exchange-rate service behavior or by verifying `IExchangeRateService.Get` is called for the required period/currency set.
+  - [ ] Cover inactive/closed-account historical inclusion by ensuring an account excluded from active lists still contributes for prior month-end balances.
+  - [ ] Add API/integration coverage in `inex.Tests` if route binding, auth, or query validation cannot be proven at service-test level.
+
+- [ ] Add the dashboard net-worth chart. (AC: 5)
+  - [ ] Update the dashboard page created by Story 6.1, likely `inex/ClientApp/src/pages/Dashboard.tsx`.
+  - [ ] Fill only the historical-net-worth chart region; preserve Story 6.2 month cards and Story 6.3 report heatmap behavior.
+  - [ ] Fetch `GET /api/reports/net-worth?months=12` through the shared authenticated `apiClient`.
+  - [ ] Render a line chart using the existing `recharts` dependency. Do not add another charting dependency.
+  - [ ] Use localized axis labels, tooltip labels, loading state, empty state, and error state through EN/RU locale files.
+  - [ ] Use the user's locale for displayed month labels, but keep API data stable and locale-independent.
+
+- [ ] Verify full-stack quality gates. (AC: 1-6)
+  - [ ] Run focused backend tests while iterating.
+  - [ ] Run `dotnet build inex.sln`.
+  - [ ] Run the relevant `dotnet test` scope; full `dotnet test inex.sln` is preferred if practical.
+  - [ ] From `inex/ClientApp`, run `npm run build`.
+  - [ ] From `inex/ClientApp`, run `npm run lint`.
+  - [ ] Manually smoke-check `/dashboard` with the net-worth chart and verify existing `/reports`, `/reports/category`, `/reports/budget`, `/reports/history`, and `/reports/heatmap` routes still render.
+
+## Dev Notes
+
+### Source Requirements
+
+- Story 6.4 implements FR-HIST-001: historical account value report / net worth over time chart with period-accurate exchange rates. [Source: `docs/planning/epics.md`, Story 6.4]
+- The source acceptance criteria require a backend endpoint, multi-currency aggregation, Epic 5 BYN/RUB NBRB support, closed-account historical inclusion, `IClock` usage, a Recharts frontend line chart, and backend test coverage. [Source: `docs/planning/epics.md`, Story 6.4]
+- Epic 6 is functional dashboard/reporting scaffold work before Epic 10. This story must provide the historical net-worth capability and chart, not the final dashboard/report visual system. [Source: `docs/planning/epics.md`, Epic 6]
+- The PRD tracks FR-HIST-001 as a P2 full-stack feature and notes that NBRB integration is independently schedulable while historical net-worth needs data integrity verification during story creation. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]
+- The sprint change proposal and readiness report require Epic 6 report integrity work to remain explicit and independently testable; do not absorb Story 6.5 category report fixes into this chart story. [Source: `docs/planning/sprint-change-proposal-2026-05-26.md`; `docs/planning/implementation-readiness-report-2026-05-26.md`]
+- `design-update-plan.md` and `ux-design.md` reserve final dashboard/report visual design, Reports hub/drill-down chrome, shell/navigation behavior, shared primitives, responsive visual QA baseline, and chart accessibility polish for Epic 10. [Source: `docs/planning/design-update-plan.md`; `docs/planning/ux-design.md`]
+
+### Dependencies
+
+- Depends on Story 6.1 for the protected `/dashboard` route, dashboard page scaffold, and Dashboard/Reports navigation separation.
+- Depends on Epic 2 / Story 2.2 for the `IClock` abstraction. The current backend registers `IClock` and tests include `FakeClock`.
+- Depends on Epic 5 / Story 5.1 for BYN/RUB NBRB rate support. Do not start implementation until the NBRB exchange-rate work is merged and accepted; current git history shows the NBRB client work exists, while `sprint-status.yaml` still lists Story 5.1 as `review`.
+- Depends on existing `IExchangeRateService.Get(userId, start, end, baseCurrency, ct)` for period rate population and provider selection. Do not add a second exchange-rate provider path inside net-worth reporting.
+- Does not depend on Story 6.2 month cards, Story 6.3 heatmap, or Story 6.5 category report fixes, but must preserve their routes/widgets if already implemented.
+- Epic 10 owns final dashboard/report visual design, Reports hub and drill-down chrome, shell/navigation behavior, mobile navigation, shared primitives, responsive visual QA, and chart accessibility polish.
+
+### Current State Analysis
+
+`inex/Controllers/ReportsController.cs`
+
+- Current routes are `GET /api/reports/category` and `GET /api/reports/history/{year}`.
+- Controllers inherit `ApiControllerBase` and pass `CurrentUserId` into report services.
+- Add the net-worth endpoint without changing the existing category/history route constants or legacy report filter behavior.
+
+`inex.Services/Services/Base/IReportService.cs`
+
+- Current methods are `GetCategoriesReportData(...)` and `GetMonthlyHistory(...)`.
+- Story 6.4 should add a specific net-worth method rather than overloading monthly income/expense history.
+
+`inex.Services/Services/ReportService.cs`
+
+- `GetMonthlyHistory` already demonstrates a year range, all transactions, exchange-rate lookup, account currency resolution, and exclusion of system transfer categories.
+- Do not copy its current hardcoded fallback assumptions blindly: this story needs month-end cumulative account balances, not monthly income/expense totals.
+- Current conversion pattern uses exchange rates keyed by `(CurrencyTo, Date)`. Net-worth should use period-end dates for each month and let `ExchangeRateService` fill/carry rates for missing non-trading dates.
+
+`inex.Services/Services/ExchangeRateService.cs`
+
+- The range overload resolves the base currency from the user's profile when empty.
+- It fetches/caches date-based rates, creates temporary rates for today through `IClock`, carries missing rates forward, and routes BYN/RUB paths through `INbrbApiClient`.
+- Reuse this service. Do not call Frankfurter, CurrencyAPI, or NBRB clients directly from report code.
+
+`inex.Data/Models/Account.cs` and `AccountService`
+
+- The current persisted account state has `IsEnabled`, not a dated active/inactive/closed status model.
+- `AccountService.Get(userId, ActivityMode.ALL)` returns active and inactive accounts with currency included.
+- For the closed-account AC, use all user-owned accounts and transaction history so inactive/closed accounts do not retroactively disappear. If implementation needs an actual closure date and the model still lacks it, stop and report the planning/model gap instead of inventing a closure-date field in this story.
+
+`inex.Data/Models/Transaction.cs` and `TransactionResponse`
+
+- Transactions store `AccountId`, `CategoryId`, `UserId`, `Created`, and decimal `Value`.
+- API/service response exposes `Amount`, `Created`, `AccountId`, `CategoryId`, and `AccountCurrency`.
+- Historical net worth should calculate cumulative balance per account as of each month-end by summing transactions up to that point. Income/expense category semantics are not enough; transfers should affect the source/destination account balances according to existing transaction records.
+
+`inex/ClientApp/src/App.tsx`
+
+- Before Story 6.1 implementation, protected `/` still redirects to `/transactions` and no dashboard route exists.
+- Story 6.4 should be implemented after Story 6.1 so it can add to the dashboard page instead of creating a competing route.
+- Existing nested Reports routes must remain intact.
+
+`inex/ClientApp/src/pages/Reports/ReportMonthlyHistory.tsx`
+
+- Existing chart usage already uses Recharts (`ComposedChart`, `Line`, `ResponsiveContainer`, axes, tooltip, legend).
+- The current component has hardcoded `ru-RU` and `USD` formatting assumptions; do not copy those into the net-worth chart. Use the user's locale/currency.
+
+`inex/ClientApp/src/store/report/report-actions.ts` and `report-slice.ts`
+
+- Existing report state uses `any[]` and shared report loading/error state.
+- Prefer an explicitly typed dashboard-local loader or narrowly scoped report state for net worth rather than adding more `any` to shared report state. Epic 7 owns broader frontend DTO cleanup.
+
+`inex/ClientApp/public/locales/en/translation.json` and `ru/translation.json`
+
+- Add net-worth labels under a stable dashboard or reports namespace in both files.
+- Preserve existing dashboard keys from Stories 6.1 and 6.2 and heatmap keys from Story 6.3.
+
+### Implementation Guidance
+
+- Keep backend report code in the existing layered architecture:
+  - controller handles route/query/current user,
+  - service computes report data,
+  - existing repositories/services provide accounts, transactions, and rates,
+  - mapping stays in static mapper extensions if new entity-to-record mapping is needed.
+- Recommended calculation shape:
+  - determine month-end dates for the last `months` months using `IClock.UtcNow`,
+  - load all user-owned accounts and relevant transactions once,
+  - group/sum transactions by account cumulatively up to each month end,
+  - convert each account balance from account currency to base currency using that month-end rate,
+  - sum converted account balances into one monthly net-worth value.
+- For same-currency balances, use the amount directly and do not require a rate.
+- For missing rates, use the behavior already provided by `ExchangeRateService`. If the service cannot provide a required historical rate after Epic 5, surface a validation/error path or planning gap; do not silently exclude BYN/RUB accounts or treat unsupported currencies as zero.
+- The endpoint should default to the user's profile currency when no `currency` query parameter is supplied. A frontend `currency` parameter is optional only if the user can select a period/currency without conflicting with source AC.
+- Keep the frontend chart functional and restrained:
+  - line chart only,
+  - selected period can be fixed to 12 months unless a minimal period control is needed to satisfy API use,
+  - localized axis and tooltip labels,
+  - simple loading/empty/error states.
+- Do not add frontend test infrastructure, new dependencies, data-fetching libraries, or charting packages in this story.
+
+### Epic 6 / Epic 10 Guardrails
+
+- This story is Epic 6 functional historical reporting work only.
+- Keep scope to the backend/frontend historical net-worth chart required by the source acceptance criteria.
+- Do not implement final dashboard/report visual design, design tokens, theme bridge, shared primitives, money primitives, or a chart summary/accessibility system.
+- Do not redesign the Reports hub, report drill-down chrome, app shell, desktop navigation, or mobile navigation.
+- Do not own the responsive visual QA baseline. Basic route/widget smoke checks are enough for this story.
+- Do not add chart accessibility polish beyond functional localized axis labels, line labels/legend where needed, and tooltip text required by the source AC.
+- Do not implement Story 6.2 month cards, Story 6.3 heatmap, or Story 6.5 category report fixes.
+- Do not create Epic 10 stories or modify existing Epic 10 story files.
+
+### Files Likely to Change
+
+- `inex/Controllers/ReportsController.cs` - add `GET /api/reports/net-worth`.
+- `inex.Services/Services/Base/IReportService.cs` - add net-worth report method.
+- `inex.Services/Services/ReportService.cs` - implement period-accurate monthly net-worth aggregation.
+- `inex.Services/Models/Records/Report/NetWorthHistoryResponse.cs` - new response record for chart points.
+- `inex.Services.Tests/...` - focused service tests for aggregation, `IClock`, and period rate selection.
+- `inex/ClientApp/src/pages/Dashboard.tsx` - render the historical net-worth chart in the Story 6.1 dashboard scaffold.
+- `inex/ClientApp/src/model/Report/*` - optional typed frontend net-worth model.
+- `inex/ClientApp/public/locales/en/translation.json` - add net-worth chart labels/loading/empty/error text.
+- `inex/ClientApp/public/locales/ru/translation.json` - add matching Russian labels/loading/empty/error text.
+
+Files that may change only if needed:
+
+- `inex.Tests/Reports/...` or similar - add API coverage if service tests do not cover route/auth/query behavior.
+- `inex/ClientApp/src/store/dashboard/*` or a small dashboard-local data module - only if component-local state is not sufficient.
+
+Files to avoid unless an implementation blocker requires them:
+
+- `inex/ClientApp/src/layouts/BasicPage.tsx` and route navigation shell files - Story 6.1 owns minimal navigation scaffold; Epic 10 owns shell/navigation redesign.
+- `inex/ClientApp/src/pages/Reports/**` - preserve existing Reports pages and heatmap; net-worth chart belongs on the dashboard per source AC.
+- `inex.Services/Services/ExchangeRateService.cs` and external exchange-rate clients - Epic 5 owns provider behavior; this story consumes it.
+- `inex.Data/Models/Account.cs` and EF migrations - do not add a closure-date/status schema unless a true planning blocker is identified and approved.
+- `inex/ClientApp/package.json` and `package-lock.json` - no dependency changes.
+- `docs/implementation/10-*.md` - Epic 10 story files are out of scope.
+
+### Testing Requirements
+
+- Backend tests:
+  - Multi-currency aggregation returns monthly net-worth values in the user's base currency.
+  - BYN/RUB account balances are converted through the existing Epic 5 rate path; they are not excluded or treated as unsupported.
+  - Account data loaded with all activity states contributes to historical months when transactions exist.
+  - Current-month boundaries use `IClock.UtcNow`, not `DateTime.Now` or `DateTime.UtcNow` directly.
+  - Invalid `months` query values are handled deterministically.
+- Frontend checks:
+  - `/dashboard` renders the net-worth line chart after auth.
+  - The chart calls `/api/reports/net-worth?months=12` through `apiClient`.
+  - Axis labels and tooltip labels are localized and do not hardcode `USD` or `ru-RU`.
+  - Loading, empty, and error states render without breaking existing dashboard widgets.
+- Required final checks:
+  - `dotnet build inex.sln`
+  - relevant `dotnet test` scope, preferably `dotnet test inex.sln` if practical
+  - `npm run build` from `inex/ClientApp`
+  - `npm run lint` from `inex/ClientApp`
+
+### References
+
+- `docs/planning/epics.md` - Epic 6 Story 6.4 source of record.
+- `docs/planning/prds/prd-inex-2026-05-20/prd.md` - FR-HIST-001, FR-RATE-4, roadmap order, and open question context.
+- `docs/planning/sprint-change-proposal-2026-05-26.md` - Epic 6 report-integrity and scope-boundary guardrails.
+- `docs/planning/implementation-readiness-report-2026-05-26.md` - Epic 6 ready with story-boundary caution and Epic 10 boundary risks.
+- `docs/planning/design-update-plan.md` - Epic 10 design sequencing and ownership boundaries.
+- `docs/planning/ux-design.md` - UX source index; final design-system details are not Story 6.4 implementation scope.
+- `docs/planning/architecture.md` - backend/frontend stack, service boundaries, `IClock`, i18n, Recharts, and Epic 10 boundary guidance.
+- `docs/project-context.md` - ownership predicates, report calculation, API compatibility, frontend `apiClient`, i18n, no-new-dependency, and verification rules.
+- `docs/implementation/6-1-frontend-dashboard-home-page-and-navigation-restructure.md` - required dashboard scaffold dependency.
+- `docs/implementation/6-2-frontend-month-summary-cards.md` - adjacent dashboard widget scope to preserve.
+- `docs/implementation/6-3-frontend-spending-heatmap-calendar.md` - adjacent Reports heatmap scope to preserve.
+- `docs/implementation/6-5-backend-fix-category-report-data-gaps-and-localization.md` - separate report-correctness scope to avoid.
+- `inex/Controllers/ReportsController.cs` - current reports controller route surface.
+- `inex.Services/Services/Base/IReportService.cs` - report service contract.
+- `inex.Services/Services/ReportService.cs` - existing monthly report patterns.
+- `inex.Services/Services/ExchangeRateService.cs` - date-range exchange-rate and NBRB provider behavior.
+- `inex.Services/Infrastructure/Time/IClock.cs` - injectable current-time abstraction.
+- `inex.Services.Tests/Helpers/FakeClock.cs` - deterministic test clock.
+- `inex.Data/Models/Account.cs` and `Transaction.cs` - account/transaction data needed for historical balances.
+- `inex/ClientApp/src/pages/Reports/ReportMonthlyHistory.tsx` - existing Recharts usage and formatting pitfalls to avoid.
+- `inex/ClientApp/src/store/report/report-actions.ts` and `report-slice.ts` - current report state patterns and typing debt to avoid expanding.
+- `inex/ClientApp/package.json` - confirms Recharts is already available.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+### Completion Notes List
+
+- Story context created via bmad-create-story workflow for key `6-4-backend-frontend-historical-net-worth-chart`.
+- Story status set to `ready-for-dev`.
+- Story intentionally limits scope to the functional historical net-worth endpoint and dashboard chart before Epic 10.
+- Sprint status was not updated because this orchestration run was constrained to create exactly one story file.
+
+### File List
+
+- docs/implementation/6-4-backend-frontend-historical-net-worth-chart.md

--- a/docs/implementation/6-5-backend-fix-category-report-data-gaps-and-localization.md
+++ b/docs/implementation/6-5-backend-fix-category-report-data-gaps-and-localization.md
@@ -1,0 +1,190 @@
+# Story 6.5: Backend - Fix Category Report Data Gaps and Localization
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run bmad-create-story validate before dev-story. -->
+
+## Story
+
+As a user running a category spending report,
+I want the report to include transactions for all my categories (including inactive ones),
+So that my historical spending data is complete and not silently excluded by category status.
+
+## Acceptance Criteria
+
+1. Given a user has categories that were active when transactions were made but are now inactive, When `GET /api/reports/categories` is called, Then transactions against inactive categories appear in the report output - category active/inactive status must not filter out transactions from history.
+
+2. Given `GetCategoriesReportData` currently filters to ACTIVE categories only, When this story is complete, Then the query includes transactions for all user-owned categories regardless of status; category status may be included in the response for display purposes but must not exclude spending data.
+
+3. Given `BuildReportDataResponse` is used by `GetCategoriesReportData` and leaves `TotalIncome` and `TotalOutcome` at 0, When this story is complete, Then category report entries correctly populate both totals, matching the explicit assignment pattern used in `BudgetReportService`.
+
+4. Given `ReportService.GetCategoriesReportData` contains the hardcoded Russian string `"Расходы по категориям"`, When this story is complete, Then the report title is either removed from the API response (rendered on the frontend via i18n) or returned as a translation key - no hardcoded language strings in services.
+
+5. Given the story is complete, When `dotnet test` runs, Then existing report tests pass; new tests cover: inactive-category transactions included, `TotalIncome`/`TotalOutcome` correctly populated, no hardcoded string in service output.
+
+## Tasks / Subtasks
+
+- [ ] Fix category inclusion for category report history. (AC: 1, 2)
+  - [ ] In `ReportService.GetCategoriesReportData`, load user categories with `ActivityMode.ALL`, not `ActivityMode.ACTIVE`.
+  - [ ] Keep system categories excluded from category report output unless existing product behavior explicitly requires showing system transfer categories.
+  - [ ] Ensure inactive user-owned categories with historical transactions can appear in `Data` when their converted value is non-zero.
+  - [ ] Preserve the existing report date filter behavior from `ReportMetadata.Start` and `ReportMetadata.End`.
+
+- [ ] Populate report totals in the category report response. (AC: 3)
+  - [ ] Compute `TotalIncome` from positive non-system transaction amounts converted into the requested report currency.
+  - [ ] Compute `TotalOutcome` from negative non-system transaction amounts converted into the requested report currency, using absolute values to match `BudgetReportService`.
+  - [ ] Return `ReportMetadata.TotalIncome` and `ReportMetadata.TotalOutcome` explicitly instead of relying on `BuildReportDataResponse` defaults.
+  - [ ] Keep category row `Value` behavior focused on per-category spending/income as the current report expects; if preserving negative spending signs is necessary for frontend compatibility, document it in completion notes.
+
+- [ ] Remove hardcoded service-language output. (AC: 4)
+  - [ ] Replace the hardcoded `"Расходы по категориям"` service title with one of these scoped options:
+    - remove report title/name from the category report metadata only if API compatibility is intentionally updated and all consumers are adjusted in the same story, or
+    - set `ReportMetadata.Name` to a stable translation key such as `reports.categoryReport`.
+  - [ ] Do not add frontend redesign work for displaying the title. Existing frontend i18n keys already include `reports.categoryReport` in EN/RU locale files.
+  - [ ] Search the backend for the old hardcoded Russian string and verify it is gone from service output.
+
+- [ ] Add focused backend tests. (AC: 1, 3, 4, 5)
+  - [ ] Add service-level tests for `ReportService.GetCategoriesReportData` in `inex.Services.Tests` if a suitable fixture/pattern exists; otherwise add API integration coverage in `inex.Tests` through `GET /api/reports/category`.
+  - [ ] Test that a transaction tied to an inactive, user-owned category appears in the category report output.
+  - [ ] Test that transactions for another user's categories are not included.
+  - [ ] Test that `TotalIncome` and `TotalOutcome` are populated from converted transaction amounts and follow the `BudgetReportService` positive/absolute-negative pattern.
+  - [ ] Test that service/API output no longer contains the hardcoded Russian title string.
+  - [ ] Keep tests independent from dashboard UI, Reports hub redesign, and Epic 10 visual behavior.
+
+- [ ] Verify backend scope. (AC: 5)
+  - [ ] Run the focused report/category test scope while iterating.
+  - [ ] Run `dotnet build inex.sln`.
+  - [ ] Run relevant `dotnet test` scope; full `dotnet test inex.sln` is preferred if practical.
+
+## Dev Notes
+
+### Source Requirements
+
+- Epic 6 is dashboard and spending-insights work, but Story 6.5 is a separate backend report correctness story for BUG-005, BUG-006, and BUG-007. It must remain independently testable from dashboard UI work. [Source: `docs/planning/epics.md`, Epic 6 Story 6.5]
+- PRD `IR-REPORT-001` requires category spending reports to include transactions for all user-owned categories, avoid silently excluding inactive categories, and populate `TotalIncome` and `TotalOutcome`. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]
+- PRD `IR-REPORT-002` requires hardcoded report title text in `ReportService` to be removed or localized so services do not emit user-visible hardcoded language strings. [Source: `docs/planning/prds/prd-inex-2026-05-20/prd.md`]
+- The sprint change proposal explicitly says Epic 6 can stay in place only if report data integrity fixes remain explicit and independently testable. [Source: `docs/planning/sprint-change-proposal-2026-05-26.md`]
+- The implementation readiness report calls out the same boundary: preserve Story 6.5 as a separate story with service/API tests and localization verification. [Source: `docs/planning/implementation-readiness-report-2026-05-26.md`]
+
+### Dependencies
+
+- Depends on the existing reports API path: `GET /api/reports/category` in `ReportsController`. The user's requested URL in the epic says `/api/reports/categories`; the current route constant is `category`, so implement against the existing route unless a separate contract-change story changes it.
+- Depends on current service/repository ownership predicates being preserved. All report aggregation must remain scoped to `userId`.
+- Depends on existing exchange-rate conversion behavior through `IExchangeRateService.Get(userId, start, end, currency, ct)`. This story does not change exchange-rate provider selection or add net-worth logic.
+- Story 6.4 historical net worth depends on Epic 5 rates work, but Story 6.5 is independent from Story 6.4 and should not add net-worth endpoints, dashboard cards, or charts.
+
+### Current State Analysis
+
+`inex.Services/Services/ReportService.cs`
+
+- `GetCategoriesReportData` reads start/end from the reports filter DSL, loads exchange rates, accounts, active categories, and all transactions in the date range.
+- It currently calls `_categoryService.Get(userId, ActivityMode.ACTIVE)`, filters out system categories, and builds `categoryIds` from that active-only set. This is the source of the inactive-category data gap.
+- It currently builds metadata with `BuildReportDataResponse(..., "Расходы по категориям", ...)`. The literal title is hardcoded service-language output and must be removed or replaced with a translation key.
+- It sums `categoryValues` only when `categoryIds.Contains(transaction.CategoryId)`, so transactions tied to inactive categories are omitted even though `_transactionService.Get(userId, ActivityMode.ALL, filters)` returns them.
+- It returns `Data` rows with `Value != 0`, but leaves `Metadata.TotalIncome` and `Metadata.TotalOutcome` at their default `0`.
+
+`inex.Services/Services/Base/Service.cs`
+
+- `BuildReportDataResponse` only sets `Name`, `Currency`, `Start`, and `End`. It does not accept totals. This helper is not enough for Story 6.5 unless callers override metadata after calculating totals.
+- Avoid broad helper changes unless needed. A local explicit `PagedResponse<CategorySummary, ReportMetadata>` construction in `ReportService` is likely lower risk and mirrors `BudgetReportService`.
+
+`inex.Services/Services/BudgetReportService.cs`
+
+- `GetBudgetComparison` shows the desired totals pattern:
+  - positive converted transaction amounts increment `totalIncome`,
+  - negative converted transaction amounts increment `totalOutcome` using `Math.Abs(amountInTargetCurrency)`,
+  - system transactions are excluded from totals.
+- It also uses `ActivityMode.ALL` for transactions and categories when the report must reason over historical data.
+
+`inex/Controllers/ReportsController.cs`
+
+- Category report route is currently `GET api/reports/category`.
+- It parses the legacy report filter DSL with `FilterHelper.ParseFilter(filter, ReportMetadata.FieldsList)` and passes the parsed filters to `IReportService.GetCategoriesReportData`.
+- Do not convert this endpoint to typed query params in this story; report typed query migration is Epic 7.4c scope.
+
+`inex.Services/Models/Records/Data/ReportMetadata.cs`
+
+- `ReportMetadata` currently includes `Name`, `Currency`, `Start`, `End`, `TotalIncome`, and `TotalOutcome`.
+- `Name` is part of the existing API shape. If choosing the translation-key option, keep the shape stable and set `Name = "reports.categoryReport"`.
+
+### Implementation Guidance
+
+- Prefer changing `ReportService.GetCategoriesReportData` to load categories with `ActivityMode.ALL`, then exclude only `IsSystem` categories from report rows and totals.
+- Keep conversion behavior aligned with current report services:
+  - resolve account currency from loaded accounts,
+  - use exact date rate when available and non-zero,
+  - if no rate exists, current category report behavior uses the transaction amount unchanged. Preserve or deliberately align with `BudgetReportService` fallback behavior, then cover with tests.
+- Be explicit about sign handling:
+  - totals use income positive, outcome absolute-negative,
+  - category row values should preserve the existing report's expectations unless tests and frontend behavior prove a safer normalization is needed.
+- Avoid changing serialized property names, response wrappers, routes, or frontend model names unless necessary for AC4. A translation key in `Metadata.Name` is the safest compatibility option.
+- Preserve cancellation-token flow through the report and exchange-rate calls.
+
+### Epic 6 / Epic 10 Guardrails
+
+- This story is backend report correctness and localization cleanup only.
+- Do not build or modify dashboard routes, month summary cards, heatmaps, historical net-worth charts, report hub chrome, drill-down chrome, visual design, mobile navigation, shared primitives, responsive visual QA baselines, or chart accessibility summaries.
+- Do not create Epic 10 stories or modify existing Epic 10 story files.
+- Do not add frontend design-system scope. Epic 10 owns final dashboard/report visual design, Reports hub and drill-down chrome, shell/navigation behavior, mobile navigation, shared primitives, responsive visual QA, and chart accessibility polish.
+- This story may mention frontend i18n only to preserve the backend contract around translation keys; it must not redesign the Reports UI.
+
+### Files Likely to Change
+
+- `inex.Services/Services/ReportService.cs` - fix category inclusion, totals, and report metadata title behavior.
+- `inex.Services.Tests/...` - add focused `ReportService` tests if a practical service-test pattern exists.
+- `inex.Tests/Reports/...` or similar - add API integration coverage if service-level testing is impractical.
+
+Files to avoid unless an implementation blocker requires them:
+
+- `inex/ClientApp/**` - no frontend implementation is required for this backend story.
+- `docs/implementation/10-*.md` - Epic 10 story files are out of scope.
+- `inex.Services/Services/Base/Service.cs` - avoid broad helper changes unless they reduce risk and are covered by tests.
+- `inex/Controllers/ReportsController.cs` - avoid route/filter-contract changes.
+
+### Testing Requirements
+
+- Add regression coverage for the three defects:
+  - inactive category transactions included,
+  - totals populated,
+  - hardcoded Russian service string absent.
+- Include an ownership regression: another user's inactive category/transaction must not appear in the current user's category report.
+- Use existing backend test patterns:
+  - `inex.Services.Tests` for service logic with mocked dependencies where available,
+  - `inex.Tests` with `InExWebApplicationFactory` for authenticated API behavior.
+- Required final backend checks:
+  - `dotnet build inex.sln`
+  - relevant `dotnet test` scope, preferably `dotnet test inex.sln` if practical.
+
+### References
+
+- `docs/planning/epics.md` - Epic 6 Story 6.5 source of record.
+- `docs/planning/prds/prd-inex-2026-05-20/prd.md` - `IR-REPORT-001`, `IR-REPORT-002`, BUG-005, BUG-006, BUG-007.
+- `docs/planning/sprint-change-proposal-2026-05-26.md` - Epic 6 report integrity guardrail.
+- `docs/planning/implementation-readiness-report-2026-05-26.md` - Story 6.5 separate-testability recommendation.
+- `docs/planning/design-update-plan.md` and `docs/planning/ux-design.md` - Epic 10 design scope boundaries; not implementation input for this backend story.
+- `docs/planning/architecture.md` - backend service/repository, API, test, and Epic 10 boundary guidance.
+- `docs/project-context.md` - durable backend testing, ownership, API compatibility, and report calculation rules.
+- `inex.Services/Services/ReportService.cs` - current category report implementation.
+- `inex.Services/Services/BudgetReportService.cs` - explicit totals pattern to mirror.
+- `inex.Services/Services/Base/Service.cs` - current report metadata helper.
+- `inex/Controllers/ReportsController.cs` - current category report route and filter parsing.
+- `inex.Services/Models/Records/Data/ReportMetadata.cs` - metadata fields used by report responses.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+### Completion Notes List
+
+- Story context created via bmad-create-story workflow for key `6-5-backend-fix-category-report-data-gaps-and-localization`.
+- Story status set to `ready-for-dev`.
+- Story intentionally remains independent from dashboard UI and Epic 10 visual/report hub work.
+- Sprint status was not updated because this orchestration run was constrained to create exactly one story file.
+
+### File List
+
+- docs/implementation/6-5-backend-fix-category-report-data-gaps-and-localization.md

--- a/docs/operations/mysql-backups.md
+++ b/docs/operations/mysql-backups.md
@@ -1,0 +1,150 @@
+# MySQL Backups
+
+## Current Setup
+
+- Host: production EC2 Ubuntu instance.
+- Database: MySQL 8 running in Docker container `inex-mysql`.
+- Backup script: `/home/ubuntu/inex/backup.sh`.
+- Schedule user: `ubuntu`.
+- Log file: `/home/ubuntu/inex/backup.log`.
+- S3 bucket: `inex-db-backups-135501091093-eu-central-1-an`.
+- S3 prefix: `backups/`.
+- Retention: 30 days through an S3 lifecycle rule on the `backups/` prefix.
+
+## Cron
+
+The production backup is scheduled in the `ubuntu` user's crontab:
+
+```cron
+CRON_TZ=UTC
+0 2 * * * /home/ubuntu/inex/backup.sh >> /home/ubuntu/inex/backup.log 2>&1
+```
+
+This runs daily at 02:00 UTC. Keep the log under `/home/ubuntu/inex/`; the `ubuntu` user may not be able to create files under `/var/log`.
+
+To inspect or edit the schedule:
+
+```bash
+crontab -l
+crontab -e
+```
+
+`sudo crontab -l` checks root's crontab and is expected to be empty unless root-specific jobs are added later.
+
+## Backup Script Contract
+
+`/home/ubuntu/inex/backup.sh` must:
+
+- dump the `inex-mysql` database with `mysqldump`;
+- compress the dump with `gzip`;
+- upload it to `s3://inex-db-backups-135501091093-eu-central-1-an/backups/`;
+- emit useful success/failure output for cron logging;
+- use UTC timestamped filenames, not date-only filenames.
+
+Use timestamped filenames so same-day manual or test runs do not overwrite the same S3 object:
+
+```bash
+DATE=$(date -u +'%Y-%m-%dT%H-%M-%SZ')
+BACKUP_FILE="inex_${DATE}.sql.gz"
+```
+
+Expected object format:
+
+```text
+s3://inex-db-backups-135501091093-eu-central-1-an/backups/inex_2026-06-01T14-35-00Z.sql.gz
+```
+
+## Manual Backup
+
+Run the backup as the same user cron uses:
+
+```bash
+sudo -u ubuntu /home/ubuntu/inex/backup.sh
+echo $?
+```
+
+Exit code `0` means the script completed. Confirm the uploaded object:
+
+```bash
+aws s3 ls s3://inex-db-backups-135501091093-eu-central-1-an/backups/
+```
+
+## Debug Cron
+
+Check whether the job is installed:
+
+```bash
+crontab -l
+sudo crontab -l
+```
+
+Check whether cron is running:
+
+```bash
+sudo systemctl status cron
+```
+
+Start it if needed:
+
+```bash
+sudo systemctl enable --now cron
+```
+
+Inspect recent cron activity:
+
+```bash
+grep CRON /var/log/syslog | tail -100
+```
+
+Inspect backup output:
+
+```bash
+tail -100 /home/ubuntu/inex/backup.log
+```
+
+To test scheduling, temporarily add an every-minute line:
+
+```cron
+* * * * * /home/ubuntu/inex/backup.sh >> /home/ubuntu/inex/backup.log 2>&1
+```
+
+Wait one or two minutes, verify the log and S3 object, then remove the every-minute line immediately.
+
+## Restore Test
+
+Test restores against a non-production MySQL instance only.
+
+Download a backup:
+
+```bash
+aws s3 cp s3://inex-db-backups-135501091093-eu-central-1-an/backups/<backup-file>.sql.gz .
+```
+
+Restore into a local or disposable MySQL container:
+
+```bash
+gunzip -c <backup-file>.sql.gz | docker exec -i inex-mysql mysql -u root -p inex
+```
+
+Use the correct target database name for the restore environment. Do not pipe a production backup into the production container unless performing an intentional recovery.
+
+## IAM And Retention
+
+The EC2 instance role needs S3 write/list access for the backup bucket:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:PutObject", "s3:ListBucket"],
+  "Resource": [
+    "arn:aws:s3:::inex-db-backups-135501091093-eu-central-1-an",
+    "arn:aws:s3:::inex-db-backups-135501091093-eu-central-1-an/*"
+  ]
+}
+```
+
+The S3 bucket should block public access. A lifecycle rule should expire objects under `backups/` after 30 days.
+
+## Future Migration
+
+When RDS replaces EC2-hosted MySQL, this cron-based `mysqldump` mechanism is superseded by RDS automated backups. The RDS setup must document retention and restore testing before this cron job is removed.

--- a/docs/planning/epics.md
+++ b/docs/planning/epics.md
@@ -54,7 +54,7 @@ FR-INF-1: Docker multi-stage build + docker-compose
 FR-INF-2: GitHub Actions CI: build + test + coverage
 FR-INF-3: AWS E-track: ECR + EC2 t4g.small (ARM) + nginx + Let's Encrypt + Porkbun DNS
 FR-INF-4: CloudWatch structured logging via Serilog sink
-FR-INF-5: MySQL daily backup to S3 (30-day retention, 02:00 UTC cron)
+FR-INF-5: MySQL daily backup to S3 (30-day retention, 02:00 UTC cron; operational runbook: `docs/operations/mysql-backups.md`)
 FR-INF-6: Secrets in SSM Parameter Store; never in source
 
 **Section 5 — Roadmap (work to be done)**
@@ -114,7 +114,7 @@ NFR-PERF-1: All filtering must execute database-side before count and pagination
 NFR-PERF-2: Cold-cache yearly report triggers ≤2 external exchange rate API calls
 NFR-PERF-3: Frontend initial bundle ≤ 500 KB minified per Vite threshold — currently violated (~1.9 MB)
 NFR-REL-1: Startup DB validation via EnsureDatabaseInitialized + /health endpoint
-NFR-REL-2: MySQL daily backup to S3 with 30-day retention
+NFR-REL-2: MySQL daily backup to S3 with 30-day retention; operational runbook: `docs/operations/mysql-backups.md`
 NFR-OBS-1: Structured JSON logs to CloudWatch via Serilog in production
 NFR-OBS-2: After DX-001 completes, dotnet build inex.sln produces zero CS1591 XML documentation warnings
 NFR-I18N-1: All user-visible strings through react-i18next; no hardcoded UI text

--- a/docs/planning/implementation-readiness-report-2026-06-01.md
+++ b/docs/planning/implementation-readiness-report-2026-06-01.md
@@ -1,0 +1,386 @@
+---
+stepsCompleted:
+  - document-discovery
+  - prd-analysis
+  - epic-coverage-validation
+  - ux-alignment
+  - epic-quality-review
+  - final-assessment
+includedFiles:
+  prd:
+    - docs/planning/prds/prd-inex-2026-05-20/prd.md
+  architecture:
+    - docs/planning/architecture.md
+  epics:
+    - docs/planning/epics.md
+  ux:
+    - docs/planning/ux-design.md
+---
+
+# Implementation Readiness Assessment Report
+
+**Date:** 2026-06-01
+**Project:** inex
+
+## Document Discovery
+
+### PRD Files Found
+
+**Whole Documents:** None.
+
+**Sharded Documents:**
+- Folder: `docs/planning/prds/prd-inex-2026-05-20/`
+  - `.decision-log.md` (5035 bytes, modified 2026-05-26 19:50:06)
+  - `prd.md` (21361 bytes, modified 2026-05-26 19:50:06)
+  - `review-quality.md` (6302 bytes, modified 2026-05-26 19:50:06)
+
+Selected for assessment: `docs/planning/prds/prd-inex-2026-05-20/prd.md`.
+
+### Architecture Files Found
+
+**Whole Documents:**
+- `docs/planning/architecture.md` (45001 bytes, modified 2026-06-01 16:46:21)
+
+**Sharded Documents:** None.
+
+### Epics & Stories Files Found
+
+**Whole Documents:**
+- `docs/planning/epics.md` (84148 bytes, modified 2026-06-01 17:30:52)
+
+**Sharded Documents:** None.
+
+### UX Design Files Found
+
+**Whole Documents:**
+- `docs/planning/ux-design.md` (702 bytes, modified 2026-05-26 19:50:06)
+
+**Sharded Documents:** None.
+
+### Discovery Issues
+
+- No whole-vs-sharded duplicate blockers found.
+- No required document category is missing.
+
+## PRD Analysis
+
+### Functional Requirements
+
+FR-AUTH-1: JWT authentication with refresh token rotation via HTTP-only cookie
+FR-AUTH-2: Invite-token gated registration
+FR-AUTH-3: Rate limiting on auth endpoints (5 req/IP/min)
+FR-AUTH-4: Profile management: update username, preferred currency, change password
+FR-AUTH-5: Language preference stored in JWT claims; EN/RU
+FR-AUTH-6: After registration, user receives a confirmation email (AWS SES in prod; LoggingEmailSender in dev)
+FR-AUTH-7: Account cannot be used until email address is confirmed
+FR-AUTH-8: `POST /api/auth/resend-confirmation` endpoint
+FR-AUTH-9: `GET /api/auth/confirm-email?userId=&token=` endpoint; on success, issues JWT and redirects to `/transactions`
+
+FR-ACC-1: Create, read, update, delete accounts per user
+FR-ACC-2: Per-account currency selection from supported currency list
+FR-ACC-3: Account status: active / inactive / closed
+FR-ACC-4: Closed account data integrity preserved across all report queries
+FR-ACC-5: Status panel: accounts grouped by currency; per-group subtotals; base-currency equivalents; MoM % change on total row
+
+FR-CAT-1: Create, read, update, delete user-defined categories
+FR-CAT-2: Active/inactive status toggle
+
+FR-TXN-1: Create, read, update, delete income / expense / transfer transactions
+FR-TXN-2: Transaction linked to account, category, date, amount, comment
+FR-TXN-3: Tags (`#hashtag`) and references (`@reference`) parsed from comment field on read; never stored separately
+FR-TXN-4: Transaction list: rows grouped by date; explicit +/- signs; neutral color for transfers
+FR-TXN-5: Column reorder; tags + comment merged into Notes column
+FR-TXN-6: Humanized date display (`D MMM` format)
+FR-TXN-7: CSV import (Fentury format) via ICSVService
+FR-TXN-8: Filtering by account, category, date range, tag, and ref; tag/ref filtering currently executes in-memory before pagination and is tracked by FR-DATA-001
+
+FR-BUD-1: Create, read, update, delete monthly budgets per category
+FR-BUD-2: Copy budgets from one month to another
+FR-BUD-3: Multiple budget entries per month supported
+
+FR-RATE-1: Date-based exchange rates via Frankfurter API (primary) with CurrencyAPI fallback
+FR-RATE-2: Batch range fetch: cold-cache yearly report triggers <=2 external API calls
+FR-RATE-3: In-process rate cache; stale dates fetched on demand
+FR-RATE-4: NBRB exchange rate client: BYN + RUB via single range call
+
+FR-RPT-1: Monthly history report: income and expense by month
+FR-RPT-2: Budget comparison report: planned vs. actual by category
+FR-RPT-3: Category spending report; TotalIncome/TotalOutcome not populated and inactive-category transactions silently excluded
+
+FR-I18N-1: Full EN/RU UI via react-i18next + Ant Design locale
+FR-I18N-2: Machine-readable FluentValidation error codes (`field.rule` format); frontend translates
+
+FR-INF-1: Docker multi-stage build + docker-compose
+FR-INF-2: GitHub Actions CI: build + test + coverage
+FR-INF-3: AWS E-track: ECR + EC2 t4g.small (ARM) + nginx + Let's Encrypt + Porkbun DNS
+FR-INF-4: CloudWatch structured logging via Serilog sink
+FR-INF-5: MySQL daily backup to S3 (30-day retention, 02:00 UTC cron)
+FR-INF-6: Secrets in SSM Parameter Store; never in source
+
+FR-SEC-001: All single-item reads, updates, and deletes must constrain by authenticated `UserId` in AccountService, CategoryService, BudgetService, TransactionService
+FR-SEC-002: Refresh token rotation must be safe under concurrent requests; only one refresh per token via optimistic concurrency or conditional DB update
+FR-SEC-003: Credentials in `.env` (DB password, exchange API key) must be rotated; replaced by user-secrets or SSM injection locally
+
+FR-DATA-001: Transaction tag/ref filtering must execute database-side before `Count`, `Skip`, and `Take`; `AsEnumerable` removed from filter path
+FR-DATA-002: Remove tracked frontend build output from git (`git rm --cached -r inex/ClientApp/build`)
+
+FR-FE-001: Active filter indicator on transaction list: visual cue when any filter is applied
+FR-FE-002: Month summary cards on dashboard home: total income, total expenses, net savings, MoM delta for each
+FR-FE-003: Dashboard home page established as app landing; Reports navigation restructured
+FR-FE-004: Spending heatmap calendar: GitHub-style daily spend grid on Reports
+FR-FE-005: Shared frontend DTO/model types for accounts, categories, budgets, transactions, reports; `any` eliminated from core transaction and Redux flows
+FR-FE-006: Transaction filter string DSL replaced with typed query parameters; frontend uses `URLSearchParams`; backend accepts standard query params
+FR-FE-007: Route-based lazy loading + vendor chunk split; main bundle warning resolved
+FR-FE-008: RTK Query replaces manual Axios thunks across all domain slices
+FR-FE-009: Vitest + React Testing Library test suite introduced
+
+FR-ARCH-001: Repository disposal must not manually dispose a DI-managed `DbContext`; data access boundary decision documented
+FR-ARCH-002: UTC timestamp consistency: injectable clock abstraction; persisted timestamps use UTC throughout; EF seed data uses fixed constants
+FR-ARCH-003: Vertical Slice Architecture spike: CopyBudgets implemented as MediatR/CQRS handler alongside existing layered architecture
+
+FR-HIST-001: Historical account value report: net worth over time chart with period-accurate exchange rates
+FR-DX-001: Build warning noise reduced; XML doc warning baseline cleaned; future warning policy documented
+
+FR-AWS-001: ECR: Docker image push from CI
+FR-AWS-002: RDS: managed MySQL replacing EC2-hosted MySQL
+FR-AWS-003: ECS Fargate: container deployment replacing EC2 Docker stack
+FR-AWS-004: ALB + ACM: HTTPS termination at load balancer
+FR-AWS-005: Route 53: custom domain management
+FR-AWS-006: Secrets Manager: runtime secret injection replacing SSM Parameter Store
+FR-AWS-007: CloudWatch: logs + alarms + dashboard
+FR-AWS-008: CI/CD: GitHub Actions -> ECR -> ECS rolling deploy
+
+FR-UX-001: Production frontend implements the `docs/design` shell: sticky desktop top nav, mobile bottom nav, page header, brand mark, user pill, and no app footer inside authenticated routes
+FR-UX-002: Frontend design tokens and shared primitives are introduced for money values, buttons, icon buttons, drawers, segmented controls, empty states, progress, and responsive layout
+FR-UX-003: Transactions page is rebuilt as a ledger-first workspace with KPI strip, grouped day rows, active filter chips, advanced filter drawer, and mobile stacked rows
+FR-UX-004: Accounts, Categories, and Budgets are rebuilt as dense management workspaces using the new hero, grouping, toolbar, row, drawer, and empty-state patterns
+FR-UX-005: Reports hub, dashboard landing, and report drill-down chrome follow the design guide, including chart accessibility and export/share/print action placement
+FR-UX-006: Profile, settings, login, and registration screens follow the design guide, include production validation/loading/error states, and fix mobile profile overflow
+FR-UX-007: Converted pages pass the documented visual QA matrix at 1440px, 1024px, 390px, and 360px where applicable
+
+IR-REPORT-001: Category spending report includes transactions for all user-owned categories; inactive categories are not silently excluded; `TotalIncome` and `TotalOutcome` are populated.
+IR-REPORT-002: Hardcoded report title text in `ReportService` is removed or localized so services do not emit user-visible hardcoded language strings.
+IR-DTO-001: Remaining DTO naming and response/request hierarchy issues are cleaned up without changing serialized API contracts unless explicitly planned.
+IR-CODE-001: Minor service/model quality traps are cleaned up, including `PagedResponse` metadata safety, service helper visibility, and validator naming alignment.
+
+Total FR/IR items: 91
+
+### Non-Functional Requirements
+
+NFR-SEC-1: All user-owned data queries must include `UserId` ownership predicate
+NFR-SEC-2: API authentication is JWT-based; backend is authoritative; frontend ProtectedRoute is UX-only
+NFR-SEC-3: Secrets must not appear in committed source, logs, comments, or screenshots
+NFR-SEC-4: HSTS in production; standard security headers in all environments
+
+NFR-PERF-1: All filtering (pagination, date range, tag/ref) must execute database-side before count and pagination
+NFR-PERF-2: Cold-cache yearly report triggers <=2 external exchange rate API calls
+NFR-PERF-3: Frontend initial bundle <= 500 KB minified per Vite threshold
+
+NFR-REL-1: Startup DB validation via `EnsureDatabaseInitialized` + `/health` endpoint
+NFR-REL-2: MySQL daily backup to S3 with 30-day retention
+
+NFR-OBS-1: Structured JSON logs to CloudWatch via Serilog in production
+NFR-OBS-2: After DX-001 completes, `dotnet build inex.sln` produces zero CS1591 XML documentation warnings in default build output
+
+NFR-I18N-1: All user-visible strings through react-i18next; no hardcoded UI text
+NFR-I18N-2: Backend validation errors return machine-readable codes (`field.rule`), not prose strings
+
+NFR-TEST-1: Unit tests cover service logic, mappers, external client adapters (inex.Services.Tests)
+NFR-TEST-2: Integration tests cover auth flows, validation, authorization, RFC 7807 contracts, cross-user access denial (inex.Tests)
+NFR-TEST-3: EF InMemory must not be the sole coverage for MySQL-specific behavior
+
+NFR-UX-1: Money values use tabular numerics, clear income/expense/transfer semantics, and a color-independent signage option
+NFR-UX-2: Authenticated app routes have no horizontal overflow at 390px or 360px mobile widths
+NFR-UX-3: Drawers, segmented controls, tabs, icon buttons, and navigation are keyboard accessible and screen-reader labeled
+NFR-UX-4: Design changes are made through shared tokens and primitives first; page-specific one-off styling is avoided unless documented
+
+Total NFRs: 21
+
+### Additional Requirements
+
+- Non-owner production usage determines whether FR-SEC-001 is an unscheduled hotfix.
+- Current phase excludes open SaaS/public registration, native mobile apps, automatic bank feed/API transaction import, and multi-currency accounting within a single account.
+- Invite-only registration and per-user data isolation are core constraints.
+- Known active bugs BUG-001 through BUG-010 are explicitly tied to implementation requirements or deferred work.
+- Delivery sequencing prioritizes security/data integrity before frontend and infrastructure expansion.
+
+### PRD Completeness Assessment
+
+The PRD is complete enough for traceability validation. It has explicit FR, IR, and NFR identifiers, known bug mappings, delivery order, and open assumptions. The key readiness risk is not missing PRD requirements; it is ensuring epics/stories preserve boundaries between security, Epic 6 dashboard/report data, Epic 7 frontend technical modernization, and Epic 10 visual rebuild work.
+
+## Epic Coverage Validation
+
+### Coverage Matrix
+
+| FR Number | PRD Requirement | Epic Coverage | Status |
+| --- | --- | --- | --- |
+| FR-AUTH-1 | JWT authentication with refresh token rotation via HTTP-only cookie | Production baseline inventory | Covered |
+| FR-AUTH-2 | Invite-token gated registration | Production baseline inventory | Covered |
+| FR-AUTH-3 | Rate limiting on auth endpoints | Production baseline inventory | Covered |
+| FR-AUTH-4 | Profile management | Production baseline inventory; Epic 10 visual redesign | Covered |
+| FR-AUTH-5 | Language preference in JWT claims; EN/RU | Production baseline inventory; Epic 10 i18n preservation | Covered |
+| FR-AUTH-6 | Confirmation email after registration | Epic 3 | Covered |
+| FR-AUTH-7 | Account cannot be used until email confirmed | Epic 3 | Covered |
+| FR-AUTH-8 | Resend confirmation endpoint | Epic 3 | Covered |
+| FR-AUTH-9 | Confirm email endpoint and redirect | Epic 3 | Covered |
+| FR-ACC-1 through FR-ACC-5 | Accounts CRUD, status, currency, closed-account report integrity, status panel | Production baseline inventory; Epic 10 visual redesign for Accounts; IR coverage where report integrity applies | Covered |
+| FR-CAT-1 through FR-CAT-2 | Categories CRUD and active/inactive status | Production baseline inventory; Epic 10 visual redesign for Categories; Epic 6 report integrity fixes for inactive-category reporting | Covered |
+| FR-TXN-1 through FR-TXN-8 | Transaction CRUD, tags/refs, display, import, filters | Production baseline inventory; Epic 4 for DB-side filters and active indicator; Epic 10 visual redesign for Transactions | Covered |
+| FR-BUD-1 through FR-BUD-3 | Budget CRUD, copy, multiple entries | Production baseline inventory; Epic 10 visual redesign for Budgets | Covered |
+| FR-RATE-1 through FR-RATE-3 | Existing exchange-rate behavior | Production baseline inventory | Covered |
+| FR-RATE-4 | NBRB range client for BYN/RUB | Epic 5 | Covered |
+| FR-RPT-1 through FR-RPT-3 | Monthly history, budget comparison, category spending reports | Production baseline inventory; Epic 6 for report expansion and report data defects; Epic 10 visual reports chrome | Covered |
+| FR-I18N-1 through FR-I18N-2 | EN/RU UI and machine-readable validation errors | Production baseline inventory; Epic 10 i18n preservation; NFR-I18N coverage | Covered |
+| FR-INF-1 through FR-INF-6 | Docker, CI, EC2 production, CloudWatch, S3 backups, SSM secrets | Production baseline inventory; Epic 9 supersedes selected infrastructure paths | Covered |
+| FR-SEC-001 | Owned-entity authorization on single-item operations | Epic 1 | Covered |
+| FR-SEC-002 | Concurrent refresh-token safety | Epic 1 | Covered |
+| FR-SEC-003 | Local credential rotation/externalization | Epic 1; superseded by Epic 9 Secrets Manager for production | Covered |
+| FR-DATA-001 | Database-side transaction tag/ref filtering | Epic 4 | Covered |
+| FR-DATA-002 | Remove tracked frontend build output | Epic 1 | Covered |
+| FR-FE-001 | Active transaction filter indicator | Epic 4 | Covered |
+| FR-FE-002 | Dashboard month-summary cards | Epic 6; Epic 10 final visual treatment | Covered |
+| FR-FE-003 | Dashboard landing and Reports nav restructure | Epic 6; Epic 10 final visual treatment | Covered |
+| FR-FE-004 | Spending heatmap calendar | Epic 6 | Covered |
+| FR-FE-005 | Shared frontend model types and `any` cleanup | Epic 7 | Covered |
+| FR-FE-006 | Typed transaction query parameters | Epic 4 | Covered |
+| FR-FE-007 | Route-based lazy loading and chunk split | Epic 7 | Covered |
+| FR-FE-008 | RTK Query migration | Epic 7 | Covered |
+| FR-FE-009 | Vitest + React Testing Library | Epic 7 | Covered |
+| FR-ARCH-001 | Repository disposal/data boundary | Epic 2 | Covered |
+| FR-ARCH-002 | UTC timestamp consistency | Epic 2 | Covered |
+| FR-ARCH-003 | VSA/MediatR spike | Epic 8 | Covered |
+| FR-HIST-001 | Historical account value report | Epic 6 | Covered |
+| FR-DX-001 | Build warning cleanup | Epic 8 | Covered |
+| FR-AWS-001 through FR-AWS-008 | ECS/Fargate migration track | Epic 9 | Covered |
+| FR-UX-001 | App shell and navigation redesign | Epic 10 Story 10.1c | Covered |
+| FR-UX-002 | Design tokens and shared primitives | Epic 10 Stories 10.1a and 10.1b | Covered |
+| FR-UX-003 | Transactions ledger redesign | Epic 10 Story 10.2 | Covered |
+| FR-UX-004 | Accounts/Categories/Budgets redesign | Epic 10 Stories 10.3a, 10.3b, 10.3c | Covered |
+| FR-UX-005 | Reports hub, dashboard landing, drill-down chrome | Epic 10 Story 10.4; consumes Epic 6 data work | Covered |
+| FR-UX-006 | Profile/settings/auth redesign | Epic 10 Stories 10.5a and 10.5b | Covered |
+| FR-UX-007 | Visual QA matrix | Epic 10 Story 10.6 | Covered |
+| IR-REPORT-001 | Category report inactive-category and totals fix | Epic 6 Story 6.5 | Covered |
+| IR-REPORT-002 | Hardcoded report title i18n fix | Epic 6 Story 6.5 | Covered |
+| IR-DTO-001 | DTO naming and response/request hierarchy cleanup | Epic 8 | Covered |
+| IR-CODE-001 | Minor service/model safety cleanup | Epic 8 | Covered |
+
+### Missing Requirements
+
+No PRD FR/IR IDs are missing from `docs/planning/epics.md`.
+
+### Coverage Statistics
+
+- Total PRD FR/IR items assessed: 91
+- FR/IR items covered in epics or production-baseline inventory: 91
+- Coverage percentage: 100%
+
+### Coverage Notes
+
+- The production-baseline FRs are not all assigned to future implementation epics because the PRD marks them as already implemented. That is acceptable for readiness, provided future stories preserve those behaviors.
+- The key Epic 10 boundary risk has been reduced by the story-file fixes: Story 10.4 now explicitly consumes Epic 6 dashboard/report data work instead of recreating it.
+
+## UX Alignment Assessment
+
+### UX Document Status
+
+Found. `docs/planning/ux-design.md` is an index that intentionally points validators to:
+
+- `docs/design/docs/design-implementation-guide.md`
+- `docs/planning/design-update-plan.md`
+- `docs/planning/epics.md`, Epic 10
+
+### Alignment Issues
+
+- PRD FR-UX-001 through FR-UX-007 align with Epic 10 and the design implementation guide: shell/navigation, tokens/primitives, Transactions, management pages, Reports/Dashboard chrome, Profile/Auth, and visual QA are all represented.
+- Architecture now supports Epic 10 through the frontend architecture addendum: token/theme bridge, primitive ownership, shell/routing migration, responsive QA, dependency policy, i18n/accessibility/error handling, and coexistence with Redux/Axios/Ant Design are documented.
+- The updated story files now better align with UX and architecture:
+  - 10.1b owns responsive layout helpers and localized primitive screen-reader text.
+  - 10.3b no longer assumes primitive names that conflict with 10.1b and blocks rather than creating local `DistributionBar`.
+  - 10.4 explicitly consumes Epic 6 dashboard/report data work and owns only final visual/chrome treatment.
+  - 10.5b now requires complete EN/RU auth-shell and API-error localization and blocks on 10.1b for `lucide-react`.
+  - 10.6 now includes visual QA command capture and known-exception handling.
+
+### Warnings
+
+- `docs/design/docs/design-implementation-guide.md` now points backlog mapping to Epic 10, matching `ux-design.md`, `design-update-plan.md`, `architecture.md`, and `epics.md`.
+- The production design guide recommends an illustrative `src/design-system` structure, while current story files use `src/components/primitives`. This is acceptable because the architecture addendum and 10.1b story establish the production path, but future story authors should treat the guide structure as conceptual, not literal.
+- Epic 10 remains sequence-sensitive. UX alignment depends on 10.1a/10.1b/10.1c being completed before page conversion stories begin.
+
+## Epic Quality Review
+
+### Critical Violations
+
+None found after the Epic 10 story-file fixes.
+
+### Major Issues
+
+1. **Epic 10 implementation is not ready as a whole because sprint status still shows every Epic 10 story as `ready-for-dev`, not `done`.**
+   - Evidence: `docs/implementation/sprint-status.yaml` lists 10.1a through 10.6 as `ready-for-dev`.
+   - Impact: Downstream Epic 10 page stories correctly depend on 10.1a/10.1b/10.1c outputs, so only 10.1a can start immediately.
+   - Remediation: Implement in fixed order. Do not start 10.1c or page stories until the prerequisite stories are accepted as `done`.
+
+2. **Some epics are technical or operational rather than purely user-outcome framed.**
+   - Epic 2, Epic 7, Epic 8, and Epic 9 are largely architecture/frontend-quality/infrastructure epics.
+   - This is acceptable for the current brownfield PRD because the PRD explicitly includes production hardening, learning, AWS migration, performance, and maintainability as product goals, but these epics should keep user-facing rationale visible in story handoff notes.
+   - Remediation: Preserve current user-value statements and avoid reducing these epics to task lists during story creation.
+
+3. **Epic 10 still depends on prior epics for safe execution.**
+   - Epic 10 depends on Epic 1 for broad UI rollout safety, Epic 4 for transaction filtering semantics, Epic 6 for dashboard/report functional data, and Epic 7 Story 7.1 before TypeScript-heavy rebuild work where possible.
+   - These are backward dependencies, not forward dependencies, so the sequence is valid.
+   - Remediation: Keep prerequisite gates explicit in story files. The updated Epic 10 story files now do this more consistently.
+
+### Minor Concerns
+
+1. **Production-baseline FRs are inventoried rather than assigned to future stories.**
+   - This is acceptable because the PRD marks them as already implemented.
+   - Remediation: Future stories must preserve baseline behavior explicitly when touching those areas.
+
+2. **Visual QA evidence remains manual-heavy.**
+   - Story 10.6 documents a repeatable manual/Playwright-assisted workflow, but not a committed automated visual regression suite.
+   - Remediation: Accept for Epic 10 baseline; consider automation after the manual baseline stabilizes.
+
+### Best Practices Compliance Checklist
+
+| Epic | User value | Independent/backward-only dependencies | Story sizing | AC quality | Traceability | Result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Epic 1 Security & Production Hygiene | Strong | Yes | Good | Testable | Strong | Pass |
+| Epic 2 Safer Data Access And Reliable Time Behavior | Technical but justified | Backward-only | Good | Testable | Strong | Pass with framing caution |
+| Epic 3 Email Verification | Strong | Backward-only | Good | Testable | Strong | Pass |
+| Epic 4 Transaction Filtering Quality | Strong | Backward-only | Good | Testable | Strong | Pass |
+| Epic 5 Exchange Rate Expansion | Strong | Backward-only | Good | Testable | Strong | Pass |
+| Epic 6 Dashboard & Spending Insights | Strong | Backward-only | Good | Testable | Strong | Pass |
+| Epic 7 Faster, Safer Frontend Evolution | Technical but PRD-backed | Backward-only | Good | Testable | Strong | Pass with framing caution |
+| Epic 8 Maintainable Backend Change And Clean Build Signal | Technical but PRD-backed | Backward-only | Good | Testable | Strong | Pass with framing caution |
+| Epic 9 Managed Production Operations | Operational but PRD-backed | Backward-only | Good | Testable | Strong | Pass with framing caution |
+| Epic 10 Frontend Design System Rebuild | Strong | Backward-only | Good after fixes | Testable | Strong | Pass for story readiness after fixes; implementation still sequence-gated |
+
+## Summary and Recommendations
+
+### Overall Readiness Status
+
+NEEDS WORK for full Epic 10 development.
+
+READY for the first Epic 10 development story only: `docs/implementation/10-1a-frontend-ux-design-tokens-and-theme-bridge.md`.
+
+### Critical Issues Requiring Immediate Action
+
+No critical document-coverage issues remain after the story-file fixes. PRD FR/IR coverage is complete, UX/architecture alignment is sufficient, and the design implementation guide exists.
+
+### Issues Requiring Attention
+
+1. **Epic 10 is sequence-gated.** `docs/implementation/sprint-status.yaml` still shows all Epic 10 stories as `ready-for-dev`, not `done`. Downstream stories cannot start until prerequisites are actually implemented.
+2. **Epic 10 depends on prior completed work.** Story 10.4 must wait for Epic 6 dashboard/report data work; 10.5b must wait for 10.4 before final `/dashboard` redirects; 10.6 must wait for all 10.1a through 10.5b stories.
+3. **Technical/operational epics need value framing preserved.** Epics 2, 7, 8, and 9 are PRD-backed but technical in nature; story handoffs should keep user/production value explicit.
+
+### Recommended Next Steps
+
+1. Start implementation with Story 10.1a only.
+2. After 10.1a is `done`, run or revalidate Story 10.1b before implementation because it owns primitive contracts, responsive helpers, and `lucide-react`.
+3. Keep the fixed Epic 10 order: 10.1a -> 10.1b -> 10.1c -> 10.2 -> 10.3a/10.3b/10.3c -> 10.4 -> 10.5a/10.5b -> 10.6.
+4. Before 10.4, verify Epic 6 Stories 6.1, 6.2, and 6.5 are merged or explicitly accepted as complete where their data surfaces affect dashboard/report chrome.
+### Final Note
+
+This assessment identified 3 issues across sequencing, dependency readiness, and epic framing. None are PRD coverage blockers. The artifacts are ready to begin Epic 10 at Story 10.1a, but the full epic is not ready for parallel development until prerequisite stories are completed in order.
+
+Assessor: Codex using `bmad-check-implementation-readiness`
+Date: 2026-06-01


### PR DESCRIPTION
## Summary
- Add Epic 6 implementation story files for dashboard, reporting, heatmap, net worth, and category report fixes.
- Add the MySQL backup operations runbook and link it from planning requirements.
- Refine Epic 10 story readiness guidance and add the 2026-06-01 implementation readiness report.

## Review Notes
- Grouped into three commits by scope: Epic 6 stories, operations runbook, Epic 10 readiness.
- Includes the design implementation guide so the Epic 10 backlog reference is tracked with the readiness update.

## Verification
- `git diff --check`
- Targeted text scans for the prior Epic 10 readiness issues

Docs-only change; application tests were not run.