### PR TITLE
fix: address fourth management review findings

### DIFF
--- a/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
+++ b/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
@@ -46,6 +46,8 @@ so that account value, currency groups, empty states, and edit flows are trustwo
 - [x] [Post-Merge Review][Patch] Clamp the shared drawer to the viewport and refresh Accounts drawer-open 390px/360px visual QA evidence. [`inex/ClientApp/src/components/primitives/InExDrawer.tsx`, `docs/implementation/visual-qa/10-3d/`]
 - [x] [Post-Merge Review][Patch] Show zero percent distribution shares for complete zero-balance currency groups instead of marking equivalents unavailable. [`inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
 - [x] [Post-Merge Review][Patch] Distinguish incomplete equivalent data from complete zero totals so account rows and currency groups do not show false zero shares or unavailable zero-balance rows. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
+- [x] [Post-Merge Review][Patch] Derive base currency only from profile/rate data so missing currency resolution shows unavailable states instead of inventing USD. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
+- [x] [Post-Merge Review][Patch] Render complete zero-share currency distribution and group bars at 0% instead of a minimum-width sliver. [`inex/ClientApp/src/pages/Accounts.tsx`]
 
 ## Dev Notes
 
@@ -98,6 +100,7 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Second post-merge BMad edge-case review found complete zero-balance currency groups rendered unavailable shares; utility logic now returns `0` shares with focused Vitest coverage.
 - 2026-06-05: Third post-merge BMad review found zero-balance row shares and incomplete equivalent data could be confused; row and group share inputs now use `null` only for incomplete data and `0` for complete zero totals.
 - 2026-06-05: Round-3 route smoke confirmed `/accounts` renders Cash wallet, PLN base equivalents, no horizontal overflow, and updated evidence in `docs/implementation/visual-qa/10-3d/qa-summary.json`.
+- 2026-06-05: Fourth post-merge BMad review found profile/rate lookup failures could still imply a USD base and complete zero-share bars rendered visible slivers; fixes were applied with focused Vitest and route smoke evidence.
 
 ### Completion Notes List
 
@@ -109,6 +112,8 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - Second follow-up fixed zero-balance currency group share handling.
 - Third follow-up fixed zero-balance row shares while preventing false zero shares when any scoped account lacks summary/rate data.
 - Accounts QA summary now includes round-3 smoke evidence for complete versus incomplete equivalent share handling.
+- Fourth follow-up removes the final USD fallback path for Accounts base currency and renders complete zero-balance distribution/group bars at true 0% width.
+- Accounts QA summary now includes round-4 smoke evidence for missing base-currency unavailable states and zero-width zero-share bars.
 
 ### File List
 
@@ -132,3 +137,4 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Applied second post-merge zero-balance share fix with focused utility test coverage.
 - 2026-06-05: Applied third post-merge account row/group share distinction with focused utility test coverage.
 - 2026-06-05: Added round-3 Accounts route-smoke evidence.
+- 2026-06-05: Applied fourth post-merge Accounts base-currency fallback and zero-share bar fixes with focused utility tests and route smoke.

--- a/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
+++ b/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
@@ -57,6 +57,9 @@ so that category structure can be managed with current financial context.
 - [x] [Post-Merge Review][Patch] Reset all category spend stats when any conversion is missing so unavailable mode cannot leave partial spend ordering behind. [`inex/ClientApp/src/pages/Categories/categories.utils.ts`]
 - [x] [Post-Merge Review][Patch] Require cached transaction ranges to cover the full final day before using them as complete current-month cache. [`inex/ClientApp/src/pages/Categories.tsx`]
 - [x] [Post-Merge Review][Patch] Fetch current-month budgets through the existing budget list contract so direct navigation can show Budgeted chips and snapshots without relying on another route's cache. [`inex/ClientApp/src/pages/Categories.tsx`]
+- [x] [Post-Merge Review][Patch] Send current-period direct transaction fetches and shared transaction filters with full-day datetimes so final-day transactions are included. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/store/transactions/transactions-api.ts`]
+- [x] [Post-Merge Review][Patch] Resolve category spend base currency only from profile/rate data and show unavailable spend instead of inventing USD when resolution fails. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/pages/Categories/categories.utils.ts`]
+- [x] [Post-Merge Review][Patch] Return focus to the Add Category trigger after the create drawer closes. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx`]
 
 ## Dev Notes
 
@@ -114,6 +117,7 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Second post-merge BMad review found direct navigation left spend permanently unavailable without complete transaction cache; Categories now loads the current period through the existing transaction contract, and route smoke confirmed visible spend with no overflow.
 - 2026-06-05: Third post-merge BMad review found conversion-miss unavailable mode could retain partial spend, date-only cache ranges were too permissive, and budget chips depended on prior budget-route cache; fixes were applied with focused Vitest coverage.
 - 2026-06-05: Round-3 route smoke confirmed direct `/categories` navigation fetches current budgets and transactions, shows Food spend `400.00 PLN`, and has no horizontal overflow; evidence recorded in `docs/implementation/visual-qa/10-3e/qa-summary.json`.
+- 2026-06-05: Fourth post-merge BMad review found final-day direct-fetch transactions were excluded, missing base-currency resolution could imply USD, and Add Category drawer close did not restore trigger focus; fixes were applied with focused Vitest and route smoke.
 
 ### Completion Notes List
 
@@ -126,16 +130,21 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - Second follow-up fixed direct-navigation spend loading and stricter exchange-rate matching.
 - Third follow-up resets spend stats on conversion miss, requires complete cached period ranges, and fetches current-month budgets through the existing contract.
 - Categories QA summary now includes round-3 direct-navigation spend and budget-chip smoke evidence.
+- Fourth follow-up serializes transaction filter ranges with full-day datetimes, removes the final category spend USD fallback path, and restores Add Category trigger focus after drawer close.
+- Categories QA summary now includes round-4 smoke evidence for final-day spend inclusion, missing-base unavailable state, and Add trigger focus return.
 
 ### File List
 
 - `inex/ClientApp/src/pages/Categories.tsx`
 - `inex/ClientApp/src/pages/Categories/CategoriesHero.tsx`
+- `inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx`
 - `inex/ClientApp/src/pages/Categories/CategoryRow.tsx`
 - `inex/ClientApp/src/pages/Categories/CategoryInlineEdit.tsx`
 - `inex/ClientApp/src/pages/Categories/categories.css`
 - `inex/ClientApp/src/pages/Categories/categories.utils.ts`
 - `inex/ClientApp/src/pages/Categories/categories.utils.test.ts`
+- `inex/ClientApp/src/store/transactions/transactions-api.ts`
+- `inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts`
 - `inex/ClientApp/public/locales/en/translation.json`
 - `inex/ClientApp/public/locales/ru/translation.json`
 - `inex/ClientApp/src/i18n.ts`
