### PR TITLE
Fix dashboard locale caching and heatmap palette

### DIFF
--- a/inex/ClientApp/src/i18n.ts
+++ b/inex/ClientApp/src/i18n.ts
@@ -7,6 +7,8 @@ function syncDayjsLocale(lang: string) {
     dayjs.locale(lang === "ru" ? "ru" : "en");
 }
 
+const localeResourceVersion = "2026-06-02-dashboard-locales";
+
 i18n
     .use(HttpBackend)
     .use(initReactI18next)
@@ -15,7 +17,7 @@ i18n
         fallbackLng: "en",
         supportedLngs: ["en", "ru"],
         backend: {
-            loadPath: "/locales/{{lng}}/translation.json",
+            loadPath: `/locales/{{lng}}/translation.json?v=${localeResourceVersion}`,
         },
         interpolation: {
             escapeValue: false,

--- a/inex/ClientApp/src/pages/Reports/ReportSpendingHeatmap.test.ts
+++ b/inex/ClientApp/src/pages/Reports/ReportSpendingHeatmap.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getSpendingIntensityColor } from "./ReportSpendingHeatmap";
+
+describe("getSpendingIntensityColor", () => {
+  it("uses a neutral color when there is no spending intensity", () => {
+    expect(getSpendingIntensityColor(0, 100)).toBe("#f8fafc");
+    expect(getSpendingIntensityColor(100, 0)).toBe("#f8fafc");
+  });
+
+  it("maps spending intensity to progressively stronger red tones", () => {
+    expect(getSpendingIntensityColor(10, 100)).toBe("#fee2e2");
+    expect(getSpendingIntensityColor(25, 100)).toBe("#fca5a5");
+    expect(getSpendingIntensityColor(50, 100)).toBe("#ef4444");
+    expect(getSpendingIntensityColor(75, 100)).toBe("#991b1b");
+  });
+});

--- a/inex/ClientApp/src/pages/Reports/ReportSpendingHeatmap.tsx
+++ b/inex/ClientApp/src/pages/Reports/ReportSpendingHeatmap.tsx
@@ -50,14 +50,15 @@ interface HeatmapCellProps extends CellShapeProps {
 
 const cellSize = 14;
 const dayTicks = [0, 1, 2, 3, 4, 5, 6];
+const spendingHeatmapColors = ["#f8fafc", "#fee2e2", "#fca5a5", "#ef4444", "#991b1b"] as const;
 
-const getIntensityColor = (totalSpend: number, maxSpend: number) => {
-  if (totalSpend <= 0 || maxSpend <= 0) return "#ebedf0";
+export const getSpendingIntensityColor = (totalSpend: number, maxSpend: number) => {
+  if (totalSpend <= 0 || maxSpend <= 0) return spendingHeatmapColors[0];
   const ratio = totalSpend / maxSpend;
-  if (ratio >= 0.75) return "#196127";
-  if (ratio >= 0.5) return "#239a3b";
-  if (ratio >= 0.25) return "#7bc96f";
-  return "#c6e48b";
+  if (ratio >= 0.75) return spendingHeatmapColors[4];
+  if (ratio >= 0.5) return spendingHeatmapColors[3];
+  if (ratio >= 0.25) return spendingHeatmapColors[2];
+  return spendingHeatmapColors[1];
 };
 
 const HeatmapCell = ({ cx = 0, cy = 0, payload, maxSpend }: HeatmapCellProps) => (
@@ -68,7 +69,7 @@ const HeatmapCell = ({ cx = 0, cy = 0, payload, maxSpend }: HeatmapCellProps) =>
     height={cellSize}
     rx={2}
     ry={2}
-    fill={getIntensityColor(payload?.totalSpend ?? 0, maxSpend)}
+    fill={getSpendingIntensityColor(payload?.totalSpend ?? 0, maxSpend)}
   />
 );
 
@@ -248,7 +249,7 @@ const ReportSpendingHeatmap = () => {
                 width: 12,
                 height: 12,
                 borderRadius: 2,
-                background: getIntensityColor(step * maxSpend, maxSpend),
+                background: getSpendingIntensityColor(step * maxSpend, maxSpend),
               }}
             />
           ))}

--- a/inex/Program.cs
+++ b/inex/Program.cs
@@ -279,8 +279,13 @@ try
                 headers.Append("X-Frame-Options", "DENY");
                 headers.Append("X-Content-Type-Options", "nosniff");
 
-                // Cache static assets for 1 year, except HTML files which should not be cached to ensure users get the latest version.
-                if (!ctx.File.Name.EndsWith(".html"))
+                var requestPath = ctx.Context.Request.Path.Value ?? string.Empty;
+                var isHtml = ctx.File.Name.EndsWith(".html", StringComparison.OrdinalIgnoreCase);
+                var isLocaleJson = requestPath.StartsWith("/locales/", StringComparison.OrdinalIgnoreCase)
+                    && ctx.File.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
+
+                // Cache hashed static assets for 1 year. HTML and locale JSON are intentionally unversioned.
+                if (!isHtml && !isLocaleJson)
                 {
                     ctx.Context.Response.Headers.CacheControl = "public,max-age=31536000,immutable";
                 }


### PR DESCRIPTION
## Summary

Fixes #140
Fixes #141

- Prevent immutable caching for unversioned locale JSON and add a versioned i18n locale request URL so production dashboards can pick up newly added translation keys.
- Replace the spending heatmap green intensity scale with a neutral-to-red spending scale and keep the legend using the same mapping.
- Add regression coverage for the heatmap color mapping.

## Validation

- npm run test
- npm run lint
- npm run build
- dotnet build inex.sln
- dotnet test inex.sln

## Notes

The root cause for the dashboard translation-key issue was that `/locales/{lng}/translation.json` is an unversioned file, but ASP.NET static-file handling cached non-HTML SPA assets for one year with `immutable`. Existing browsers could keep stale locale bundles after new dashboard/report keys shipped.