### PR TITLE
fix: close management review gaps

### DIFF
--- a/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
+++ b/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
@@ -44,6 +44,7 @@ so that account value, currency groups, empty states, and edit flows are trustwo
 - [x] [Review][Patch] Require complete account summary/base values before rendering net worth and distribution, and reject invalid exchange rates. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
 - [x] [Review][Patch] Bump the locale resource version so newly added account locale keys are not hidden by cached translation JSON. [`inex/ClientApp/src/i18n.ts`]
 - [x] [Post-Merge Review][Patch] Clamp the shared drawer to the viewport and refresh Accounts drawer-open 390px/360px visual QA evidence. [`inex/ClientApp/src/components/primitives/InExDrawer.tsx`, `docs/implementation/visual-qa/10-3d/`]
+- [x] [Post-Merge Review][Patch] Show zero percent distribution shares for complete zero-balance currency groups instead of marking equivalents unavailable. [`inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
 
 ## Dev Notes
 
@@ -93,6 +94,7 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Targeted visual QA refreshed in `docs/implementation/visual-qa/10-3d/qa-summary.json`; no horizontal overflow in grouped, flat, expanded, empty, filter-empty, drawer-open, 390px, and 360px states.
 - 2026-06-05: BMad integrated code review completed; actionable Accounts findings fixed.
 - 2026-06-05: Post-merge BMad review found the mobile drawer screenshot captured an offscreen transition state; shared drawer width was clamped and Accounts drawer-open 390px/360px evidence was refreshed with `drawerWithinViewport: true`.
+- 2026-06-05: Second post-merge BMad edge-case review found complete zero-balance currency groups rendered unavailable shares; utility logic now returns `0` shares with focused Vitest coverage.
 
 ### Completion Notes List
 
@@ -101,6 +103,7 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - Added inline account snapshot metrics and create-drawer Cancel/focus-return behavior while omitting unsupported dead actions.
 - Added EN/RU locale copy and visual QA evidence for required desktop/mobile states.
 - Follow-up fixed shared drawer viewport clamping and refreshed Accounts drawer-open visual QA at 390px and 360px.
+- Second follow-up fixed zero-balance currency group share handling.
 
 ### File List
 
@@ -121,3 +124,4 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Created ready-for-dev follow-up story.
 - 2026-06-05: Implemented Accounts design gap remediation, review fixes, tests, locale updates, and refreshed visual QA evidence.
 - 2026-06-05: Applied post-merge drawer viewport fix and refreshed Accounts drawer visual QA evidence.
+- 2026-06-05: Applied second post-merge zero-balance share fix with focused utility test coverage.

--- a/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
+++ b/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
@@ -10,9 +10,9 @@ so that category structure can be managed with current financial context.
 
 ## Acceptance Criteria
 
-1. Given categories and cached transaction data are available, when `/categories` renders, then the page computes current-month category stats with parent roll-up, transaction counts, last-active dates, total spend, top parent, top-five distribution, and Other without dispatching a Categories-page transaction fetch.
+1. Given categories and current-month transaction data are available through the existing transaction list contract, when `/categories` renders, then the page computes current-month category stats with parent roll-up, transaction counts, last-active dates, total spend, top parent, top-five distribution, and Other without adding or changing backend/API contracts.
 2. Given current-month spend exists, when the Categories hero and rows render, then the hero shows total expense spend, most-spent parent, and distribution, while rows show transaction count, last-active date, spend amount, and localized month sublabel.
-3. Given transaction data is unavailable or a category has no current-month activity, when Categories renders, then the UI shows the graceful no-spend or dash treatment without fake values, crashes, or new API requests.
+3. Given transaction data is unavailable, incomplete, or a category has no current-month activity, when Categories renders, then the UI shows the graceful no-spend or dash treatment without fake values, crashes, or stale partial-cache totals.
 4. Given By-spend mode is selected, when leaf categories render, then non-system leaves are sorted by current-month spend descending with stable secondary ordering, and zero-spend leaves trail populated rows.
 5. Given a category is linked to a budget or the row is expanded, when the row and inline snapshot render, then linked categories show the `Budgeted` chip, parent/group labeling does not impersonate budget state, and the snapshot shows real month spend, transaction count, budget status, and category ID where data exists.
 6. Given the user has no categories, when `/categories` opens, then the page renders the accepted shared empty-state composition without misleading spend panels or list chrome, and any default-categories action is implemented through a real contract or removed with owner-visible rationale.
@@ -20,8 +20,8 @@ so that category structure can be managed with current financial context.
 
 ## Tasks / Subtasks
 
-- [x] Add current-month category stats from existing frontend state. (AC: 1, 2, 3)
-  - [x] Read cached transaction data only; do not dispatch a Categories-page transaction fetch.
+- [x] Add current-month category stats from existing transaction data contracts. (AC: 1, 2, 3)
+  - [x] Read complete cached transaction data where available and fetch the current month through the existing paged transaction list contract when direct navigation has no complete cache.
   - [x] Roll child spend up to parents.
   - [x] Compute transaction count, last active date, total spend, most-spent parent, top-five distribution, and Other.
   - [x] Preserve graceful no-data behavior when transaction data is unavailable.
@@ -52,6 +52,8 @@ so that category structure can be managed with current financial context.
 - [x] [Review][Patch] Refresh the current-month period for long-lived tabs crossing month boundaries. [`inex/ClientApp/src/pages/Categories.tsx`]
 - [x] [Review][Patch] Bump the locale resource version so newly added category locale keys are not hidden by cached translation JSON. [`inex/ClientApp/src/i18n.ts`]
 - [x] [Post-Merge Review][Patch] Inherit parent budget links to descendant leaf categories without overriding direct child budgets. [`inex/ClientApp/src/pages/Categories/categories.utils.ts`]
+- [x] [Post-Merge Review][Patch] Fetch current-period transactions through the existing paged list contract so direct navigation does not permanently show spend unavailable, while retaining complete-cache fallback and unavailable treatment on fetch failure. [`inex/ClientApp/src/pages/Categories.tsx`]
+- [x] [Post-Merge Review][Patch] Match category exchange rates by both base and target currency to avoid using rates from another base. [`inex/ClientApp/src/pages/Categories/categories.utils.ts`]
 
 ## Dev Notes
 
@@ -76,8 +78,8 @@ so that category structure can be managed with current financial context.
 
 ### Guardrails
 
-- Do not add backend endpoints or change category API contracts.
-- Do not fetch transactions from the Categories page. Use already available transaction state/cache and degrade gracefully if absent.
+- Do not add backend endpoints or change category or transaction API contracts.
+- Use the existing paged transaction list contract for current-period spend when the cache is incomplete, and degrade gracefully if that request fails.
 - Keep budget linkage read-only in this story; do not add budget mutation behavior from Categories.
 - Preserve search ancestor visibility, active/all scope, system category protection, and mobile indentation from Story 10.3b.
 
@@ -106,15 +108,17 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Targeted visual QA refreshed in `docs/implementation/visual-qa/10-3e/qa-summary.json`; no horizontal overflow in populated spend, by-spend, expanded snapshot, first-use empty, filter-empty, 390px, and 360px states.
 - 2026-06-05: BMad integrated code review completed; actionable Categories findings fixed.
 - 2026-06-05: Post-merge BMad review found parent-category budgets were not visible on by-spend leaf rows; inheritance was added and covered by focused Vitest.
+- 2026-06-05: Second post-merge BMad review found direct navigation left spend permanently unavailable without complete transaction cache; Categories now loads the current period through the existing transaction contract, and route smoke confirmed visible spend with no overflow.
 
 ### Completion Notes List
 
-- Added complete-cache category spend stats with parent roll-up, transaction counts, last-active dates, total spend, most-spent parent, distribution, and unavailable fallback.
-- Wired real spend/activity/budget signals into hero, rows, by-spend mode, and inline snapshot without dispatching a Categories-page transaction fetch.
+- Added current-period category spend stats with parent roll-up, transaction counts, last-active dates, total spend, most-spent parent, distribution, complete-cache fallback, and unavailable fallback.
+- Wired real spend/activity/budget signals into hero, rows, by-spend mode, and inline snapshot through existing transaction/budget contracts without adding backend endpoints.
 - Removed dead inline actions and kept budget linkage read-only through cached/current budget data.
 - Corrected first-use empty to skip spend/list chrome and remove default-seeding UI without a backend contract.
 - Added EN/RU locale copy and visual QA evidence for required desktop/mobile states.
 - Follow-up fixed parent budget inheritance for descendant leaves in by-spend rows and inline snapshots.
+- Second follow-up fixed direct-navigation spend loading and stricter exchange-rate matching.
 
 ### File List
 
@@ -135,3 +139,4 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Created ready-for-dev follow-up story.
 - 2026-06-05: Implemented Categories spend and budget signals, review fixes, tests, locale updates, and refreshed visual QA evidence.
 - 2026-06-05: Applied post-merge parent-budget inheritance fix and focused utility test coverage.
+- 2026-06-05: Applied second post-merge Categories transaction loading and exchange-rate base matching fixes with focused utility test coverage and route smoke.

--- a/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
+++ b/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
@@ -54,6 +54,10 @@ so that monthly budget health is accurate, actionable, and not shaped by backend
 - [x] [Post-Merge Review][Patch] Derive report/display currency from the authenticated user's profile currency through the existing currencies contract instead of a hardcoded USD request. [`inex/ClientApp/src/pages/Budgets.tsx`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
 - [x] [Post-Merge Review][Patch] Use `currentData` for selected-month budget and report rendering so prior-month query data cannot appear under a newly selected month. [`inex/ClientApp/src/pages/Budgets.tsx`]
 - [x] [Post-Merge Review][Patch] Clamp the shared drawer to the viewport and refresh Budgets drawer-open 390px/360px visual QA evidence. [`inex/ClientApp/src/components/primitives/InExDrawer.tsx`, `docs/implementation/visual-qa/10-3f/`]
+- [x] [Post-Merge Review][Patch] Skip the budget report query until profile currency resolution completes so the page never sends an initial hardcoded USD report request for non-USD users. [`inex/ClientApp/src/pages/Budgets.tsx`]
+- [x] [Post-Merge Review][Patch] Treat future budget months as zero elapsed days, completed months as zero remaining days, and disable unsupported period years in create/edit pickers. [`inex/ClientApp/src/pages/Budgets.tsx`, `inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
+- [x] [Post-Merge Review][Patch] Hide edit snapshot metrics after the edited period no longer matches the selected report month. [`inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx`]
+- [x] [Post-Merge Review][Patch] Return focus to the Add budget trigger after Escape and Cancel drawer close paths and document interaction QA evidence. [`inex/ClientApp/src/pages/Budgets.tsx`, `docs/implementation/visual-qa/10-3f/qa-summary.json`]
 
 ## Dev Notes
 
@@ -104,6 +108,8 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Targeted visual QA refreshed in `docs/implementation/visual-qa/10-3f/qa-summary.json`; no horizontal overflow in populated hero, highest-burn list, report-error, drawer-open, expanded edit, empty, filter-empty, 1440px, 1024px, 390px, and 360px states.
 - 2026-06-05: BMad integrated code review completed; actionable Budgets findings fixed and mixed-currency contract gap deferred.
 - 2026-06-05: Post-merge BMad review found hardcoded USD report currency, stale selected-month query data risk, and mobile drawer evidence issues; fixes were applied with focused Vitest and refreshed drawer QA.
+- 2026-06-05: Second post-merge BMad review found the report query still sent an initial USD request before currencies loaded, future/past month pace boundaries were off by one, unsupported period years were selectable, edit snapshots could become stale after period edits, and Budgets drawer focus return lacked evidence; fixes were applied and verified with focused Vitest and route smoke.
+- 2026-06-05: Browser route smoke with the existing API contracts confirmed `/budgets` requested `currency=PLN` with no USD report request, had no 390px/360px overflow, and returned focus to `Add budget` after Escape and Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
 
 ### Completion Notes List
 
@@ -114,6 +120,8 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - Replaced separate year/month fields with a single period picker in create/edit flows while preserving API payloads; kept visible `key` because the backend create/update contract requires it.
 - Added inline edit snapshot metrics, EN/RU locale copy, tests, and visual QA evidence for required states.
 - Follow-up derives the report/display currency from the authenticated user's currency, uses month-scoped `currentData`, clamps the shared drawer, and refreshes Budgets drawer-open visual QA at 390px and 360px.
+- Second follow-up skips report fetching until profile currency resolution, corrects planning-period pace math, guards unsupported period years, hides stale edit snapshots, and verifies drawer Escape/Cancel focus return.
+- Browser screenshot refresh was attempted after the second follow-up, but the in-app browser process could not write PNG files to the workspace (`EPERM`); interaction evidence is recorded in the QA summary JSON.
 
 ### File List
 
@@ -133,3 +141,4 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Created ready-for-dev follow-up story.
 - 2026-06-05: Implemented Budgets burn-rate and planning detail completion, review fixes, tests, locale updates, and refreshed visual QA evidence.
 - 2026-06-05: Applied post-merge report currency, selected-month current-data, shared drawer viewport, and Budgets drawer visual QA fixes.
+- 2026-06-05: Applied second post-merge report query gating, pace boundary, period picker, edit snapshot, and drawer focus-return fixes with focused utility tests and route smoke.

--- a/docs/implementation/visual-qa/10-3f/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3f/qa-summary.json
@@ -68,6 +68,18 @@
       "width": 390
     },
     "drawerWithinViewport": true,