@@ -149,3 +158,4 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Applied second post-merge Categories transaction loading and exchange-rate base matching fixes with focused utility test coverage and route smoke.
 - 2026-06-05: Applied third post-merge Categories conversion-miss reset, cache-range strictness, and current-budget fetch fixes with focused utility test coverage.
 - 2026-06-05: Added round-3 Categories direct-navigation route-smoke evidence.
+- 2026-06-05: Applied fourth post-merge Categories full-day transaction filter, base-currency fallback, and Add drawer focus-return fixes with focused tests and route smoke.

--- a/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
+++ b/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
@@ -60,6 +60,8 @@ so that category structure can be managed with current financial context.
 - [x] [Post-Merge Review][Patch] Send current-period direct transaction fetches and shared transaction filters with full-day datetimes so final-day transactions are included. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/store/transactions/transactions-api.ts`]
 - [x] [Post-Merge Review][Patch] Resolve category spend base currency only from profile/rate data and show unavailable spend instead of inventing USD when resolution fails. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/pages/Categories/categories.utils.ts`]
 - [x] [Post-Merge Review][Patch] Return focus to the Add Category trigger after the create drawer closes. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx`]
+- [x] [PR Review][Patch] Parse date-only transaction filter URLs as inclusive calendar days so linked/report-driven end dates do not drop final-day activity. [`inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts`]
+- [x] [PR Review][Patch] Keep Add Category focus recovery valid when the empty-state opener unmounts after a successful first category create. [`inex/ClientApp/src/pages/Categories.tsx`]
 
 ## Dev Notes
 
@@ -118,6 +120,7 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Third post-merge BMad review found conversion-miss unavailable mode could retain partial spend, date-only cache ranges were too permissive, and budget chips depended on prior budget-route cache; fixes were applied with focused Vitest coverage.
 - 2026-06-05: Round-3 route smoke confirmed direct `/categories` navigation fetches current budgets and transactions, shows Food spend `400.00 PLN`, and has no horizontal overflow; evidence recorded in `docs/implementation/visual-qa/10-3e/qa-summary.json`.
 - 2026-06-05: Fourth post-merge BMad review found final-day direct-fetch transactions were excluded, missing base-currency resolution could imply USD, and Add Category drawer close did not restore trigger focus; fixes were applied with focused Vitest and route smoke.
+- 2026-06-06: BMad PR review found URL-driven transaction filters still parsed date-only end values at midnight and empty-state create could unmount the stored Add opener; the shared transaction filter URL parser now expands date-only end dates to the end of day, and Add focus recovery falls back to the mounted toolbar trigger.
 
 ### Completion Notes List
 
@@ -132,6 +135,7 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - Categories QA summary now includes round-3 direct-navigation spend and budget-chip smoke evidence.
 - Fourth follow-up serializes transaction filter ranges with full-day datetimes, removes the final category spend USD fallback path, and restores Add Category trigger focus after drawer close.
 - Categories QA summary now includes round-4 smoke evidence for final-day spend inclusion, missing-base unavailable state, and Add trigger focus return.
+- PR review follow-up expands date-only transaction URL filter end dates to inclusive end-of-day timestamps so linked transaction views preserve final-day coverage, and keeps focus recovery valid when the empty-state Add opener unmounts after create.
 
 ### File List
 
@@ -145,6 +149,8 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - `inex/ClientApp/src/pages/Categories/categories.utils.test.ts`
 - `inex/ClientApp/src/store/transactions/transactions-api.ts`
 - `inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts`
+- `inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts`
+- `inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts`
 - `inex/ClientApp/public/locales/en/translation.json`
 - `inex/ClientApp/public/locales/ru/translation.json`
 - `inex/ClientApp/src/i18n.ts`
@@ -159,3 +165,4 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Applied third post-merge Categories conversion-miss reset, cache-range strictness, and current-budget fetch fixes with focused utility test coverage.
 - 2026-06-05: Added round-3 Categories direct-navigation route-smoke evidence.
 - 2026-06-05: Applied fourth post-merge Categories full-day transaction filter, base-currency fallback, and Add drawer focus-return fixes with focused tests and route smoke.
+- 2026-06-06: Fixed PR-review findings for inclusive date-only transaction URL filters and empty-state Add focus fallback with focused parser tests.

--- a/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
+++ b/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
@@ -62,6 +62,8 @@ so that monthly budget health is accurate, actionable, and not shaped by backend
 - [x] [Post-Merge Review][Patch] Display the resolved profile/request currency rather than report metadata when rendering budget amounts. [`inex/ClientApp/src/pages/Budgets.tsx`]
 - [x] [Post-Merge Review][Patch] Keep categorized budgets scannable with zero-spend metrics when the report has no matching category item. [`inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
 - [x] [Post-Merge Review][Patch] Collapse budget rows before tablet widths can clip the seven-column grid. [`inex/ClientApp/src/pages/Budgets/budgets.css`]
+- [x] [Post-Merge Review][Patch] Normalize invalid, nonnumeric, or unsupported URL year/month params to the current supported budget period before querying. [`inex/ClientApp/src/pages/Budgets.tsx`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
+- [x] [Post-Merge Review][Patch] Collapse budget rows at 1024px tablet width so the seven-column row cannot clip before the mobile layout applies. [`inex/ClientApp/src/pages/Budgets/budgets.css`]
 
 ## Dev Notes
 
@@ -116,6 +118,7 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Browser route smoke with the existing API contracts confirmed `/budgets` requested `currency=PLN` with no USD report request, had no 390px/360px overflow, and returned focus to `Add budget` after Escape and Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
 - 2026-06-05: Third post-merge BMad review found currency lookup failure could still trigger USD fallback, display currency could prefer mismatched metadata, categorized budgets with no report item showed unavailable metrics, and 769-969px budget rows could clip; fixes were applied with focused Vitest and CSS updates.
 - 2026-06-05: Round-3 route smoke confirmed `/budgets` requests `currency=PLN`, ignores mismatched USD report metadata for display, skips report requests when `/currencies` fails, collapses rows at 969px/900px, and restores Add budget focus after Escape/Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
+- 2026-06-05: Fourth post-merge BMad review found invalid URL period params could produce unsupported queries and 1024px tablet rows could still clip; fixes were applied with focused Vitest and route smoke.
 
 ### Completion Notes List
 
@@ -130,6 +133,8 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - Browser screenshot refresh was attempted after the second follow-up, but the in-app browser process could not write PNG files to the workspace (`EPERM`); interaction evidence is recorded in the QA summary JSON.
 - Third follow-up removes the final USD fallback path, aligns display currency to the profile/request currency, keeps categorized no-spend budgets scannable, and collapses rows at tablet widths.
 - Budgets QA summary now includes round-3 PLN display, currency-failure, tablet-collapse, and drawer focus-return smoke evidence.
+- Fourth follow-up normalizes invalid URL year/month params before Budgets queries and moves the row-collapse breakpoint to cover 1024px tablet widths.
+- Budgets QA summary now includes round-4 smoke evidence for invalid-param normalization and 1024px row collapse.
 
 ### File List
 
@@ -152,3 +157,4 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Applied second post-merge report query gating, pace boundary, period picker, edit snapshot, and drawer focus-return fixes with focused utility tests and route smoke.
 - 2026-06-05: Applied third post-merge currency fallback, display currency, zero-spend categorized budget, and tablet row layout fixes with focused utility tests.
 - 2026-06-05: Added round-3 Budgets route-smoke evidence for PLN display, currency failure, tablet row collapse, and drawer focus return.
+- 2026-06-05: Applied fourth post-merge Budgets URL period normalization and 1024px row-collapse fixes with focused utility tests and route smoke.

--- a/docs/implementation/visual-qa/10-3d/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3d/qa-summary.json
@@ -133,5 +133,32 @@
       "incompleteEquivalentDataDoesNotRenderFalseZero": true
     },
     "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA MANAGE Accounts Add account NET WORTH 4,554.35 PLN +5.5% MoM 3 active 3 currencies CURRENCY DISTRIBUTION By current balance USD 43.9% 2,000.00 PLN EUR 28.6% 1,304.35 PLN PLN 27.4% 1,250.00 PLN Account inventory Visible accounts: 3 / 3 active only: 3 active Active All By currency Flat list Search accounts USD 1 account 43.9% of net worth 500.00 USD approx 2,000.00 PLN"
