### PR TITLE
Add API integration test coverage

### DIFF
--- a/docs/implementation/tests/test-summary.md
+++ b/docs/implementation/tests/test-summary.md
@@ -1,0 +1,18 @@
+# Test Automation Summary
+
+## Generated Tests
+
+### API Tests
+- [x] `inex.Tests/Currencies/CurrenciesControllerTests.cs` - Public currency list contract
+- [x] `inex.Tests/ExchangeRates/ExchangeRateControllerTests.cs` - Exchange-rate authentication and cached-rate response contract
+
+### E2E Tests
+- [ ] Not generated - the frontend has no committed E2E test framework or test script.
+
+## Coverage
+- API controllers: added coverage for 2 previously untested controllers.
+- UI features: no browser E2E coverage added in this pass.
+
+## Next Steps
+- Add a frontend E2E framework in a dedicated story if browser workflows need automated coverage.
+- Keep using `dotnet test inex.sln` for backend integration verification.

--- a/inex.Tests/Currencies/CurrenciesControllerTests.cs
+++ b/inex.Tests/Currencies/CurrenciesControllerTests.cs
@@ -1,0 +1,55 @@
+using System.Net.Http.Json;
+using inex.Data;
+using inex.Data.Models;
+using inex.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace inex.Tests.Currencies;
+
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class CurrenciesControllerTests : IClassFixture<InExWebApplicationFactory>
+{
+    private readonly InExWebApplicationFactory _factory;
+
+    public CurrenciesControllerTests(InExWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task List_AnonymousRequest_Returns200WithCurrencies()
+    {
+        await SeedCurrencyAsync("EUR", "Euro");
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/currencies");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var currencies = body.EnumerateArray().ToList();
+        Assert.Contains(currencies, currency =>
+            currency.GetProperty("key").GetString() == "EUR" &&
+            currency.GetProperty("name").GetString() == "Euro");
+    }
+
+    private async Task SeedCurrencyAsync(string key, string name)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<InExDbContext>();
+        if (db.Set<Currency>().Any(currency => currency.Key == key))
+        {
+            return;
+        }
+
+        db.Set<Currency>().Add(new Currency
+        {
+            Key = key,
+            Name = name,
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+    }
+}

--- a/inex.Tests/ExchangeRates/ExchangeRateControllerTests.cs
+++ b/inex.Tests/ExchangeRates/ExchangeRateControllerTests.cs
@@ -1,0 +1,86 @@
+using System.Net.Http.Json;
+using inex.Data;
+using inex.Data.Models;
+using inex.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace inex.Tests.ExchangeRates;
+
+[Collection(Infrastructure.IntegrationTestCollection.Name)]
+public class ExchangeRateControllerTests : IClassFixture<InExWebApplicationFactory>
+{
+    private readonly InExWebApplicationFactory _factory;
+
+    public ExchangeRateControllerTests(InExWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetDateRates_AnonymousRequest_Returns401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/exchange/rates/2026-05-01");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetDateRates_AuthenticatedRequest_ReturnsCachedRates()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync(
+            email: $"{Guid.NewGuid()}@example.com",
+            username: $"user-{Guid.NewGuid():N}");
+        var rateDate = new DateTime(2026, 5, 1);
+        await SeedCurrencyAndRateAsync(rateDate);
+
+        var response = await client.GetAsync("/api/exchange/rates/2026-05-01");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var rates = body.GetProperty("data").EnumerateArray().ToList();
+        var eurRate = Assert.Single(rates, rate => rate.GetProperty("currencyTo").GetString() == "EUR");
+        Assert.Equal("USD", eurRate.GetProperty("currencyFrom").GetString());
+        Assert.Equal(0.92m, eurRate.GetProperty("rate").GetDecimal());
+        Assert.False(eurRate.GetProperty("isTemporary").GetBoolean());
+        Assert.Equal(rateDate, eurRate.GetProperty("date").GetDateTime().Date);
+    }
+
+    private async Task SeedCurrencyAndRateAsync(DateTime rateDate)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<InExDbContext>();
+
+        if (!db.Set<Currency>().Any(currency => currency.Key == "EUR"))
+        {
+            db.Set<Currency>().Add(new Currency
+            {
+                Key = "EUR",
+                Name = "Euro",
+                Created = DateTime.UtcNow,
+                Updated = DateTime.UtcNow,
+            });
+        }
+
+        if (!db.Set<ExchangeRate>().Any(rate =>
+                rate.Created == rateDate &&
+                rate.FromCode == "USD" &&
+                rate.ToCode == "EUR"))
+        {
+            db.Set<ExchangeRate>().Add(new ExchangeRate
+            {
+                FromCode = "USD",
+                ToCode = "EUR",
+                Rate = 0.92m,
+                IsTemporary = false,
+                Created = rateDate,
+                Updated = rateDate,
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

- Add xUnit integration coverage for the public currencies API contract.
- Add xUnit integration coverage for exchange-rate authentication and cached-rate response behavior.
- Add the BMad test automation summary for the generated coverage.

## Validation

- `dotnet test D:\work\inex\inex.Tests\inex.Tests.csproj`
- `dotnet test D:\work\inex\inex.sln`

## Notes

Frontend browser E2E tests were not added because the React app currently has no committed E2E framework or test script. The generated coverage follows the existing .NET/xUnit API integration pattern.