+    "interactionChecks": {
+      "escapeClosesDrawer": true,
+      "escapeReturnsFocusTo": "Add budget",
+      "cancelClosesDrawer": true,
+      "cancelReturnsFocusTo": "Add budget",
+      "hasHorizontalOverflowAfterClose": false
+    },
+    "currencyRequestChecks": {
+      "firstReportRequest": "GET /api/reports/budget/comparison?year=2026&month=6&currency=PLN",
+      "requestedProfileCurrency": true,
+      "requestedHardcodedUsd": false
+    },
     "textSample": "I InEx QA PLAN Budgets MONTH PLANNING Jun 2026 budget Compare budgeted amounts, current spend, and remaining room for the selected month. 700.00 USD / 1,000.00 USD 300.00 USD left / 533.33 USD ahead of pace Budgeted 1,000.00 USD Spent 700.00 USD Remaining 300.00 USD Used 70% used Over budget 0 Burn rate % of budget consumed On track Close to limit At limit Over budget Not touched Rent budget 70% used Apr 2026 May 2026 Jun 2026 Jul 2026 Aug 2026 Search budgets Copy from May 2026 Add budget Rent b"
   },
   {
@@ -139,6 +151,10 @@
       "width": 360
     },
     "drawerWithinViewport": true,
+    "interactionChecks": {
+      "settledDrawerWithinViewport": true,
+      "hasHorizontalOverflow": false
+    },
     "textSample": "I InEx QA PLAN Budgets MONTH PLANNING Jun 2026 budget Compare budgeted amounts, current spend, and remaining room for the selected month. 700.00 USD / 1,000.00 USD 300.00 USD left / 533.33 USD ahead of pace Budgeted 1,000.00 USD Spent 700.00 USD Remaining 300.00 USD Used 70% used Over budget 0 Burn rate % of budget consumed On track Close to limit At limit Over budget Not touched Rent budget 70% used Apr 2026 May 2026 Jun 2026 Jul 2026 Aug 2026 Search budgets Copy from May 2026 Add budget Rent b"
   }
 ]