+  },
+  {
+    "name": "round4-base-and-zero-bars-1440",
+    "title": "Accounts",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1425,
+    "clientWidth": 1425,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "cashWalletVisible": true,
+      "missingBaseShowsBalanceUnavailable": true,
+      "missingBaseShowsEquivalentUnavailable": true,
+      "missingBaseDoesNotInventUsdHero": true,
+      "completeZeroShareBarsRenderAtZeroWidth": true
+    },
+    "zeroShareBarWidths": [
+      "width: 0%;",
+      "width: 0%;",
+      "width: 0%;",
+      "width: 0%;",
+      "width: 0%;",
+      "width: 0%;"
+    ],
+    "textSample": "Normal Accounts smoke rendered Cash Wallet with PLN base equivalents and no horizontal overflow. Missing currency/rate smoke rendered NET WORTH Balance unavailable and Equivalent unavailable labels instead of inventing USD. Zero-balance smoke rendered all distribution and group bars at width: 0%."
   }
 ]

--- a/docs/implementation/visual-qa/10-3e/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3e/qa-summary.json
@@ -129,5 +129,29 @@
       "activeText": "Add"
     },
     "textSample": "Direct Categories smoke included the final-day Food transaction for 460.00 PLN, used an end-of-day transaction request, rendered Spend unavailable when currency/rate resolution failed, and returned focus to Add after the create drawer closed."
+  },
+  {
+    "name": "pr-review-url-filter-empty-create-focus",
+    "title": "Categories",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1440,
+    "clientWidth": 1440,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "transactionUrlEndDateUsesEndOfDay": true,
+      "emptyStateCreateFocusReturnedToToolbarAdd": true,
+      "createdCategoryVisibleAfterEmptyCreate": true
+    },
+    "requestLog": [
+      "GET /api/transactions?mode=active&pageSize=20&page=1&startDate=2026-06-01T00:00:00&endDate=2026-06-30T23:59:59"
+    ],
+    "focusAfterCreate": {
+      "activeTag": "BUTTON",
+      "activeText": "Add"
+    },
+    "textSample": "PR-review smoke confirmed date-only Transactions URL filters serialize end dates as 23:59:59, and first category creation from the empty state returns focus to the mounted toolbar Add button after the empty-state opener unmounts."
   }
 ]

--- a/docs/implementation/visual-qa/10-3e/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3e/qa-summary.json
@@ -101,5 +101,33 @@
       "GET /api/transactions?mode=active&pageSize=250&page=1&startDate=2026-06-01&endDate=2026-06-30"
     ],
     "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA MANAGE Categories JUNE 2026 SPEND 2,420.00 PLN Most spent in Travel 1,020.00 PLN Active 4 Parents 4 Children 0 By category PLN equivalent Travel 42% Rent 41% Food 17% Category structure 4 of 4 categories active Active All Add Tree By spend CATEGORY ACTIVITY SPEND Food Groceries and cafes Budgeted 1 txn last 5 Jun 400.00 PLN PLN - June 2026"
+  },
+  {
+    "name": "round4-final-day-base-focus-1440",
+    "title": "Categories",
+    "viewport": {
+      "width": 1440,
+      "height": 1000
+    },
+    "scrollWidth": 1440,
+    "clientWidth": 1440,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "finalDayFoodSpendVisible": true,
+      "finalDayFoodSpendText": "460.00 PLN",
+      "endDateRequestUsedEndOfDay": true,
+      "missingBaseShowsSpendUnavailable": true,
+      "missingBaseHasNoUsdEquivalentSignal": true,
+      "addDrawerClosedWithCloseButton": true,
+      "focusReturnedToAdd": true
+    },
+    "requestLog": [
+      "GET /api/transactions?mode=active&pageSize=250&page=1&startDate=2026-06-01T00:00:00&endDate=2026-06-30T23:59:59"
+    ],
+    "focusAfterClose": {
+      "activeTag": "BUTTON",
+      "activeText": "Add"
+    },
+    "textSample": "Direct Categories smoke included the final-day Food transaction for 460.00 PLN, used an end-of-day transaction request, rendered Spend unavailable when currency/rate resolution failed, and returned focus to Add after the create drawer closed."
   }
 ]

--- a/docs/implementation/visual-qa/10-3f/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3f/qa-summary.json
@@ -244,5 +244,31 @@
       "metricsShowFailureState": true
     },
     "textSample": "I InEx Dashboard Transactions Accounts Categories Budgets Reports QA QA PLAN Budgets MONTH PLANNING Jun 2026 budget Metrics failed / 3,700.00 Metrics failed Metrics failed Budgeted 3,700.00 Spent Metrics failed Remaining Metrics failed Used Metrics failed Food budget Budget metrics could not load. Editing remains available. Retry"
+  },
+  {
+    "name": "round4-invalid-params-and-1024-collapse",
+    "title": "Budgets",
+    "viewport": {
+      "width": 1024,
+      "height": 900
+    },
+    "scrollWidth": 1009,
+    "clientWidth": 1009,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "invalidParamsNormalizedToSupportedMonth": true,
+      "normalizedUrl": "http://127.0.0.1:5177/budgets?year=2026&month=6",
+      "noNaNOrInvalidRequests": true,
+      "rowCollapsedAt1024": true
+    },
+    "layoutChecks": {
+      "budgetListHeaderDisplay": "none",
+      "budgetRowGridColumns": "895.333px"
+    },
+    "requestLog": [
+      "GET /api/budgets?year=2026&month=6",
+      "GET /api/reports/budget/comparison?year=2026&month=6&currency=PLN"
+    ],
+    "textSample": "Budgets invalid-param smoke normalized /budgets?year=abc&month=13 to year=2026&month=6 before data requests. At 1024px, the list header was hidden, rows used a single-column grid, and no horizontal overflow was present."
   }
 ]

