### PR TITLE
[docs] Document local project startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,33 +24,35 @@ docs/                   Learning plan, architecture docs
 
 ## Dev Commands
 
-**Start everything:**
+For full local startup instructions, see `README.md`.
+
+**Start local dependencies** (from repo root):
 ```powershell
-./start-project.ps1   # starts both backend and frontend
+docker compose up -d mysql
 ```
 
 **Backend only** (from repo root):
-```bash
+```powershell
 dotnet watch run --project inex
 ```
 Swagger UI: `http://localhost:5000/help`
 
 **Frontend only** (from `inex/ClientApp/`):
-```bash
+```powershell
 npm start       # Vite dev server, proxies /api → localhost:5000
 npm run build   # tsc --noEmit && vite build
 npm run lint
 ```
 
 **Tests:**
-```bash
+```powershell
 dotnet test                         # all projects
 dotnet test inex.Services.Tests/    # unit only
 dotnet test inex.Tests/             # integration only
 ```
 
 **Migrations** (from repo root):
-```bash
+```powershell
 dotnet ef migrations add <Name> --project inex.Data --startup-project inex
 dotnet ef database update           --project inex.Data --startup-project inex
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,123 @@
+# InEx
+
+InEx is a multi-user personal finance management web application. The backend is ASP.NET Core 8 with EF Core and MySQL. The frontend is a React 18 + TypeScript + Vite SPA.
+
+## Local Development
+
+### Prerequisites
+
+- .NET 8 SDK
+- Node.js and npm
+- Docker Desktop or another Docker Compose runtime
+- A CurrencyAPI key for exchange-rate lookups
+
+### First-Time Setup
+
+Create local environment settings for Docker Compose:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Edit `.env` and set non-placeholder values for:
+
+- `DB_ROOT_PASSWORD`
+- `DB_PASSWORD`
+- `JWT_SECRET`
+- `INVITE_TOKEN`
+- `CURRENCY_API_KEY`
+
+For local `dotnet watch` runs, set ASP.NET Core user-secrets from the repo root:
+
+```powershell
+dotnet user-secrets set "ConnectionStrings:InExConnection" "Server=localhost;Port=3306;Database=inex_db;Uid=inex_user;Pwd=<DB_PASSWORD>;Convert Zero Datetime=True" --project inex
+dotnet user-secrets set "JwtOptions:Secret" "<JWT_SECRET>" --project inex
+dotnet user-secrets set "JwtOptions:Issuer" "inex-api" --project inex
+dotnet user-secrets set "JwtOptions:Audience" "inex-client" --project inex
+dotnet user-secrets set "InviteOptions:Token" "<INVITE_TOKEN>" --project inex
+dotnet user-secrets set "CurrencyApiSettings:ApiKey" "<CURRENCY_API_KEY>" --project inex
+```
+
+Install frontend dependencies:
+
+```powershell
+Set-Location inex\ClientApp
+npm install
+Set-Location ..\..
+```
+
+### Start The App
+
+Use three terminals from the repo root.
+
+Terminal 1: start MySQL.
+
+```powershell
+docker compose up -d mysql
+```
+
+Terminal 2: start the backend.
+
+```powershell
+dotnet watch run --project inex
+```
+
+Terminal 3: start the frontend.
+
+```powershell
+Set-Location inex\ClientApp
+npm start
+```
+
+### Local URLs
+
+- Frontend: `http://localhost:3000`
+- Backend health check: `http://localhost:5000/health`
+- Swagger UI: `http://localhost:5000/help`
+- MySQL: `localhost:3306`
+
+The Vite dev server proxies `/api` requests to `http://localhost:5000`, so frontend API calls should use relative `/api/...` paths.
+
+### Stop Local Services
+
+Stop the backend and frontend with `Ctrl+C` in their terminals. Stop MySQL with:
+
+```powershell
+docker compose stop mysql
+```
+
+### Full Docker Compose Stack
+
+The repository also has a Docker Compose API service. For normal development, prefer the local backend/frontend commands above because they support hot reload. To build and run the API container with MySQL:
+
+```powershell
+docker compose up --build
+```
+
+The API container listens on `http://localhost:5000`.
+
+## Verification
+
+Backend:
+
+```powershell
+dotnet build inex.sln
+dotnet test inex.sln
+```
+
+Frontend:
+
+```powershell
+Set-Location inex\ClientApp
+npm run build
+npm run lint
+```
+
+## Migrations
+
+From the repo root:
+
+```powershell
+dotnet ef migrations add <Name> --project inex.Data --startup-project inex
+dotnet ef database update --project inex.Data --startup-project inex
+```

--- a/docs/implementation/10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist.md
+++ b/docs/implementation/10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist.md
@@ -39,7 +39,7 @@ This is the capstone story for Epic 10. **All of the following stories must reac
 
 **Check before starting:** every story above must be status `done` in `docs/implementation/sprint-status.yaml`. If any story is not `done`, do not start the final Epic 10 QA gate; send the incomplete story back to its owner first. Subset QA is allowed only as story-level evidence for an individual route story, not as completion evidence for Story 10.6.
 
-**Dev server must be running** with populated data. Use `./start-project.ps1` or run backend (`dotnet watch run --project inex`) and frontend (`npm start` from `inex/ClientApp/`) separately. Confirm `http://localhost:3000` loads and you can log in.
+**Dev server must be running** with populated data. Follow the local startup flow in `README.md`: start MySQL with Docker Compose, run the backend (`dotnet watch run --project inex`), and run the frontend (`npm start` from `inex/ClientApp/`). Confirm `http://localhost:3000` loads and you can log in.
 
 **Test account setup:** log in with a test user that has at least:
 


### PR DESCRIPTION
## Summary

- Add a root README as the canonical local development startup guide.
- Replace the stale `./start-project.ps1` reference in `CLAUDE.md` with the documented MySQL/backend/frontend flow.
- Update the Epic 10 visual QA checklist to point at the README startup flow.

## Impact

New contributors and agents have one reliable place to find local startup, setup, URL, verification, and migration commands. The removed helper script is no longer referenced.

## Validation

- Searched Markdown and PowerShell files for stale `start-project` references.
- No runtime tests run; documentation-only change.