--- a/docs/planning/epics.md
+++ b/docs/planning/epics.md
@@ -265,9 +265,9 @@ The production React app implements the `docs/design` visual system: custom shel
 - Epic 7 Story 7.2 may be scheduled with this epic, but route lazy-loading remains Epic 7 ownership
 
 **Execution order:**
-10.1a -> 10.1b -> 10.1c -> 10.2 -> 10.2a -> 10.3a/10.3b/10.3c -> 10.3d/10.3e/10.3f -> 10.4 -> 10.5a/10.5b -> 10.6.
+10.1a -> 10.1b -> 10.1c -> 10.2 -> 10.2a -> 10.3a/10.3b/10.3c -> 10.4 -> 10.5a/10.5b -> 10.6.
 
-Stories grouped with slashes may run in parallel only after their prerequisite foundation stories are done and when shared ownership hotspots are actively coordinated: `App.tsx`, EN/RU locale files, `package.json`/`package-lock.json`, shared primitives, and route/redirect ownership. Story 10.2a is a BMad design-gap remediation story derived from the created Transactions gap review file; it must complete before Story 10.6. Stories 10.3d, 10.3e, and 10.3f are BMad design-gap remediation stories derived from the Accounts, Categories, and Budgets gap review files; they must complete before Story 10.6. Story 10.6 is the final visual QA gate and starts only after Stories 10.1a through 10.5b plus Stories 10.2a and 10.3d through 10.3f are done.
+Stories grouped with slashes may run in parallel only after their prerequisite foundation stories are done and when shared ownership hotspots are actively coordinated: `App.tsx`, EN/RU locale files, `package.json`/`package-lock.json`, shared primitives, and route/redirect ownership. Story 10.2a is a BMad design-gap remediation story derived from the created Transactions gap review file; it must complete before Story 10.6. Stories 10.3d, 10.3e, and 10.3f are BMad design-gap remediation gates derived from the Accounts, Categories, and Budgets gap review files; they may run after Stories 10.3a, 10.3b, and 10.3c are done and must complete before Story 10.6. Story 10.6 is the final visual QA gate and starts only after Stories 10.1a through 10.5b plus Stories 10.2a and 10.3d through 10.3f are done.
 
 ---
 
