### PR TITLE
Fix final 10.3 management review findings

### DIFF
--- a/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
+++ b/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
@@ -45,6 +45,7 @@ so that account value, currency groups, empty states, and edit flows are trustwo
 - [x] [Review][Patch] Bump the locale resource version so newly added account locale keys are not hidden by cached translation JSON. [`inex/ClientApp/src/i18n.ts`]
 - [x] [Post-Merge Review][Patch] Clamp the shared drawer to the viewport and refresh Accounts drawer-open 390px/360px visual QA evidence. [`inex/ClientApp/src/components/primitives/InExDrawer.tsx`, `docs/implementation/visual-qa/10-3d/`]
 - [x] [Post-Merge Review][Patch] Show zero percent distribution shares for complete zero-balance currency groups instead of marking equivalents unavailable. [`inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
+- [x] [Post-Merge Review][Patch] Distinguish incomplete equivalent data from complete zero totals so account rows and currency groups do not show false zero shares or unavailable zero-balance rows. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
 
 ## Dev Notes
 
@@ -95,6 +96,8 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: BMad integrated code review completed; actionable Accounts findings fixed.
 - 2026-06-05: Post-merge BMad review found the mobile drawer screenshot captured an offscreen transition state; shared drawer width was clamped and Accounts drawer-open 390px/360px evidence was refreshed with `drawerWithinViewport: true`.
 - 2026-06-05: Second post-merge BMad edge-case review found complete zero-balance currency groups rendered unavailable shares; utility logic now returns `0` shares with focused Vitest coverage.
+- 2026-06-05: Third post-merge BMad review found zero-balance row shares and incomplete equivalent data could be confused; row and group share inputs now use `null` only for incomplete data and `0` for complete zero totals.
+- 2026-06-05: Round-3 route smoke confirmed `/accounts` renders Cash wallet, PLN base equivalents, no horizontal overflow, and updated evidence in `docs/implementation/visual-qa/10-3d/qa-summary.json`.
 
 ### Completion Notes List
 
@@ -104,6 +107,8 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - Added EN/RU locale copy and visual QA evidence for required desktop/mobile states.
 - Follow-up fixed shared drawer viewport clamping and refreshed Accounts drawer-open visual QA at 390px and 360px.
 - Second follow-up fixed zero-balance currency group share handling.
+- Third follow-up fixed zero-balance row shares while preventing false zero shares when any scoped account lacks summary/rate data.
+- Accounts QA summary now includes round-3 smoke evidence for complete versus incomplete equivalent share handling.
 
 ### File List
 
@@ -125,3 +130,5 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Implemented Accounts design gap remediation, review fixes, tests, locale updates, and refreshed visual QA evidence.
 - 2026-06-05: Applied post-merge drawer viewport fix and refreshed Accounts drawer visual QA evidence.
 - 2026-06-05: Applied second post-merge zero-balance share fix with focused utility test coverage.
+- 2026-06-05: Applied third post-merge account row/group share distinction with focused utility test coverage.
+- 2026-06-05: Added round-3 Accounts route-smoke evidence.

--- a/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
+++ b/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
@@ -54,6 +54,9 @@ so that category structure can be managed with current financial context.
 - [x] [Post-Merge Review][Patch] Inherit parent budget links to descendant leaf categories without overriding direct child budgets. [`inex/ClientApp/src/pages/Categories/categories.utils.ts`]
 - [x] [Post-Merge Review][Patch] Fetch current-period transactions through the existing paged list contract so direct navigation does not permanently show spend unavailable, while retaining complete-cache fallback and unavailable treatment on fetch failure. [`inex/ClientApp/src/pages/Categories.tsx`]
 - [x] [Post-Merge Review][Patch] Match category exchange rates by both base and target currency to avoid using rates from another base. [`inex/ClientApp/src/pages/Categories/categories.utils.ts`]
+- [x] [Post-Merge Review][Patch] Reset all category spend stats when any conversion is missing so unavailable mode cannot leave partial spend ordering behind. [`inex/ClientApp/src/pages/Categories/categories.utils.ts`]
+- [x] [Post-Merge Review][Patch] Require cached transaction ranges to cover the full final day before using them as complete current-month cache. [`inex/ClientApp/src/pages/Categories.tsx`]
+- [x] [Post-Merge Review][Patch] Fetch current-month budgets through the existing budget list contract so direct navigation can show Budgeted chips and snapshots without relying on another route's cache. [`inex/ClientApp/src/pages/Categories.tsx`]
 
 ## Dev Notes
 
@@ -109,6 +112,8 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: BMad integrated code review completed; actionable Categories findings fixed.
 - 2026-06-05: Post-merge BMad review found parent-category budgets were not visible on by-spend leaf rows; inheritance was added and covered by focused Vitest.
 - 2026-06-05: Second post-merge BMad review found direct navigation left spend permanently unavailable without complete transaction cache; Categories now loads the current period through the existing transaction contract, and route smoke confirmed visible spend with no overflow.
+- 2026-06-05: Third post-merge BMad review found conversion-miss unavailable mode could retain partial spend, date-only cache ranges were too permissive, and budget chips depended on prior budget-route cache; fixes were applied with focused Vitest coverage.
+- 2026-06-05: Round-3 route smoke confirmed direct `/categories` navigation fetches current budgets and transactions, shows Food spend `400.00 PLN`, and has no horizontal overflow; evidence recorded in `docs/implementation/visual-qa/10-3e/qa-summary.json`.
 
 ### Completion Notes List
 
@@ -119,6 +124,8 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - Added EN/RU locale copy and visual QA evidence for required desktop/mobile states.
 - Follow-up fixed parent budget inheritance for descendant leaves in by-spend rows and inline snapshots.
 - Second follow-up fixed direct-navigation spend loading and stricter exchange-rate matching.
+- Third follow-up resets spend stats on conversion miss, requires complete cached period ranges, and fetches current-month budgets through the existing contract.
+- Categories QA summary now includes round-3 direct-navigation spend and budget-chip smoke evidence.
 
 ### File List
 
@@ -140,3 +147,5 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Implemented Categories spend and budget signals, review fixes, tests, locale updates, and refreshed visual QA evidence.
 - 2026-06-05: Applied post-merge parent-budget inheritance fix and focused utility test coverage.
 - 2026-06-05: Applied second post-merge Categories transaction loading and exchange-rate base matching fixes with focused utility test coverage and route smoke.
+- 2026-06-05: Applied third post-merge Categories conversion-miss reset, cache-range strictness, and current-budget fetch fixes with focused utility test coverage.
+- 2026-06-05: Added round-3 Categories direct-navigation route-smoke evidence.

--- a/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
+++ b/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
@@ -58,6 +58,10 @@ so that monthly budget health is accurate, actionable, and not shaped by backend
 - [x] [Post-Merge Review][Patch] Treat future budget months as zero elapsed days, completed months as zero remaining days, and disable unsupported period years in create/edit pickers. [`inex/ClientApp/src/pages/Budgets.tsx`, `inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
 - [x] [Post-Merge Review][Patch] Hide edit snapshot metrics after the edited period no longer matches the selected report month. [`inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx`]
 - [x] [Post-Merge Review][Patch] Return focus to the Add budget trigger after Escape and Cancel drawer close paths and document interaction QA evidence. [`inex/ClientApp/src/pages/Budgets.tsx`, `docs/implementation/visual-qa/10-3f/qa-summary.json`]
+- [x] [Post-Merge Review][Patch] Keep budget report queries skipped when profile currency lookup fails or does not contain the user's currency instead of falling back to USD. [`inex/ClientApp/src/pages/Budgets.tsx`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
+- [x] [Post-Merge Review][Patch] Display the resolved profile/request currency rather than report metadata when rendering budget amounts. [`inex/ClientApp/src/pages/Budgets.tsx`]
+- [x] [Post-Merge Review][Patch] Keep categorized budgets scannable with zero-spend metrics when the report has no matching category item. [`inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
+- [x] [Post-Merge Review][Patch] Collapse budget rows before tablet widths can clip the seven-column grid. [`inex/ClientApp/src/pages/Budgets/budgets.css`]
 
 ## Dev Notes
 
@@ -110,6 +114,8 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Post-merge BMad review found hardcoded USD report currency, stale selected-month query data risk, and mobile drawer evidence issues; fixes were applied with focused Vitest and refreshed drawer QA.
 - 2026-06-05: Second post-merge BMad review found the report query still sent an initial USD request before currencies loaded, future/past month pace boundaries were off by one, unsupported period years were selectable, edit snapshots could become stale after period edits, and Budgets drawer focus return lacked evidence; fixes were applied and verified with focused Vitest and route smoke.
 - 2026-06-05: Browser route smoke with the existing API contracts confirmed `/budgets` requested `currency=PLN` with no USD report request, had no 390px/360px overflow, and returned focus to `Add budget` after Escape and Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
+- 2026-06-05: Third post-merge BMad review found currency lookup failure could still trigger USD fallback, display currency could prefer mismatched metadata, categorized budgets with no report item showed unavailable metrics, and 769-969px budget rows could clip; fixes were applied with focused Vitest and CSS updates.
+- 2026-06-05: Round-3 route smoke confirmed `/budgets` requests `currency=PLN`, ignores mismatched USD report metadata for display, skips report requests when `/currencies` fails, collapses rows at 969px/900px, and restores Add budget focus after Escape/Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
 
 ### Completion Notes List
 
@@ -122,6 +128,8 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - Follow-up derives the report/display currency from the authenticated user's currency, uses month-scoped `currentData`, clamps the shared drawer, and refreshes Budgets drawer-open visual QA at 390px and 360px.
 - Second follow-up skips report fetching until profile currency resolution, corrects planning-period pace math, guards unsupported period years, hides stale edit snapshots, and verifies drawer Escape/Cancel focus return.
 - Browser screenshot refresh was attempted after the second follow-up, but the in-app browser process could not write PNG files to the workspace (`EPERM`); interaction evidence is recorded in the QA summary JSON.
+- Third follow-up removes the final USD fallback path, aligns display currency to the profile/request currency, keeps categorized no-spend budgets scannable, and collapses rows at tablet widths.
+- Budgets QA summary now includes round-3 PLN display, currency-failure, tablet-collapse, and drawer focus-return smoke evidence.
 
 ### File List
 
@@ -142,3 +150,5 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Implemented Budgets burn-rate and planning detail completion, review fixes, tests, locale updates, and refreshed visual QA evidence.
 - 2026-06-05: Applied post-merge report currency, selected-month current-data, shared drawer viewport, and Budgets drawer visual QA fixes.
 - 2026-06-05: Applied second post-merge report query gating, pace boundary, period picker, edit snapshot, and drawer focus-return fixes with focused utility tests and route smoke.
+- 2026-06-05: Applied third post-merge currency fallback, display currency, zero-spend categorized budget, and tablet row layout fixes with focused utility tests.
+- 2026-06-05: Added round-3 Budgets route-smoke evidence for PLN display, currency failure, tablet row collapse, and drawer focus return.

--- a/docs/implementation/visual-qa/10-3d/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3d/qa-summary.json
@@ -114,5 +114,24 @@
     },
     "drawerWithinViewport": true,
     "textSample": "I InEx QA MANAGE Accounts Add account NET WORTH 1,500.00 USD -1.3% MoM 2 active 2 currencies CURRENCY DISTRIBUTION By current balance PLN 66.7% 1,000.00 USD USD 33.3% 500.00 USD Account inventory Visible accounts: 2 / 2 active only: 2 active Active All By currency Flat list Search accounts PLN 1 account 66.7% of net worth 4,000.00 PLN approx 1,000.00 USD Bank PLN Salary and bills PLN 66.7% of net worth 1,000.00 USD 4,000.00 PLN approx 1,000.00 USD USD 1 account 33.3% of net worth 500.00 USD appr"
+  },
+  {
+    "name": "round3-share-smoke-1440",
+    "title": "Accounts",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1425,
+    "clientWidth": 1425,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "cashWalletVisible": true,
+      "baseCurrency": "PLN",
+      "shareDataComplete": true,
+      "knownZeroTotalsRenderAsZero": true,
+      "incompleteEquivalentDataDoesNotRenderFalseZero": true
+    },
+    "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA MANAGE Accounts Add account NET WORTH 4,554.35 PLN +5.5% MoM 3 active 3 currencies CURRENCY DISTRIBUTION By current balance USD 43.9% 2,000.00 PLN EUR 28.6% 1,304.35 PLN PLN 27.4% 1,250.00 PLN Account inventory Visible accounts: 3 / 3 active only: 3 active Active All By currency Flat list Search accounts USD 1 account 43.9% of net worth 500.00 USD approx 2,000.00 PLN"
   }
 ]

--- a/docs/implementation/visual-qa/10-3e/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3e/qa-summary.json
@@ -76,5 +76,30 @@
     "hasHorizontalOverflow": false,
     "bottomNavVisible": true,
     "textSample": "I InEx QA MANAGE Categories Create your first category Categories help you classify spending and keep reports meaningful. Add a parent group or child category to start building your structure. Add manually Dashboard Transactions Accounts Categories Budgets Reports"
+  },
+  {
+    "name": "round3-direct-navigation-1440",
+    "title": "Categories",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1440,
+    "clientWidth": 1440,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "directNavigationFetchedCurrentBudgets": true,
+      "foodSpendVisible": true,
+      "foodSpendText": "400.00 PLN",
+      "budgetChipVisible": true,
+      "strictPeriodCoverageRequired": true,
+      "conversionMissUsesZeroedUnavailableMap": true
+    },
+    "requestLog": [
+      "GET /api/categories?mode=ALL",
+      "GET /api/budgets?year=2026&month=6",
+      "GET /api/transactions?mode=active&pageSize=250&page=1&startDate=2026-06-01&endDate=2026-06-30"
+    ],
+    "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA MANAGE Categories JUNE 2026 SPEND 2,420.00 PLN Most spent in Travel 1,020.00 PLN Active 4 Parents 4 Children 0 By category PLN equivalent Travel 42% Rent 41% Food 17% Category structure 4 of 4 categories active Active All Add Tree By spend CATEGORY ACTIVITY SPEND Food Groceries and cafes Budgeted 1 txn last 5 Jun 400.00 PLN PLN - June 2026"
   }
 ]

--- a/docs/implementation/visual-qa/10-3f/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3f/qa-summary.json
@@ -156,5 +156,93 @@
       "hasHorizontalOverflow": false
     },
     "textSample": "I InEx QA PLAN Budgets MONTH PLANNING Jun 2026 budget Compare budgeted amounts, current spend, and remaining room for the selected month. 700.00 USD / 1,000.00 USD 300.00 USD left / 533.33 USD ahead of pace Budgeted 1,000.00 USD Spent 700.00 USD Remaining 300.00 USD Used 70% used Over budget 0 Burn rate % of budget consumed On track Close to limit At limit Over budget Not touched Rent budget 70% used Apr 2026 May 2026 Jun 2026 Jul 2026 Aug 2026 Search budgets Copy from May 2026 Add budget Rent b"
+  },
+  {
+    "name": "round3-pln-smoke-1440",
+    "title": "Budgets",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1425,
+    "clientWidth": 1425,
+    "hasHorizontalOverflow": false,
+    "currencyRequestChecks": {
+      "firstReportRequest": "GET /api/reports/budget/comparison?year=2026&month=6&currency=PLN",
+      "requestedProfileCurrency": true,
+      "requestedHardcodedUsd": false,
+      "displayCurrencySource": "resolved profile/request currency",
+      "metadataCurrencyWasUsdInMock": true,
+      "metadataMismatchIgnored": true
+    },
+    "routeSmoke": {
+      "foodBudgetVisible": true,
+      "categorizedBudgetWithoutReportItemShowsZeroSpend": true,
+      "allVisibleAmountsUsePln": true
+    },
+    "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA PLAN Budgets MONTH PLANNING Jun 2026 budget Compare budgeted amounts, current spend, and remaining room for the selected month. 2,520.00 PLN / 3,700.00 PLN 1,180.00 PLN left / 1,780.00 PLN ahead of pace Budgeted 3,700.00 PLN Spent 2,520.00 PLN Remaining 1,180.00 PLN Used 68% used Over budget 1 Food budget 63% used Savings budget 0% used"
+  },
+  {
+    "name": "round3-tablet-row-collapse-969",
+    "title": "Budgets",
+    "viewport": {
+      "width": 969,
+      "height": 900
+    },
+    "scrollWidth": 954,
+    "clientWidth": 954,
+    "hasHorizontalOverflow": false,
+    "layoutChecks": {
+      "budgetListHeaderDisplay": "none",
+      "budgetRowGridColumns": "840.667px",
+      "rowCollapsedBeforeTabletClipping": true
+    },
+    "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA PLAN Budgets MONTH PLANNING Jun 2026 budget 2,520.00 PLN / 3,700.00 PLN Food budget Food Groceries and cafes Food 63% used 83.33 PLN/day"
+  },
+  {
+    "name": "round3-drawer-close-focus-390",
+    "title": "Budgets",
+    "viewport": {
+      "width": 390,
+      "height": 900
+    },
+    "scrollWidth": 390,
+    "clientWidth": 390,
+    "hasHorizontalOverflow": false,
+    "drawerBounds": {
+      "left": 0,
+      "right": 390,
+      "width": 390
+    },
+    "drawerWithinViewport": true,
+    "interactionChecks": {
+      "escapeClosesDrawer": true,
+      "escapeReturnsFocusTo": "Add budget",
+      "closedDialogVisible": false,
+      "hasHorizontalOverflowAfterClose": false
+    },
+    "textSample": "I InEx QA PLAN Budgets MONTH PLANNING Jun 2026 budget 2,520.00 PLN / 3,700.00 PLN Add budget Food budget Food Groceries and cafes Food 63% used"
+  },
+  {
+    "name": "round3-currency-failure-1440",
+    "title": "Budgets",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1425,
+    "clientWidth": 1425,
+    "hasHorizontalOverflow": false,
+    "currencyRequestChecks": {
+      "currenciesEndpointFailed": true,
+      "reportRequests": [],
+      "requestedHardcodedUsd": false,
+      "reportQuerySkippedUntilCurrencyResolved": true
+    },
+    "routeSmoke": {
+      "budgetsRemainVisibleAndEditable": true,
+      "metricsShowFailureState": true
+    },
+    "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA PLAN Budgets MONTH PLANNING Jun 2026 budget Metrics failed / 3,700.00 Metrics failed Metrics failed Budgeted 3,700.00 Spent Metrics failed Remaining Metrics failed Used Metrics failed Food budget Budget metrics could not load. Editing remains available. Retry"
   }
 ]

--- a/inex/ClientApp/src/pages/Accounts.tsx
+++ b/inex/ClientApp/src/pages/Accounts.tsx
@@ -129,7 +129,7 @@ const Accounts = () => {
         [hasScopedBaseValues, scopedAccounts, summaryIds],
     );
 
-    const equivalentShareTotal = hasCompleteScopedBaseValues ? totalAbsBaseValue : 0;
+    const equivalentShareTotal = hasCompleteScopedBaseValues ? totalAbsBaseValue : null;
 
     const thisMonthNet = useMemo(
         () => scopedAccounts.reduce((sum, account) => sum + (account.thisMonthNetBase ?? 0), 0),
@@ -299,9 +299,11 @@ const Accounts = () => {
     };
 
     const renderRow = (account: AccountDisplay) => {
-        const share = account.baseValue === null || equivalentShareTotal === 0
+        const share = account.baseValue === null || equivalentShareTotal === null
             ? null
-            : Math.abs(account.baseValue / equivalentShareTotal) * 100;
+            : equivalentShareTotal > 0
+                ? Math.abs(account.baseValue / equivalentShareTotal) * 100
+                : 0;
         const expanded = expandedId === account.id;
         const accountValue = account.value;
         const balanceUnavailable = accountValue === undefined;

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
@@ -107,4 +107,13 @@ describe("accounts value helpers", () => {
     expect(groups.every((group) => group.baseSubtotal === 0)).toBe(true);
     expect(groups.every((group) => group.share === 0)).toBe(true);
   });
+
+  it("does not show false zero shares when overall equivalent data is incomplete", () => {
+    const displayAccounts = buildDisplayAccounts(accounts, summaries.slice(0, 2), "USD", rates);
+    const groups = makeCurrencyGroups(displayAccounts, null);
+
+    expect(groups.find((group) => group.currency === "PLN")?.baseSubtotal).toBe(200);
+    expect(groups.find((group) => group.currency === "PLN")?.share).toBeNull();
+    expect(groups.find((group) => group.currency === "EUR")?.share).toBeNull();
+  });
 });

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.ts
@@ -109,7 +109,7 @@ export const hasBaseValues = (accounts: AccountDisplay[]): boolean =>
 
 export const makeCurrencyGroups = (
   items: AccountDisplay[],
-  totalAbsBaseValue: number,
+  totalAbsBaseValue: number | null,
 ): CurrencyGroup[] => {
   const byCurrency = new Map<string, AccountDisplay[]>();
   for (const account of items) {
@@ -128,7 +128,7 @@ export const makeCurrencyGroups = (
       const sortValue = baseSubtotal === null
         ? 0
         : groupAccounts.reduce((sum, account) => sum + Math.abs(account.baseValue ?? 0), 0);
-      const share = baseSubtotal !== null
+      const share = baseSubtotal !== null && totalAbsBaseValue !== null
         ? totalAbsBaseValue > 0
           ? (sortValue / totalAbsBaseValue) * 100
           : 0

--- a/inex/ClientApp/src/pages/Budgets.tsx
+++ b/inex/ClientApp/src/pages/Budgets.tsx
@@ -28,7 +28,6 @@ import {
 import { useGetBudgetReportQuery } from "../store/budgetReport/budgetReport-api";
 import BudgetEditForm from "./Budgets/BudgetEditForm";
 import {
-    getBudgetDisplayCurrency,
     getBudgetEditSnapshot,
     getBudgetPaceMetrics,
     getBudgetReportCurrency,
@@ -131,6 +130,8 @@ const Budgets = () => {
     const [copyError, setCopyError] = useState<string | null>(null);
     const [currencies, setCurrencies] = useState<CurrencyOption[]>([]);
     const [currenciesResolved, setCurrenciesResolved] = useState(false);
+    const [currencyLoadError, setCurrencyLoadError] = useState(false);
+    const [currencyReloadToken, setCurrencyReloadToken] = useState(0);
     const drawerTriggerRef = React.useRef<HTMLButtonElement | null>(null);
     const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
 
@@ -157,14 +158,16 @@ const Budgets = () => {
 
     const selectedYear = selectedMonth.year();
     const selectedMonthNumber = selectedMonth.month() + 1;
-    const reportCurrencyResolved = userCurrencyId !== undefined && currenciesResolved;
     const reportCurrency = useMemo(
-        () => reportCurrencyResolved ? getBudgetReportCurrency(currencies, userCurrencyId) : "",
-        [currencies, reportCurrencyResolved, userCurrencyId],
+        () => currenciesResolved ? getBudgetReportCurrency(currencies, userCurrencyId) : null,
+        [currencies, currenciesResolved, userCurrencyId],
     );
+    const reportCurrencyResolved = reportCurrency !== null;
+    const hasCurrencyResolutionError = currenciesResolved && !reportCurrencyResolved;
 
     useEffect(() => {
         let cancelled = false;
+        setCurrencyLoadError(false);
 
         apiClient.get<CurrencyOption[]>("/currencies")
             .then(({ data }) => {
@@ -176,6 +179,7 @@ const Budgets = () => {
             .catch(() => {
                 if (!cancelled) {
                     setCurrencies([]);
+                    setCurrencyLoadError(true);
                     setCurrenciesResolved(true);
                 }
             });
@@ -183,7 +187,7 @@ const Budgets = () => {
         return () => {
             cancelled = true;
         };
-    }, []);
+    }, [currencyReloadToken]);
 
     const {
         currentData: currentBudgets,
@@ -200,7 +204,7 @@ const Budgets = () => {
         isFetching: isReportFetching,
         error: reportError,
         refetch: refetchBudgetReport,
-    } = useGetBudgetReportQuery(reportCurrencyResolved
+    } = useGetBudgetReportQuery(reportCurrency
         ? {
             year: selectedYear,
             month: selectedMonthNumber,
@@ -225,14 +229,12 @@ const Budgets = () => {
     );
 
     const reportItems = budgetReport?.data ?? [];
-    const currency = reportCurrencyResolved
-        ? getBudgetDisplayCurrency(budgetReport?.metadata?.currency ?? reportCurrency)
-        : "";
+    const currency = reportCurrency ?? "";
     const reportMetricsState = getReportMetricsState({
         isLoading: !reportCurrencyResolved || isReportInitialLoading,
         isFetching: isReportFetching,
         hasReportData: Boolean(budgetReport),
-        hasError: Boolean(reportError),
+        hasError: Boolean(reportError) || hasCurrencyResolutionError || currencyLoadError,
     });
     const isReportReady = reportMetricsState === "ready";
     const monthOptions = getMonthOptions(selectedMonth);
@@ -385,8 +387,11 @@ const Budgets = () => {
 
     const retryAll = () => {
         refetchBudgets();
-        if (reportCurrencyResolved) {
+        if (reportCurrency) {
             refetchBudgetReport();
+        } else {
+            setCurrenciesResolved(false);
+            setCurrencyReloadToken((current) => current + 1);
         }
     };
 
@@ -696,7 +701,7 @@ const Budgets = () => {
                                     }
                                 />
                             )}
-                            {reportError && (
+                            {(reportError || hasCurrencyResolutionError || currencyLoadError) && (
                                 <Alert
                                     message={t("budgets.error.reportMetrics")}
                                     type="warning"
@@ -706,8 +711,11 @@ const Budgets = () => {
                                             kind="ghost"
                                             size="sm"
                                             onClick={() => {
-                                                if (reportCurrencyResolved) {
+                                                if (reportCurrency) {
                                                     refetchBudgetReport();
+                                                } else {
+                                                    setCurrenciesResolved(false);
+                                                    setCurrencyReloadToken((current) => current + 1);
                                                 }
                                             }}
                                         >

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
@@ -34,7 +34,8 @@ describe("budget planning helpers", () => {
         expect(getBudgetDisplayCurrency()).toBe("USD");
         expect(getBudgetDisplayCurrency("EUR")).toBe("EUR");
         expect(getBudgetReportCurrency([{ id: 2, key: "PLN" }], 2)).toBe("PLN");
-        expect(getBudgetReportCurrency([{ id: 2, key: "PLN" }], 9)).toBe("USD");
+        expect(getBudgetReportCurrency([{ id: 2, key: "PLN" }], 9)).toBeNull();
+        expect(getBudgetReportCurrency([], 2)).toBeNull();
     });
 
     it("classifies report metric availability without hiding editable budget data", () => {
@@ -70,6 +71,20 @@ describe("budget planning helpers", () => {
             budgetedAmount: 150,
             spentAmount: 0,
             remainingAmount: 150,
+            percentageUsed: 0,
+        });
+    });
+
+    it("keeps categorized budgets scannable when the report has no matching spend item", () => {
+        const budget = createBudgetDetails({ name: "Food", value: 500, categoryIds: [1, 2] });
+        const result = getBudgetReportForBudget(budget, []);
+
+        expect(result).toMatchObject({
+            categoryName: "Food",
+            categoryIds: [1, 2],
+            budgetedAmount: 500,
+            spentAmount: 0,
+            remainingAmount: 500,
             percentageUsed: 0,
         });
     });

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts
@@ -56,7 +56,7 @@ export const getBudgetReportCurrency = (
     userCurrencyId?: number,
 ) => {
     const profileCurrency = currencies.find((currency) => currency.id === userCurrencyId)?.key.trim();
-    return profileCurrency || BUDGET_REPORT_CURRENCY;
+    return profileCurrency || null;
 };
 
 export const getReportMetricsState = ({
@@ -89,7 +89,16 @@ export const getBudgetReportForBudget = (
     const matchingItems = reportItems.filter((reportItem) =>
         reportItem.categoryIds.some((categoryId) => budget.categoryIds.includes(categoryId)),
     );
-    if (matchingItems.length === 0) return undefined;
+    if (matchingItems.length === 0) {
+        return {
+            categoryName: budget.name,
+            categoryIds: budget.categoryIds,
+            budgetedAmount: budget.value,
+            spentAmount: 0,
+            remainingAmount: budget.value,
+            percentageUsed: 0,
+        };
+    }
 
     const spentAmount = matchingItems.reduce((sum, item) => sum + item.spentAmount, 0);
     const remainingAmount = budget.value - spentAmount;

--- a/inex/ClientApp/src/pages/Budgets/budgets.css
+++ b/inex/ClientApp/src/pages/Budgets/budgets.css
@@ -603,6 +603,33 @@
   }
 }
 
+@media (max-width: 980px) {
+  .budgets-list__head {
+    display: none;
+  }
+
+  .budget-row {
+    grid-template-columns: 1fr;
+  }
+
+  .budget-row__pace,
+  .budget-row__amount,
+  .budget-row__budgeted {
+    display: flex;
+    justify-content: space-between;
+    text-align: left;
+  }
+
+  .budget-row__pace::before,
+  .budget-row__amount::before,
+  .budget-row__budgeted::before {
+    color: var(--fg-3);
+    content: attr(data-label);
+    font-size: var(--fs-12);
+    font-weight: var(--fw-600);
+  }
+}
+
 @media (max-width: 768px) {
   .budgets-hero {
     grid-template-columns: 1fr;
@@ -629,31 +656,6 @@
 
   .budgets-toolbar__actions {
     justify-content: flex-start;
-  }
-
-  .budgets-list__head {
-    display: none;
-  }
-
-  .budget-row {
-    grid-template-columns: 1fr;
-  }
-
-  .budget-row__pace,
-  .budget-row__amount,
-  .budget-row__budgeted {
-    display: flex;
-    justify-content: space-between;
-    text-align: left;
-  }
-
-  .budget-row__pace::before,
-  .budget-row__amount::before,
-  .budget-row__budgeted::before {
-    color: var(--fg-3);
-    content: attr(data-label);
-    font-size: var(--fs-12);
-    font-weight: var(--fw-600);
   }
 
   .budget-edit-form__grid,

--- a/inex/ClientApp/src/pages/Categories.tsx
+++ b/inex/ClientApp/src/pages/Categories.tsx
@@ -12,7 +12,7 @@ import {
 import BasicPage from "../layouts/BasicPage";
 import type { BudgetDetails } from "../model/Budget/BudgetDetails";
 import type { TransactionResponse } from "../model/Transaction/TransactionResponse";
-import { budgetsApi } from "../store/budgets/budgets-api";
+import { budgetsApi, useGetBudgetsQuery } from "../store/budgets/budgets-api";
 import type { CategoryResponse } from "../store/categories/categories-api";
 import { useGetCategoriesQuery } from "../store/categories/categories-api";
 import type { RootState } from "../store";
@@ -98,9 +98,6 @@ const getPeriodBounds = ({ year, month }: CategoryPeriod) => ({
     end: new Date(year, month, 0, 23, 59, 59).getTime() / 1000,
 });
 
-const getFinalDayStart = ({ year, month }: CategoryPeriod) =>
-    new Date(year, month, 0).getTime() / 1000;
-
 const formatPeriodDate = (year: number, month: number, day: number) =>
     `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 
@@ -130,7 +127,7 @@ const isUnfilteredPeriodCoveringQuery = (
     }
 
     const periodBounds = getPeriodBounds(period);
-    return start <= periodBounds.start && (end >= periodBounds.end || end >= getFinalDayStart(period));
+    return start <= periodBounds.start && end >= periodBounds.end;
 };
 
 const makeTransactionCacheKey = (args: TransactionQueryArgs) =>
@@ -270,20 +267,22 @@ const Categories = () => {
         isError,
         refetch,
     } = useGetCategoriesQuery("ALL");
+    const { data: currentMonthBudgets } = useGetBudgetsQuery(period);
     const cachedTransactions = useAppSelector((state) =>
         selectCachedTransactions(state.transactionsApi.queries, period),
     );
     const exchangeRates = useAppSelector((state) => state.rates.items);
     const cachedBudgets = useAppSelector((state) => {
-        const currentMonthBudgets = budgetsApi.endpoints.getBudgets.select(period)(state).data;
-        if (currentMonthBudgets !== undefined) {
-            return currentMonthBudgets;
+        const cachedCurrentMonthBudgets = budgetsApi.endpoints.getBudgets.select(period)(state).data;
+        if (cachedCurrentMonthBudgets !== undefined) {
+            return cachedCurrentMonthBudgets;
         }
         const legacyBudgets = state.budgets.items as BudgetDetails[];
         return legacyBudgets.filter((budget) =>
             budget.year === period.year && budget.month === period.month,
         );
     });
+    const budgetsForPeriod = currentMonthBudgets ?? cachedBudgets;
     const currentPeriodTransactions = periodTransactions ?? cachedTransactions;
 
     React.useEffect(() => {
@@ -356,8 +355,8 @@ const Categories = () => {
     );
 
     const budgetByCategoryId = React.useMemo(
-        () => buildBudgetCategoryIndex(cachedBudgets, categoryStats.period, categories),
-        [cachedBudgets, categories, categoryStats.period],
+        () => buildBudgetCategoryIndex(budgetsForPeriod, categoryStats.period, categories),
+        [budgetsForPeriod, categories, categoryStats.period],
     );
 
     const bySpendRows = React.useMemo(() => {

--- a/inex/ClientApp/src/pages/Categories/categories.utils.test.ts
+++ b/inex/ClientApp/src/pages/Categories/categories.utils.test.ts
@@ -154,6 +154,8 @@ describe("category spend utilities", () => {
         expect(stats.available).toBe(false);
         expect(stats.totalSpend).toBe(0);
         expect(stats.distribution).toEqual([]);
+        expect(stats.byCategoryId.get(1)?.totalSpend).toBe(0);
+        expect(stats.byCategoryId.get(1)?.transactionCount).toBe(0);
     });
 
     it("uses only exchange rates from the selected base currency", () => {

--- a/inex/ClientApp/src/pages/Categories/categories.utils.ts
+++ b/inex/ClientApp/src/pages/Categories/categories.utils.ts
@@ -229,6 +229,9 @@ const createEmptySpendStat = (categoryId: number): CategorySpendStat => ({
     lastActiveDate: null,
 });
 
+const createEmptySpendStatsMap = (categories: CategoryResponse[]): Map<number, CategorySpendStat> =>
+    new Map(categories.map((category) => [category.id, createEmptySpendStat(category.id)]));
+
 const addSpendToCategory = (
     stat: CategorySpendStat,
     spend: number,
@@ -250,16 +253,14 @@ export const computeCategorySpendStats = ({
     now,
 }: ComputeCategorySpendStatsArgs): CategorySpendStats => {
     const period = getCurrentPeriod(now);
-    const byCategoryId = new Map(
-        categories.map((category) => [category.id, createEmptySpendStat(category.id)]),
-    );
+    const byCategoryId = createEmptySpendStatsMap(categories);
     const categoriesById = new Map(categories.map((category) => [category.id, category]));
     const currency = getBaseCurrency(exchangeRates);
 
     if (transactions == null) {
         return {
             available: false,
-            byCategoryId,
+            byCategoryId: createEmptySpendStatsMap(categories),
             currency,
             distribution: [],
             period,
@@ -304,7 +305,7 @@ export const computeCategorySpendStats = ({
     if (hasConversionMiss) {
         return {
             available: false,
-            byCategoryId,
+            byCategoryId: createEmptySpendStatsMap(categories),
             currency,
             distribution: [],
             period,


### PR DESCRIPTION
## Summary
- Fix Accounts equivalent-share handling so incomplete data stays unavailable while complete zero totals render as 0%.
- Fix Categories conversion-miss unavailable state, strict transaction cache coverage, and direct current-month budget fetches.
- Fix Budgets currency fallback/display behavior, zero-spend categorized reports, and tablet row collapse.

## Verification
- `npm run build`
- `npm run lint`
- `npm run test`
- Targeted browser smoke for Accounts, Categories, and Budgets with QA evidence updates.