--- a/inex/ClientApp/src/pages/Accounts.tsx
+++ b/inex/ClientApp/src/pages/Accounts.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert } from "antd";
 import {
@@ -23,6 +23,7 @@ import {
 } from "../components/primitives";
 import BasicPage from "../layouts/BasicPage";
 import { useAppSelector } from "../store/hooks";
+import apiClient from "../utils/apiClient";
 import {
     useGetAccountsQuery,
     useGetAccountsSummaryQuery,
@@ -45,6 +46,11 @@ import "./Accounts/accounts.css";
 
 type AccountScope = "active" | "all";
 type AccountViewMode = "currency" | "flat";
+
+interface CurrencyOption {
+    id: number;
+    key: string;
+}
 
 const currencyToneClass = (currency: string): string => {
     const tones = ["teal", "slate", "amber", "terracotta", "ink"];
@@ -73,10 +79,36 @@ const Accounts = () => {
     const [search, setSearch] = useState("");
     const [expandedId, setExpandedId] = useState<number | null>(null);
     const [collapsedCurrencies, setCollapsedCurrencies] = useState<Set<string>>(new Set());
+    const [currencies, setCurrencies] = useState<CurrencyOption[]>([]);
     const drawerTriggerRef = useRef<HTMLButtonElement | null>(null);
 
     const exchangeRates = useAppSelector((state) => state.rates.items);
-    const baseCurrency = getBaseCurrency(exchangeRates);
+    const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
+    const profileCurrency = useMemo(
+        () => currencies.find((currency) => currency.id === userCurrencyId)?.key.trim() || null,
+        [currencies, userCurrencyId],
+    );
+    const baseCurrency = getBaseCurrency(exchangeRates, profileCurrency);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        apiClient.get<CurrencyOption[]>("/currencies")
+            .then(({ data }) => {
+                if (!cancelled) {
+                    setCurrencies(data);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setCurrencies([]);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     const accountsQuery = useGetAccountsQuery("ALL");
     const accounts = accountsQuery.data ?? [];
@@ -213,7 +245,7 @@ const Accounts = () => {
         value: number | null,
         options: { approx?: boolean; className?: string } = {},
     ) => {
-        if (value === null) {
+        if (value === null || !baseCurrency) {
             return (
                 <span className={options.className ?? "accounts-muted-metric"}>
                     {t("accounts.equivalent.unavailable")}
@@ -238,6 +270,7 @@ const Accounts = () => {
     };
 
     const getRateToBaseLabel = (account: AccountDisplay): string | null => {
+        if (!baseCurrency) return null;
         if (account.currency === baseCurrency) {
             return t("accounts.snapshot.rateValue", {
                 value: "1.0000",
@@ -270,6 +303,9 @@ const Accounts = () => {
 
     const renderAccountSnapshot = (account: AccountDisplay) => {
         const rateToBase = getRateToBaseLabel(account);
+        const baseEquivalentLabel = baseCurrency
+            ? t("accounts.snapshot.baseEquivalent", { currency: baseCurrency })
+            : t("accounts.equivalent.unavailable");
 
         return (
             <aside className="accounts-snapshot" aria-label={t("accounts.snapshot.title")}>
@@ -288,7 +324,7 @@ const Accounts = () => {
                             ),
                     )}
                     {renderSnapshotMetric(
-                        t("accounts.snapshot.baseEquivalent", { currency: baseCurrency }),
+                        baseEquivalentLabel,
                         renderBaseEquivalent(account.baseValue, { className: "accounts-snapshot__amount" }),
                     )}
                     {rateToBase && renderSnapshotMetric(t("accounts.snapshot.rateToBase"), rateToBase)}
@@ -468,7 +504,7 @@ const Accounts = () => {
                             </button>
                             {group.share !== null && (
                                 <div className="accounts-group__bar" aria-hidden="true">
-                                    <span style={{ width: `${Math.min(100, Math.max(4, group.share))}%` }} />
+                                    <span style={{ width: `${group.share === 0 ? 0 : Math.min(100, Math.max(4, group.share))}%` }} />
                                 </div>
                             )}
                             {!collapsed && <div className="accounts-list">{group.accounts.map(renderRow)}</div>}
@@ -532,7 +568,7 @@ const Accounts = () => {
                                 {hasCompleteScopedBaseValues
                                     ? (
                                         <Num
-                                            currency={baseCurrency}
+                                            currency={baseCurrency ?? undefined}
                                             kind={totalBaseValue < 0 ? "expense" : "neutral"}
                                             value={toFixedMoney(totalBaseValue)}
                                         />
@@ -565,7 +601,9 @@ const Accounts = () => {
                                 )}
                             </div>
                             <div
-                                aria-label={t("accounts.hero.baseEquivalentLabel", { currency: baseCurrency })}
+                                aria-label={baseCurrency
+                                    ? t("accounts.hero.baseEquivalentLabel", { currency: baseCurrency })
+                                    : t("accounts.equivalent.unavailable")}
                                 className="accounts-distribution"
                             >
                                 {distributionGroups.length > 0 ? distributionGroups.map((group) => (
@@ -582,7 +620,7 @@ const Accounts = () => {
                                         })}
                                         {group.share !== null && (
                                             <div className="accounts-distribution__bar" aria-hidden="true">
-                                                <span style={{ width: `${Math.min(100, Math.max(4, group.share))}%` }} />
+                                                <span style={{ width: `${group.share === 0 ? 0 : Math.min(100, Math.max(4, group.share))}%` }} />
                                             </div>
                                         )}
                                     </div>

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
 import {
   buildDisplayAccounts,
+  getBaseCurrency,
   makeCurrencyGroups,
   sortAccountsByBaseValue,
   toBaseCurrencyAmount,
@@ -49,6 +50,11 @@ const rates = [
 ];
 
 describe("accounts value helpers", () => {
+  it("does not invent USD when no profile or rate base is available", () => {
+    expect(getBaseCurrency([], null)).toBeNull();
+    expect(toBaseCurrencyAmount(100, "USD", null, [])).toBeNull();
+  });
+
   it("returns base equivalents only when existing rate data supports them", () => {
     expect(toBaseCurrencyAmount(100, "USD", "USD", rates)).toBe(100);
     expect(toBaseCurrencyAmount(800, "PLN", "USD", rates)).toBe(200);

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.ts
@@ -26,15 +26,18 @@ export const toFixedMoney = (value: number): number => Math.round(value * 100) /
 
 export const normalizeAccountSearch = (value: string): string => value.trim().toLowerCase();
 
-export const getBaseCurrency = (exchangeRates: ExchangeRateLike[]): string =>
-  exchangeRates[0]?.currencyFrom ?? "USD";
+export const getBaseCurrency = (
+  exchangeRates: ExchangeRateLike[],
+  profileCurrency?: string | null,
+): string | null => profileCurrency?.trim() || exchangeRates[0]?.currencyFrom || null;
 
 export const toBaseCurrencyAmount = (
   value: number,
   currency: string,
-  baseCurrency: string,
+  baseCurrency: string | null,
   exchangeRates: ExchangeRateLike[],
 ): number | null => {
+  if (!baseCurrency) return null;
   if (currency === baseCurrency) return value;
 
   const rate = exchangeRates.find((item) =>
@@ -49,7 +52,7 @@ export const toBaseCurrencyAmount = (
 export const buildDisplayAccounts = (
   accounts: AccountResponse[],
   summaries: AccountSummary[],
-  baseCurrency: string,
+  baseCurrency: string | null,
   exchangeRates: ExchangeRateLike[],
 ): AccountDisplay[] => {
   const summaryById = new Map(summaries.map((summary) => [summary.id, summary]));

--- a/inex/ClientApp/src/pages/Budgets.tsx
+++ b/inex/ClientApp/src/pages/Budgets.tsx
@@ -35,6 +35,7 @@ import {
     getBudgetUsageStatus,
     getPeriodPayload,
     getReportMetricsState,
+    getSupportedBudgetMonthFromParams,
     isBudgetPeriodDisabled,
 } from "./Budgets/budget-planning-utils";
 import type {
@@ -96,6 +97,8 @@ const CategoryDropdown: React.FC<CategoryDropdownProps> = ({
 
 const formatMonthLabel = (month: Dayjs) => month.format("MMM YYYY");
 
+const getDefaultBudgetMonth = () => dayjs().date(1).startOf("day");
+
 const getMonthOptions = (selectedMonth: Dayjs) =>
     [-2, -1, 0, 1, 2].map((offset) => {
         const value = selectedMonth.add(offset, "month");
@@ -132,27 +135,27 @@ const Budgets = () => {
     const [currenciesResolved, setCurrenciesResolved] = useState(false);
     const [currencyLoadError, setCurrencyLoadError] = useState(false);
     const [currencyReloadToken, setCurrencyReloadToken] = useState(0);
+    const initialSearchParamsInvalidRef = React.useRef(false);
     const drawerTriggerRef = React.useRef<HTMLButtonElement | null>(null);
     const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
 
     const [selectedMonth, setSelectedMonth] = useState(() => {
         const year = searchParams.get("year");
         const month = searchParams.get("month");
-        if (year && month) {
-            return dayjs()
-                .year(Number(year))
-                .month(Number(month) - 1)
-                .date(1)
-                .startOf("day");
-        }
-        return dayjs();
+        const fallbackMonth = getDefaultBudgetMonth();
+        const supportedMonth = getSupportedBudgetMonthFromParams(year, month, fallbackMonth);
+        initialSearchParamsInvalidRef.current = Boolean(year || month) &&
+            (supportedMonth.year().toString() !== year ||
+                (supportedMonth.month() + 1).toString() !== month);
+        return supportedMonth;
     });
 
     useEffect(() => {
         const year = selectedMonth.year().toString();
         const month = (selectedMonth.month() + 1).toString();
         if (searchParams.get("year") !== year || searchParams.get("month") !== month) {
-            setSearchParams({ year, month });
+            setSearchParams({ year, month }, { replace: initialSearchParamsInvalidRef.current });
+            initialSearchParamsInvalidRef.current = false;
         }
     }, [selectedMonth, setSearchParams, searchParams]);
 

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
@@ -13,6 +13,7 @@ import {
     getBudgetPaceMetrics,
     getBudgetReportForBudget,
     getBudgetUsageStatus,
+    getSupportedBudgetMonthFromParams,
     isBudgetPeriodDisabled,
     getPeriodPayload,
     getReportMetricsState,
@@ -167,5 +168,14 @@ describe("budget planning helpers", () => {
         expect(isBudgetPeriodDisabled(dayjs("2020-01-01"))).toBe(false);
         expect(isBudgetPeriodDisabled(dayjs("2030-12-01"))).toBe(false);
         expect(isBudgetPeriodDisabled(dayjs("2031-01-01"))).toBe(true);
+    });
+
+    it("falls back from invalid URL period params before queries are built", () => {
+        const fallback = dayjs("2026-06-15T12:00:00");
+
+        expect(getSupportedBudgetMonthFromParams("2026", "7", fallback).format("YYYY-MM-DD")).toBe("2026-07-01");
+        expect(getSupportedBudgetMonthFromParams("2026", "13", fallback).format("YYYY-MM-DD")).toBe("2026-06-01");
+        expect(getSupportedBudgetMonthFromParams("2031", "1", fallback).format("YYYY-MM-DD")).toBe("2026-06-01");
+        expect(getSupportedBudgetMonthFromParams("abc", "6", fallback).format("YYYY-MM-DD")).toBe("2026-06-01");
     });
 });

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts
@@ -231,3 +231,25 @@ export const getPeriodPayload = (period: Dayjs) => ({
 
 export const isBudgetPeriodDisabled = (period: Dayjs) =>
     period.year() < BUDGET_MIN_YEAR || period.year() > BUDGET_MAX_YEAR;
+
+export const getSupportedBudgetMonthFromParams = (
+    yearParam: string | null,
+    monthParam: string | null,
+    fallback: Dayjs,
+) => {
+    const fallbackMonth = fallback.date(1).startOf("day");
+    const year = Number(yearParam);
+    const month = Number(monthParam);
+
+    if (
+        !Number.isInteger(year) ||
+        !Number.isInteger(month) ||
+        month < 1 ||
+        month > 12
+    ) {
+        return fallbackMonth;
+    }
+
+    const parsedMonth = fallbackMonth.year(year).month(month - 1);
+    return isBudgetPeriodDisabled(parsedMonth) ? fallbackMonth : parsedMonth;
+};

--- a/inex/ClientApp/src/pages/Budgets/budgets.css
+++ b/inex/ClientApp/src/pages/Budgets/budgets.css
@@ -603,7 +603,7 @@
   }
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1048px) {
   .budgets-list__head {
     display: none;
   }

--- a/inex/ClientApp/src/pages/Categories.tsx
+++ b/inex/ClientApp/src/pages/Categories.tsx
@@ -309,11 +309,29 @@ const Categories = () => {
     const budgetsForPeriod = currentMonthBudgets ?? cachedBudgets;
     const currentPeriodTransactions = periodTransactions ?? cachedTransactions;
 
-    const closeAddDrawer = React.useCallback(() => {
+    const focusAddTrigger = React.useCallback((preferToolbarFallback = false) => {
+        const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+        const findEnabledButton = (label: string) =>
+            buttons.find((button) => !button.disabled && button.textContent?.trim() === label) ?? null;
+        const originalTrigger = addDrawerTriggerRef.current;
+        const connectedOriginalTrigger = originalTrigger?.isConnected ? originalTrigger : null;
+        const toolbarAddButton = findEnabledButton(t("common.add"));
+        const emptyAddButton = findEnabledButton(t("categories.emptyState.addManually"));
+        const focusTarget = preferToolbarFallback
+            ? toolbarAddButton ?? connectedOriginalTrigger ?? emptyAddButton
+            : connectedOriginalTrigger ?? toolbarAddButton ?? emptyAddButton;
+
+        focusTarget?.focus();
+    }, [t]);
+
+    const closeAddDrawer = React.useCallback((preferToolbarFallback = false) => {
         setAddOpen(false);
         setCreateError(null);
-        window.setTimeout(() => addDrawerTriggerRef.current?.focus(), 0);
-    }, []);
+        window.setTimeout(() => focusAddTrigger(preferToolbarFallback), 0);
+        if (preferToolbarFallback) {
+            window.setTimeout(() => focusAddTrigger(true), 250);
+        }
+    }, [focusAddTrigger]);
 
     const openAddDrawer: React.MouseEventHandler<HTMLButtonElement> = React.useCallback((event) => {
         addDrawerTriggerRef.current = event.currentTarget;
@@ -494,7 +512,7 @@ const Categories = () => {
                     />
                 ) : null}
                 <CategoryCreateForm
-                    onCreated={closeAddDrawer}
+                    onCreated={() => closeAddDrawer(true)}
                     onError={() => setCreateError(t("categories.formErrors.createFailed"))}
                 />
             </InExDrawer>

--- a/inex/ClientApp/src/pages/Categories.tsx
+++ b/inex/ClientApp/src/pages/Categories.tsx
@@ -32,6 +32,7 @@ import {
     categoryPaletteColor,
     computeCategorySpendStats,
     flattenCategoryTree,
+    getCategoryBaseCurrency,
     hasChildCategories,
     includeAncestorCategories,
     sortLeafCategoriesBySpend,
@@ -73,6 +74,11 @@ interface TransactionQueryArgs {
     };
 }
 
+interface CurrencyOption {
+    id: number;
+    key: string;
+}
+
 const CATEGORY_TRANSACTIONS_PAGE_SIZE = 250;
 const CATEGORY_TRANSACTIONS_MAX_PAGES = 40;
 
@@ -101,9 +107,16 @@ const getPeriodBounds = ({ year, month }: CategoryPeriod) => ({
 const formatPeriodDate = (year: number, month: number, day: number) =>
     `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 
+const formatPeriodDateTime = (
+    year: number,
+    month: number,
+    day: number,
+    time: "start" | "end",
+) => `${formatPeriodDate(year, month, day)}T${time === "start" ? "00:00:00" : "23:59:59"}`;
+
 const getPeriodQueryDates = ({ year, month }: CategoryPeriod) => ({
-    startDate: formatPeriodDate(year, month, 1),
-    endDate: formatPeriodDate(year, month, new Date(year, month, 0).getDate()),
+    startDate: formatPeriodDateTime(year, month, 1, "start"),
+    endDate: formatPeriodDateTime(year, month, new Date(year, month, 0).getDate(), "end"),
 });
 
 const isUnfilteredPeriodCoveringQuery = (
@@ -257,6 +270,8 @@ const Categories = () => {
     const [view, setView] = React.useState<CategoriesViewMode>("tree");
     const [expandedId, setExpandedId] = React.useState<number | null>(null);
     const [createError, setCreateError] = React.useState<string | null>(null);
+    const [currencies, setCurrencies] = React.useState<CurrencyOption[]>([]);
+    const addDrawerTriggerRef = React.useRef<HTMLButtonElement | null>(null);
     const period = useCurrentPeriod();
     const [periodTransactions, setPeriodTransactions] = React.useState<TransactionResponse[] | null>(null);
 
@@ -272,6 +287,15 @@ const Categories = () => {
         selectCachedTransactions(state.transactionsApi.queries, period),
     );
     const exchangeRates = useAppSelector((state) => state.rates.items);
+    const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
+    const profileCurrency = React.useMemo(
+        () => currencies.find((currency) => currency.id === userCurrencyId)?.key.trim() || null,
+        [currencies, userCurrencyId],
+    );
+    const baseCurrency = React.useMemo(
+        () => getCategoryBaseCurrency(exchangeRates, profileCurrency),
+        [exchangeRates, profileCurrency],
+    );
     const cachedBudgets = useAppSelector((state) => {
         const cachedCurrentMonthBudgets = budgetsApi.endpoints.getBudgets.select(period)(state).data;
         if (cachedCurrentMonthBudgets !== undefined) {
@@ -284,6 +308,18 @@ const Categories = () => {
     });
     const budgetsForPeriod = currentMonthBudgets ?? cachedBudgets;
     const currentPeriodTransactions = periodTransactions ?? cachedTransactions;
+
+    const closeAddDrawer = React.useCallback(() => {
+        setAddOpen(false);
+        setCreateError(null);
+        window.setTimeout(() => addDrawerTriggerRef.current?.focus(), 0);
+    }, []);
+
+    const openAddDrawer: React.MouseEventHandler<HTMLButtonElement> = React.useCallback((event) => {
+        addDrawerTriggerRef.current = event.currentTarget;
+        setCreateError(null);
+        setAddOpen(true);
+    }, []);
 
     React.useEffect(() => {
         if (expandedId != null && !categories.some((category) => category.id === expandedId)) {
@@ -311,6 +347,26 @@ const Categories = () => {
             cancelled = true;
         };
     }, [period.month, period.year]);
+
+    React.useEffect(() => {
+        let cancelled = false;
+
+        apiClient.get<CurrencyOption[]>("/currencies")
+            .then(({ data }) => {
+                if (!cancelled) {
+                    setCurrencies(data);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setCurrencies([]);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     const filteredCategories = React.useMemo(() => {
         const query = search.trim().toLowerCase();
@@ -340,9 +396,10 @@ const Categories = () => {
                 categories,
                 transactions: currentPeriodTransactions,
                 exchangeRates,
+                baseCurrency,
                 now: new Date(period.year, period.month - 1, 1),
             }),
-        [categories, currentPeriodTransactions, exchangeRates, period.month, period.year],
+        [baseCurrency, categories, currentPeriodTransactions, exchangeRates, period.month, period.year],
     );
 
     const periodLabel = React.useMemo(
@@ -426,10 +483,7 @@ const Categories = () => {
                 title={t("categories.addDrawerTitle")}
                 subtitle={t("categories.addDrawerSubtitle")}
                 open={addOpen}
-                onClose={() => {
-                    setAddOpen(false);
-                    setCreateError(null);
-                }}
+                onClose={closeAddDrawer}
             >
                 {createError ? (
                     <Alert
@@ -440,10 +494,7 @@ const Categories = () => {
                     />
                 ) : null}
                 <CategoryCreateForm
-                    onCreated={() => {
-                        setAddOpen(false);
-                        setCreateError(null);
-                    }}
+                    onCreated={closeAddDrawer}
                     onError={() => setCreateError(t("categories.formErrors.createFailed"))}
                 />
             </InExDrawer>
@@ -470,7 +521,7 @@ const Categories = () => {
                                 onActiveOnlyChange={setActiveOnly}
                                 onViewChange={setView}
                                 onSearchChange={setSearch}
-                                onAdd={() => setAddOpen(true)}
+                                onAdd={openAddDrawer}
                             />
                         </React.Fragment>
                     ) : null}
@@ -508,7 +559,7 @@ const Categories = () => {
                                 <InExButton
                                     kind="primary"
                                     icon={<Plus size={16} aria-hidden="true" />}
-                                    onClick={() => setAddOpen(true)}
+                                    onClick={openAddDrawer}
                                 >
                                     {t("categories.emptyState.addManually")}
                                 </InExButton>

--- a/inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx
+++ b/inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx
@@ -16,7 +16,7 @@ interface CategoriesToolbarProps {
     onActiveOnlyChange: (activeOnly: boolean) => void;
     onViewChange: (view: CategoriesViewMode) => void;
     onSearchChange: (search: string) => void;
-    onAdd: () => void;
+    onAdd: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export const CategoriesToolbar: React.FC<CategoriesToolbarProps> = ({

--- a/inex/ClientApp/src/pages/Categories/categories.utils.test.ts
+++ b/inex/ClientApp/src/pages/Categories/categories.utils.test.ts
@@ -64,6 +64,7 @@ describe("category spend utilities", () => {
                 transaction(106, 2, -80, "2026-05-20T08:00:00Z"),
             ],
             exchangeRates: [{ currencyFrom: "USD", currencyTo: "EUR", rate: 2 }],
+            baseCurrency: "USD",
             now: "2026-06-05T12:00:00Z",
         });
 
@@ -101,6 +102,7 @@ describe("category spend utilities", () => {
             categories,
             transactions,
             exchangeRates: [],
+            baseCurrency: "USD",
             now: "2026-06-05T12:00:00Z",
         });
 
@@ -130,6 +132,7 @@ describe("category spend utilities", () => {
                 transaction(2, 3, -30, "2026-06-01T08:00:00Z"),
             ],
             exchangeRates: [],
+            baseCurrency: "USD",
             now: "2026-06-05T12:00:00Z",
         });
 
@@ -148,6 +151,7 @@ describe("category spend utilities", () => {
             categories,
             transactions: [transaction(1, 1, -50, "2026-06-01T08:00:00Z", "EUR")],
             exchangeRates: [],
+            baseCurrency: "USD",
             now: "2026-06-05T12:00:00Z",
         });
 
@@ -169,11 +173,27 @@ describe("category spend utilities", () => {
                 { currencyFrom: "GBP", currencyTo: "EUR", rate: 2 },
                 { currencyFrom: "USD", currencyTo: "EUR", rate: 5 },
             ],
+            baseCurrency: "USD",
             now: "2026-06-05T12:00:00Z",
         });
 
         expect(stats.available).toBe(true);
         expect(stats.totalSpend).toBe(40);
+    });
+
+    it("marks spend unavailable instead of inventing a base currency", () => {
+        const categories = [category(1, "Cash")];
+
+        const stats = computeCategorySpendStats({
+            categories,
+            transactions: [transaction(1, 1, -50, "2026-06-01T08:00:00Z", "USD")],
+            exchangeRates: [],
+            now: "2026-06-05T12:00:00Z",
+        });
+
+        expect(stats.available).toBe(false);
+        expect(stats.currency).toBe("");
+        expect(stats.byCategoryId.get(1)?.totalSpend).toBe(0);
     });
 
     it("indexes only current-month budget links by category", () => {

--- a/inex/ClientApp/src/pages/Categories/categories.utils.ts
+++ b/inex/ClientApp/src/pages/Categories/categories.utils.ts
@@ -52,6 +52,7 @@ interface ComputeCategorySpendStatsArgs {
     categories: CategoryResponse[];
     transactions: TransactionResponse[] | null;
     exchangeRates: CategoryExchangeRate[];
+    baseCurrency?: string | null;
     now?: string | Date;
 }
 
@@ -171,8 +172,10 @@ export const hasChildCategories = (
     allItems: CategoryResponse[],
 ): boolean => allItems.some((item) => item.parentId === category.id);
 
-const getBaseCurrency = (exchangeRates: CategoryExchangeRate[]): string =>
-    exchangeRates[0]?.currencyFrom || "USD";
+export const getCategoryBaseCurrency = (
+    exchangeRates: CategoryExchangeRate[],
+    profileCurrency?: string | null,
+): string | null => profileCurrency?.trim() || exchangeRates[0]?.currencyFrom || null;
 
 const sameCurrency = (left: string, right: string): boolean =>
     left.localeCompare(right, undefined, { sensitivity: "accent" }) === 0;
@@ -180,9 +183,12 @@ const sameCurrency = (left: string, right: string): boolean =>
 const toBaseCurrencyAmount = (
     amount: number,
     accountCurrency: string,
+    baseCurrency: string | null,
     exchangeRates: CategoryExchangeRate[],
 ): number | null => {
-    const baseCurrency = getBaseCurrency(exchangeRates);
+    if (!baseCurrency) {
+        return null;
+    }
 
     if (sameCurrency(accountCurrency, baseCurrency)) {
         return amount;
@@ -250,24 +256,30 @@ export const computeCategorySpendStats = ({
     categories,
     transactions,
     exchangeRates,
+    baseCurrency: resolvedBaseCurrency,
     now,
 }: ComputeCategorySpendStatsArgs): CategorySpendStats => {
     const period = getCurrentPeriod(now);
     const byCategoryId = createEmptySpendStatsMap(categories);
     const categoriesById = new Map(categories.map((category) => [category.id, category]));
-    const currency = getBaseCurrency(exchangeRates);
+    const currency = resolvedBaseCurrency ?? getCategoryBaseCurrency(exchangeRates);
+    const unavailableStats = () => ({
+        available: false,
+        byCategoryId: createEmptySpendStatsMap(categories),
+        currency: currency ?? "",
+        distribution: [],
+        period,
+        totalSpend: 0,
+        topParent: null,
+        topParentSpend: 0,
+    });
 
     if (transactions == null) {
-        return {
-            available: false,
-            byCategoryId: createEmptySpendStatsMap(categories),
-            currency,
-            distribution: [],
-            period,
-            totalSpend: 0,
-            topParent: null,
-            topParentSpend: 0,
-        };
+        return unavailableStats();
+    }
+
+    if (!currency) {
+        return unavailableStats();
     }
 
     let hasConversionMiss = false;
@@ -282,6 +294,7 @@ export const computeCategorySpendStats = ({
         const baseAmount = toBaseCurrencyAmount(
             transaction.amount,
             transaction.accountCurrency,
+            currency,
             exchangeRates,
         );
 
@@ -303,16 +316,7 @@ export const computeCategorySpendStats = ({
     });
 
     if (hasConversionMiss) {
-        return {
-            available: false,
-            byCategoryId: createEmptySpendStatsMap(categories),
-            currency,
-            distribution: [],
-            period,
-            totalSpend: 0,
-            topParent: null,
-            topParentSpend: 0,
-        };
+        return unavailableStats();
     }
 
     const parentCategories = categories.filter(

--- a/inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts
@@ -1,0 +1,43 @@
+import dayjs from "dayjs";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTransactionFilterSearch,
+  parseTransactionFilterParam,
+} from "./transaction-filter-url";
+
+const emptyFilter = {
+  accountIds: [],
+  categoryIds: [],
+  tags: [],
+  refs: [],
+};
+
+describe("transaction filter URL helpers", () => {
+  it("parses date-only ranges as inclusive calendar days", () => {
+    const filter = parseTransactionFilterParam("start:2026-06-01;end:2026-06-30;");
+
+    expect(filter?.range).toEqual([
+      dayjs("2026-06-01T00:00:00").unix(),
+      dayjs("2026-06-30T23:59:59").unix(),
+    ]);
+  });
+
+  it("round-trips ranges without losing final-day coverage", () => {
+    const search = buildTransactionFilterSearch({
+      ...emptyFilter,
+      range: [
+        dayjs("2026-06-01T00:00:00").unix(),
+        dayjs("2026-06-30T23:59:59").unix(),
+      ],
+    });
+
+    const params = new URLSearchParams(search);
+    const filter = parseTransactionFilterParam(params.get("filter"));
+
+    expect(filter?.range).toEqual([
+      dayjs("2026-06-01T00:00:00").unix(),
+      dayjs("2026-06-30T23:59:59").unix(),
+    ]);
+  });
+});

--- a/inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts
@@ -24,6 +24,12 @@ const parseTextValues = (values: string[]): string[] =>
         .map(decodeFilterValue)
         .filter(value => value !== "");
 
+const parseStartDate = (value: string): number =>
+    dayjs(value).startOf("day").unix();
+
+const parseEndDate = (value: string): number =>
+    dayjs(value).endOf("day").unix();
+
 export const parseTransactionFilterParam = (filter: string | null): TransactionFilter | null => {
     const parsedFilter: TransactionFilter = {
         accountIds: [],
@@ -69,8 +75,8 @@ export const parseTransactionFilterParam = (filter: string | null): TransactionF
 
     if (startDate !== "" && endDate !== "") {
         parsedFilter.range = [
-            dayjs(startDate, "YYYY-MM-DD").unix(),
-            dayjs(endDate, "YYYY-MM-DD").unix(),
+            parseStartDate(startDate),
+            parseEndDate(endDate),
         ];
     }
 

--- a/inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
+++ b/inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
@@ -1,6 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { waitFor } from "@testing-library/react";
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import dayjs from "dayjs";
 import { vi } from "vitest";
 
 import apiClient from "../../../utils/apiClient";
@@ -92,6 +93,32 @@ describe("transactionsApi", () => {
     expect(mockApiClient).toHaveBeenCalledTimes(1);
     expect(mockApiClient).toHaveBeenCalledWith({
       url: "/transactions?mode=active&pageSize=25&page=1",
+      method: "get",
+      data: undefined,
+      params: undefined,
+    });
+  });
+
+  it("serializes transaction range filters with times so final-day activity is included", async () => {
+    const store = createTestStore();
+    mockApiClient.mockResolvedValue(axiosResponse(fixture));
+
+    await store.dispatch(
+      transactionsApi.endpoints.getTransactions.initiate({
+        pageSize: 25,
+        page: 1,
+        filter: {
+          ...emptyFilter,
+          range: [
+            dayjs("2026-06-01T00:00:00").unix(),
+            dayjs("2026-06-30T23:59:59").unix(),
+          ],
+        },
+      }),
+    );
+
+    expect(mockApiClient).toHaveBeenCalledWith({
+      url: "/transactions?mode=active&pageSize=25&page=1&startDate=2026-06-01T00%3A00%3A00&endDate=2026-06-30T23%3A59%3A59",
       method: "get",
       data: undefined,
       params: undefined,

--- a/inex/ClientApp/src/store/transactions/transactions-api.ts
+++ b/inex/ClientApp/src/store/transactions/transactions-api.ts
@@ -22,6 +22,9 @@ export interface TransactionsPagedResult {
   metadata: { totalItems: number };
 }
 
+export const formatTransactionFilterDateTime = (timestamp: number): string =>
+  dayjs.unix(timestamp).format("YYYY-MM-DDTHH:mm:ss");
+
 export interface CreateTransactionArgs {
   accountId: number;
   categoryId: number;
@@ -62,10 +65,10 @@ function buildTransactionParams(
   filter.tags.forEach((tag) => params.append("tag", tag));
   filter.refs.forEach((ref) => params.append("ref", ref));
   if (filter.range.length === 2 && filter.range[0] > 0) {
-    params.set("startDate", dayjs.unix(filter.range[0]).format("YYYY-MM-DD"));
+    params.set("startDate", formatTransactionFilterDateTime(filter.range[0]));
   }
   if (filter.range.length === 2 && filter.range[1] > 0) {
-    params.set("endDate", dayjs.unix(filter.range[1]).format("YYYY-MM-DD"));
+    params.set("endDate", formatTransactionFilterDateTime(filter.range[1]));
   }
   return params;
 }


### PR DESCRIPTION
## Summary

Addresses the fourth post-merge BMad review findings for Stories 10.3d, 10.3e, and 10.3f.

- Accounts now derives base currency only from profile/rate data, shows unavailable states when currency resolution is missing, and renders complete zero-share bars at true 0% width.
- Categories now uses full-day datetime transaction filters for direct period fetches, does not invent a spend base currency, and restores focus to the Add trigger after the create drawer closes.
- Budgets now normalizes invalid URL year/month params before querying and collapses rows at 1024px tablet width.
- Story Dev Agent Records and visual QA summaries include the round-4 BMad findings and route-smoke evidence.

## Validation

From `inex/ClientApp`:

- `npm run build` passed outside the sandbox after Windows esbuild `spawn EPERM` in the sandbox.
- `npm run lint` passed.
- `npm run test` passed: 12 files, 62 tests.

Targeted Browser smoke:

- Accounts normal, missing-base, and zero-balance states.
- Categories final-day transaction inclusion, missing-base unavailable state, and Add drawer focus return.
- Budgets invalid-param normalization and 1024px row collapse.