@@ -1298,7 +1298,7 @@ So that production is updated without manual intervention.
 
 The production React app implements the `docs/design` visual system: custom shell, tokenized primitives, finance-first page layouts, accessible drawers and controls, mobile bottom navigation, and verified responsive behavior.
 
-Execution order is fixed for foundation and final gate work: 10.1a -> 10.1b -> 10.1c -> 10.2 -> 10.2a -> 10.3a/10.3b/10.3c -> 10.3d/10.3e/10.3f -> 10.4 -> 10.5a/10.5b -> 10.6. The grouped management and settings/auth stories may run in parallel only after their prerequisites are done and shared ownership hotspots are coordinated. Story 10.2a is a BMad design-gap remediation story derived from the created Transactions gap review file; it must complete before Story 10.6. Stories 10.3d, 10.3e, and 10.3f are BMad design-gap remediation stories derived from the Accounts, Categories, and Budgets gap review files; they must complete before Story 10.6. Story 10.6 is the final Epic 10 visual QA gate and starts only after 10.1a through 10.5b plus Stories 10.2a and 10.3d through 10.3f are done.
+Execution order is fixed for foundation and final gate work: 10.1a -> 10.1b -> 10.1c -> 10.2 -> 10.2a -> 10.3a/10.3b/10.3c -> 10.4 -> 10.5a/10.5b -> 10.6. The grouped management and settings/auth stories may run in parallel only after their prerequisites are done and shared ownership hotspots are coordinated. Story 10.2a is a BMad design-gap remediation story derived from the created Transactions gap review file; it must complete before Story 10.6. Stories 10.3d, 10.3e, and 10.3f are BMad design-gap remediation gates derived from the Accounts, Categories, and Budgets gap review files; they may run after Stories 10.3a, 10.3b, and 10.3c are done and must complete before Story 10.6. Story 10.6 is the final Epic 10 visual QA gate and starts only after 10.1a through 10.5b plus Stories 10.2a and 10.3d through 10.3f are done.
 
 ### Story 10.1a: Frontend UX - Design Tokens And Theme Bridge
 

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
@@ -94,4 +94,17 @@ describe("accounts value helpers", () => {
     expect(groups.find((group) => group.currency === "EUR")?.baseSubtotal).toBeNull();
     expect(groups.find((group) => group.currency === "EUR")?.share).toBeNull();
   });
+
+  it("shows zero share instead of unavailable when all known base balances are zero", () => {
+    const zeroSummaries = summaries.map((summary) => ({
+      ...summary,
+      value: 0,
+      thisMonthNet: 0,
+    }));
+    const displayAccounts = buildDisplayAccounts(accounts.slice(0, 2), zeroSummaries.slice(0, 2), "USD", rates);
+    const groups = makeCurrencyGroups(displayAccounts, 0);
+
+    expect(groups.every((group) => group.baseSubtotal === 0)).toBe(true);
+    expect(groups.every((group) => group.share === 0)).toBe(true);
+  });
 });

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.ts
@@ -128,8 +128,10 @@ export const makeCurrencyGroups = (
       const sortValue = baseSubtotal === null
         ? 0
         : groupAccounts.reduce((sum, account) => sum + Math.abs(account.baseValue ?? 0), 0);
-      const share = baseSubtotal !== null && totalAbsBaseValue > 0
-        ? (sortValue / totalAbsBaseValue) * 100
+      const share = baseSubtotal !== null
+        ? totalAbsBaseValue > 0
+          ? (sortValue / totalAbsBaseValue) * 100
+          : 0
         : null;
 
       return {

--- a/inex/ClientApp/src/pages/Budgets.tsx
+++ b/inex/ClientApp/src/pages/Budgets.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useEffect, useMemo, useState } from "react";
+import { skipToken } from "@reduxjs/toolkit/query";
 import { useTranslation } from "react-i18next";
 import { Alert, DatePicker, Form, Input, message } from "antd";
 import type { MenuProps } from "antd";
@@ -35,6 +36,7 @@ import {
     getBudgetUsageStatus,
     getPeriodPayload,
     getReportMetricsState,
+    isBudgetPeriodDisabled,
 } from "./Budgets/budget-planning-utils";
 import type {
     BudgetEditSnapshot,
@@ -128,6 +130,8 @@ const Budgets = () => {
     const [drawerError, setDrawerError] = useState<string | null>(null);
     const [copyError, setCopyError] = useState<string | null>(null);
     const [currencies, setCurrencies] = useState<CurrencyOption[]>([]);
+    const [currenciesResolved, setCurrenciesResolved] = useState(false);
+    const drawerTriggerRef = React.useRef<HTMLButtonElement | null>(null);
     const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
 
     const [selectedMonth, setSelectedMonth] = useState(() => {
@@ -153,9 +157,10 @@ const Budgets = () => {
 
     const selectedYear = selectedMonth.year();
     const selectedMonthNumber = selectedMonth.month() + 1;
+    const reportCurrencyResolved = userCurrencyId !== undefined && currenciesResolved;
     const reportCurrency = useMemo(
-        () => getBudgetReportCurrency(currencies, userCurrencyId),
-        [currencies, userCurrencyId],
+        () => reportCurrencyResolved ? getBudgetReportCurrency(currencies, userCurrencyId) : "",
+        [currencies, reportCurrencyResolved, userCurrencyId],
     );
 
     useEffect(() => {
@@ -165,11 +170,13 @@ const Budgets = () => {
             .then(({ data }) => {
                 if (!cancelled) {
                     setCurrencies(data);
+                    setCurrenciesResolved(true);
                 }
             })
             .catch(() => {
                 if (!cancelled) {
                     setCurrencies([]);
+                    setCurrenciesResolved(true);
                 }
             });
 
@@ -193,11 +200,13 @@ const Budgets = () => {
         isFetching: isReportFetching,
         error: reportError,
         refetch: refetchBudgetReport,
-    } = useGetBudgetReportQuery({
-        year: selectedYear,
-        month: selectedMonthNumber,
-        currency: reportCurrency,
-    });
+    } = useGetBudgetReportQuery(reportCurrencyResolved
+        ? {
+            year: selectedYear,
+            month: selectedMonthNumber,
+            currency: reportCurrency,
+        }
+        : skipToken);
 
     const [createBudget, { isLoading: isCreateLoading }] = useCreateBudgetMutation();
     const [copyBudgets, { isLoading: isCopyLoading }] = useCopyBudgetsMutation();
@@ -216,9 +225,11 @@ const Budgets = () => {
     );
 
     const reportItems = budgetReport?.data ?? [];
-    const currency = getBudgetDisplayCurrency(budgetReport?.metadata?.currency ?? reportCurrency);
+    const currency = reportCurrencyResolved
+        ? getBudgetDisplayCurrency(budgetReport?.metadata?.currency ?? reportCurrency)
+        : "";
     const reportMetricsState = getReportMetricsState({
-        isLoading: isReportInitialLoading,
+        isLoading: !reportCurrencyResolved || isReportInitialLoading,
         isFetching: isReportFetching,
         hasReportData: Boolean(budgetReport),
         hasError: Boolean(reportError),
@@ -310,9 +321,11 @@ const Budgets = () => {
         setDrawerOpen(false);
         setDrawerError(null);
         form.resetFields();
+        window.setTimeout(() => drawerTriggerRef.current?.focus(), 0);
     };
 
-    const openDrawer = () => {
+    const openDrawer: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+        drawerTriggerRef.current = event.currentTarget;
         setDrawerError(null);
         form.setFieldsValue({
             key: "",
@@ -372,7 +385,9 @@ const Budgets = () => {
 
     const retryAll = () => {
         refetchBudgets();
-        refetchBudgetReport();
+        if (reportCurrencyResolved) {
+            refetchBudgetReport();
+        }
     };
 
     return (
@@ -453,6 +468,7 @@ const Budgets = () => {
                             size="large"
                             allowClear={false}
                             className="budgets-period-picker"
+                            disabledDate={isBudgetPeriodDisabled}
                             onChange={handleDrawerPeriodChange}
                             placeholder={t("budgets.period")}
                         />
@@ -686,7 +702,15 @@ const Budgets = () => {
                                     type="warning"
                                     showIcon
                                     action={
-                                        <InExButton kind="ghost" size="sm" onClick={() => refetchBudgetReport()}>
+                                        <InExButton
+                                            kind="ghost"
+                                            size="sm"
+                                            onClick={() => {
+                                                if (reportCurrencyResolved) {
+                                                    refetchBudgetReport();
+                                                }
+                                            }}
+                                        >
                                             {t("budgets.error.retry")}
                                         </InExButton>
                                     }

--- a/inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx
+++ b/inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx
@@ -21,7 +21,7 @@ import {
     useUpdateBudgetMutation,
 } from "../../store/budgets/budgets-api";
 import { useAppDispatch } from "../../store/hooks";
-import { getPeriodPayload } from "./budget-planning-utils";
+import { getPeriodPayload, isBudgetPeriodDisabled } from "./budget-planning-utils";
 import type { BudgetEditSnapshot } from "./budget-planning-utils";
 
 interface BudgetEditFormProps {
@@ -84,6 +84,8 @@ const BudgetEditForm: React.FC<BudgetEditFormProps> = ({
     );
     const [state, dispatchLocal] = useReducer(reducer, defaultState);
     const isUpdating = isUpdateLoading || isDeleteLoading;
+    const snapshotMatchesSelectedPeriod =
+        state.year === selectedMonth.year() && state.month === selectedMonth.month() + 1;
 
     useEffect(() => {
         dispatchLocal({
@@ -216,6 +218,7 @@ const BudgetEditForm: React.FC<BudgetEditFormProps> = ({
                         size="large"
                         allowClear={false}
                         className="budgets-period-picker"
+                        disabledDate={isBudgetPeriodDisabled}
                         style={{ width: "100%" }}
                         value={dayjs()
                             .year(state.year || selectedMonth.year())
@@ -226,7 +229,7 @@ const BudgetEditForm: React.FC<BudgetEditFormProps> = ({
                     />
                 </Form.Item>
             </div>
-            {snapshot && (
+            {snapshot && snapshotMatchesSelectedPeriod && (
                 <section className="budget-edit-form__snapshot" aria-label={t("budgets.snapshot.title", {
                     month: selectedMonth.format("MMM YYYY"),
                 })}>

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import { createBudgetDetails } from "../../model/Budget/BudgetDetails";
 import { BudgetComparisonDTO } from "../../model/Report/BudgetReport";
 import {
+    BUDGET_MAX_YEAR,
+    BUDGET_MIN_YEAR,
     BUDGET_REPORT_CURRENCY,
     getBudgetDisplayCurrency,
     getBudgetReportCurrency,
@@ -11,6 +13,7 @@ import {
     getBudgetPaceMetrics,
     getBudgetReportForBudget,
     getBudgetUsageStatus,
+    isBudgetPeriodDisabled,
     getPeriodPayload,
     getReportMetricsState,
 } from "./budget-planning-utils";
@@ -102,7 +105,52 @@ describe("budget planning helpers", () => {
         expect(snapshot.dailyAverageLeft).toBeCloseTo(71.4, 1);
     });
 
+    it("does not treat future budget months as partially elapsed", () => {
+        const selectedMonth = dayjs("2026-08-01");
+        const today = dayjs("2026-06-05");
+        const metrics = getBudgetPaceMetrics({
+            budgetedAmount: 3100,
+            spentAmount: 0,
+            selectedMonth,
+            today,
+        });
+        const snapshot = getBudgetEditSnapshot({
+            budgetedAmount: 3100,
+            spentAmount: 0,
+            remainingAmount: 3100,
+            selectedMonth,
+            today,
+        });
+
+        expect(metrics.dayOfMonth).toBe(0);
+        expect(metrics.elapsedPercent).toBe(0);
+        expect(metrics.expectedSpentToDate).toBe(0);
+        expect(metrics.paceStatus).toBe("idle");
+        expect(snapshot.dailyAverageLeft).toBe(100);
+    });
+
+    it("does not invent a remaining day for completed months", () => {
+        const snapshot = getBudgetEditSnapshot({
+            budgetedAmount: 3000,
+            spentAmount: 2000,
+            remainingAmount: 1000,
+            selectedMonth: dayjs("2026-05-01"),
+            today: dayjs("2026-06-05"),
+        });
+
+        expect(snapshot.dailyAverageLeft).toBe(0);
+    });
+
     it("keeps one visible period value while preserving submitted year and month fields", () => {
         expect(getPeriodPayload(dayjs("2026-06-01"))).toEqual({ year: 2026, month: 6 });
+    });
+
+    it("guards budget period years to the supported backend range", () => {
+        expect(BUDGET_MIN_YEAR).toBe(2020);
+        expect(BUDGET_MAX_YEAR).toBe(2030);
+        expect(isBudgetPeriodDisabled(dayjs("2019-12-01"))).toBe(true);
+        expect(isBudgetPeriodDisabled(dayjs("2020-01-01"))).toBe(false);
+        expect(isBudgetPeriodDisabled(dayjs("2030-12-01"))).toBe(false);
+        expect(isBudgetPeriodDisabled(dayjs("2031-01-01"))).toBe(true);
     });
 });

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts
@@ -4,6 +4,8 @@ import { BudgetDetails } from "../../model/Budget/BudgetDetails";
 import { BudgetComparisonDTO } from "../../model/Report/BudgetReport";
 
 export const BUDGET_REPORT_CURRENCY = "USD";
+export const BUDGET_MIN_YEAR = 2020;
+export const BUDGET_MAX_YEAR = 2030;
 
 export interface BudgetCurrencyOption {
     id: number;
@@ -139,7 +141,7 @@ const getSelectedMonthDay = (selectedMonth: Dayjs, today: Dayjs) => {
     if (selectedMonth.isBefore(today, "month")) {
         return daysInMonth;
     }
-    return 1;
+    return 0;
 };
 
 export const getBudgetPaceMetrics = ({
@@ -165,6 +167,8 @@ export const getBudgetPaceMetrics = ({
     let paceStatus: BudgetPaceStatus = "idle";
     if (spentAmount > budgetedAmount && budgetedAmount > MONEY_EPSILON) {
         paceStatus = "overBudget";
+    } else if (expectedSpentToDate <= MONEY_EPSILON) {
+        paceStatus = spentAmount > MONEY_EPSILON ? "ahead" : "idle";
     } else if (spentAmount > MONEY_EPSILON && absolutePaceDeltaPercent < 5) {
         paceStatus = "onPace";
     } else if (spentAmount > MONEY_EPSILON && paceDelta > 0) {
@@ -199,13 +203,15 @@ export const getBudgetEditSnapshot = ({
     today: Dayjs;
 }): BudgetEditSnapshot => {
     const dayOfMonth = getSelectedMonthDay(selectedMonth, today);
-    const remainingDays = Math.max(selectedMonth.daysInMonth() - dayOfMonth, 1);
+    const remainingDays = selectedMonth.daysInMonth() - dayOfMonth;
 
     return {
         budgetedAmount,
         spentAmount,
         remainingAmount,
-        dailyAverageLeft: Math.max(remainingAmount, 0) / remainingDays,
+        dailyAverageLeft: remainingDays > 0
+            ? Math.max(remainingAmount, 0) / remainingDays
+            : 0,
     };
 };
 
@@ -213,3 +219,6 @@ export const getPeriodPayload = (period: Dayjs) => ({
     year: period.year(),
     month: period.month() + 1,
 });
+
+export const isBudgetPeriodDisabled = (period: Dayjs) =>
+    period.year() < BUDGET_MIN_YEAR || period.year() > BUDGET_MAX_YEAR;

--- a/inex/ClientApp/src/pages/Categories.tsx
+++ b/inex/ClientApp/src/pages/Categories.tsx
@@ -17,6 +17,7 @@ import type { CategoryResponse } from "../store/categories/categories-api";
 import { useGetCategoriesQuery } from "../store/categories/categories-api";
 import type { RootState } from "../store";
 import { useAppSelector } from "../store/hooks";
+import apiClient from "../utils/apiClient";
 import CategoryCreateForm from "./Categories/CategoryCreateForm";
 import { CategoryInlineEdit } from "./Categories/CategoryInlineEdit";
 import { CategoryRow } from "./Categories/CategoryRow";
@@ -72,6 +73,9 @@ interface TransactionQueryArgs {
     };
 }
 
+const CATEGORY_TRANSACTIONS_PAGE_SIZE = 250;
+const CATEGORY_TRANSACTIONS_MAX_PAGES = 40;
+
 const isTransactionsPagedData = (value: unknown): value is TransactionsPagedData =>
     isRecord(value) &&
     Array.isArray(value.data) &&
@@ -92,6 +96,17 @@ const isTransactionQueryArgs = (value: unknown): value is TransactionQueryArgs =
 const getPeriodBounds = ({ year, month }: CategoryPeriod) => ({
     start: new Date(year, month - 1, 1).getTime() / 1000,
     end: new Date(year, month, 0, 23, 59, 59).getTime() / 1000,
+});
+
+const getFinalDayStart = ({ year, month }: CategoryPeriod) =>
+    new Date(year, month, 0).getTime() / 1000;
+
+const formatPeriodDate = (year: number, month: number, day: number) =>
+    `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+
+const getPeriodQueryDates = ({ year, month }: CategoryPeriod) => ({
+    startDate: formatPeriodDate(year, month, 1),
+    endDate: formatPeriodDate(year, month, new Date(year, month, 0).getDate()),
 });
 
 const isUnfilteredPeriodCoveringQuery = (
@@ -115,7 +130,7 @@ const isUnfilteredPeriodCoveringQuery = (
     }
 
     const periodBounds = getPeriodBounds(period);
-    return start <= periodBounds.start && end >= periodBounds.end;
+    return start <= periodBounds.start && (end >= periodBounds.end || end >= getFinalDayStart(period));
 };
 
 const makeTransactionCacheKey = (args: TransactionQueryArgs) =>
@@ -170,6 +185,45 @@ const selectCachedTransactions = (
     return completeGroups[0]?.transactions ?? null;
 };
 
+const fetchPeriodTransactions = async (period: CategoryPeriod): Promise<TransactionResponse[] | null> => {
+    const { startDate, endDate } = getPeriodQueryDates(period);
+    const transactions: TransactionResponse[] = [];
+    const seenIds = new Set<number>();
+    let totalItems = Number.POSITIVE_INFINITY;
+    let page = 1;
+
+    while (seenIds.size < totalItems && page <= CATEGORY_TRANSACTIONS_MAX_PAGES) {
+        const { data } = await apiClient.get<TransactionsPagedData>("/transactions", {
+            params: {
+                mode: "active",
+                pageSize: CATEGORY_TRANSACTIONS_PAGE_SIZE,
+                page,
+                startDate,
+                endDate,
+            },
+        });
+
+        if (!isTransactionsPagedData(data)) {
+            return null;
+        }
+
+        totalItems = data.metadata.totalItems;
+        data.data.forEach((transaction) => {
+            if (!seenIds.has(transaction.id)) {
+                seenIds.add(transaction.id);
+                transactions.push(transaction);
+            }
+        });
+
+        if (data.data.length === 0) {
+            break;
+        }
+        page += 1;
+    }
+
+    return seenIds.size >= totalItems ? transactions : null;
+};
+
 const getCurrentPeriod = () => {
     const now = new Date();
     return {
@@ -207,6 +261,7 @@ const Categories = () => {
     const [expandedId, setExpandedId] = React.useState<number | null>(null);
     const [createError, setCreateError] = React.useState<string | null>(null);
     const period = useCurrentPeriod();
+    const [periodTransactions, setPeriodTransactions] = React.useState<TransactionResponse[] | null>(null);
 
     const {
         data: categories = [],
@@ -229,12 +284,34 @@ const Categories = () => {
             budget.year === period.year && budget.month === period.month,
         );
     });
+    const currentPeriodTransactions = periodTransactions ?? cachedTransactions;
 
     React.useEffect(() => {
         if (expandedId != null && !categories.some((category) => category.id === expandedId)) {
             setExpandedId(null);
         }
     }, [categories, expandedId]);
+
+    React.useEffect(() => {
+        let cancelled = false;
+        setPeriodTransactions(null);
+
+        fetchPeriodTransactions(period)
+            .then((transactions) => {
+                if (!cancelled) {
+                    setPeriodTransactions(transactions);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setPeriodTransactions(null);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [period.month, period.year]);
 
     const filteredCategories = React.useMemo(() => {
         const query = search.trim().toLowerCase();
@@ -262,11 +339,11 @@ const Categories = () => {
         () =>
             computeCategorySpendStats({
                 categories,
-                transactions: cachedTransactions,
+                transactions: currentPeriodTransactions,
                 exchangeRates,
                 now: new Date(period.year, period.month - 1, 1),
             }),
-        [cachedTransactions, categories, exchangeRates, period.month, period.year],
+        [categories, currentPeriodTransactions, exchangeRates, period.month, period.year],
     );
 
     const periodLabel = React.useMemo(

--- a/inex/ClientApp/src/pages/Categories/categories.utils.test.ts
+++ b/inex/ClientApp/src/pages/Categories/categories.utils.test.ts
@@ -156,6 +156,24 @@ describe("category spend utilities", () => {
         expect(stats.distribution).toEqual([]);
     });
 
+    it("uses only exchange rates from the selected base currency", () => {
+        const categories = [category(1, "Travel")];
+
+        const stats = computeCategorySpendStats({
+            categories,
+            transactions: [transaction(1, 1, -200, "2026-06-01T08:00:00Z", "EUR")],
+            exchangeRates: [
+                { currencyFrom: "USD", currencyTo: "PLN", rate: 4 },
+                { currencyFrom: "GBP", currencyTo: "EUR", rate: 2 },
+                { currencyFrom: "USD", currencyTo: "EUR", rate: 5 },
+            ],
+            now: "2026-06-05T12:00:00Z",
+        });
+
+        expect(stats.available).toBe(true);
+        expect(stats.totalSpend).toBe(40);
+    });
+
     it("indexes only current-month budget links by category", () => {
         const budget = (
             id: number,

--- a/inex/ClientApp/src/pages/Categories/categories.utils.ts
+++ b/inex/ClientApp/src/pages/Categories/categories.utils.ts
@@ -188,7 +188,9 @@ const toBaseCurrencyAmount = (
         return amount;
     }
 
-    const rate = exchangeRates.find((item) => sameCurrency(item.currencyTo, accountCurrency));
+    const rate = exchangeRates.find((item) =>
+        sameCurrency(item.currencyFrom, baseCurrency) && sameCurrency(item.currencyTo, accountCurrency),
+    );
     if (!rate || !Number.isFinite(rate.rate) || rate.rate <= 0) {
         return null;
     }


### PR DESCRIPTION
## Summary

Addresses the second post-merge BMad review findings for Stories 10.3d, 10.3e, and 10.3f.

- Fixes zero-balance account group shares so complete zero totals render as `0%` instead of unavailable.
- Loads current-period Categories transactions through the existing paged transaction list contract when direct navigation has no complete cache, and tightens exchange-rate base matching.
- Gates Budgets report fetching until profile currency resolution completes, avoiding an initial hardcoded USD request for non-USD users.
- Corrects future/past budget pace boundaries, disables unsupported period years, hides stale edit snapshots after period changes, and restores drawer trigger focus after Escape/Cancel.
- Updates Epic/story records and Budgets QA summary with interaction/currency smoke evidence.

## Validation

From `inex/ClientApp`:

- `npm run build`
- `npm run lint`
- `npm run test` (56 tests)
- Focused Accounts/Categories/Budgets utility tests
- Targeted browser smoke for `/accounts`, `/categories`, and `/budgets` at mobile width with mock API contracts; confirmed no horizontal overflow, Categories spend visible on direct navigation, Budgets report request used `currency=PLN` and did not request USD, and Budgets drawer Escape/Cancel returned focus to `Add budget`.