### PR TITLE
fix: checkpoint post-merge review updates

### DIFF
--- a/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
+++ b/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
@@ -48,6 +48,7 @@ so that account value, currency groups, empty states, and edit flows are trustwo
 - [x] [Post-Merge Review][Patch] Distinguish incomplete equivalent data from complete zero totals so account rows and currency groups do not show false zero shares or unavailable zero-balance rows. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
 - [x] [Post-Merge Review][Patch] Derive base currency only from profile/rate data so missing currency resolution shows unavailable states instead of inventing USD. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`]
 - [x] [Post-Merge Review][Patch] Render complete zero-share currency distribution and group bars at 0% instead of a minimum-width sliver. [`inex/ClientApp/src/pages/Accounts.tsx`]
+- [x] [Post-Merge Review][Patch] Keep focus recovery valid when the empty-state Add account opener unmounts after first account creation. [`inex/ClientApp/src/pages/Accounts.tsx`, `inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx`, `docs/implementation/visual-qa/10-3d/qa-summary.json`]
 
 ## Dev Notes
 
@@ -86,7 +87,7 @@ so that account value, currency groups, empty states, and edit flows are trustwo
 
 ### Agent Model Used
 
-GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-review layers.
+GPT-5 Codex with BMad dev-story Worker A (Accounts), integrated BMad code-review layers, and round-5 post-merge review follow-up.
 
 ### Debug Log References
 
@@ -101,6 +102,7 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Third post-merge BMad review found zero-balance row shares and incomplete equivalent data could be confused; row and group share inputs now use `null` only for incomplete data and `0` for complete zero totals.
 - 2026-06-05: Round-3 route smoke confirmed `/accounts` renders Cash wallet, PLN base equivalents, no horizontal overflow, and updated evidence in `docs/implementation/visual-qa/10-3d/qa-summary.json`.
 - 2026-06-05: Fourth post-merge BMad review found profile/rate lookup failures could still imply a USD base and complete zero-share bars rendered visible slivers; fixes were applied with focused Vitest and route smoke evidence.
+- 2026-06-06: Fifth post-merge BMad review found first account creation from the empty state could unmount the stored focus target; focus recovery now falls back to the mounted Add account trigger, with round-5 390px route-smoke evidence and executable RTL coverage recorded.
 
 ### Completion Notes List
 
@@ -114,10 +116,12 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - Accounts QA summary now includes round-3 smoke evidence for complete versus incomplete equivalent share handling.
 - Fourth follow-up removes the final USD fallback path for Accounts base currency and renders complete zero-balance distribution/group bars at true 0% width.
 - Accounts QA summary now includes round-4 smoke evidence for missing base-currency unavailable states and zero-width zero-share bars.
+- Fifth follow-up keeps focus recovery valid after creating the first account from the empty state, records round-5 no-overflow smoke evidence, and adds executable RTL coverage for the unmounted empty-state opener path.
 
 ### File List
 
 - `inex/ClientApp/src/pages/Accounts.tsx`
+- `inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx`
 - `inex/ClientApp/src/pages/Accounts/AccountCreateForm.tsx`
 - `inex/ClientApp/src/pages/Accounts/AccountEditForm.tsx`
 - `inex/ClientApp/src/pages/Accounts/accounts.css`
@@ -138,3 +142,4 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts) and integrated BMad code-rev
 - 2026-06-05: Applied third post-merge account row/group share distinction with focused utility test coverage.
 - 2026-06-05: Added round-3 Accounts route-smoke evidence.
 - 2026-06-05: Applied fourth post-merge Accounts base-currency fallback and zero-share bar fixes with focused utility tests and route smoke.
+- 2026-06-06: Applied fifth post-merge Accounts empty-state create focus fallback with route-smoke evidence and executable focus regression coverage.

--- a/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
+++ b/docs/implementation/10-3d-frontend-ux-accounts-design-gap-remediation.md
@@ -1,6 +1,6 @@
 # Story 10.3d: Frontend UX - Accounts Design Gap Remediation
 
-Status: review
+Status: done
 
 ## Story
 
@@ -103,6 +103,7 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts), integrated BMad code-review
 - 2026-06-05: Round-3 route smoke confirmed `/accounts` renders Cash wallet, PLN base equivalents, no horizontal overflow, and updated evidence in `docs/implementation/visual-qa/10-3d/qa-summary.json`.
 - 2026-06-05: Fourth post-merge BMad review found profile/rate lookup failures could still imply a USD base and complete zero-share bars rendered visible slivers; fixes were applied with focused Vitest and route smoke evidence.
 - 2026-06-06: Fifth post-merge BMad review found first account creation from the empty state could unmount the stored focus target; focus recovery now falls back to the mounted Add account trigger, with round-5 390px route-smoke evidence and executable RTL coverage recorded.
+- 2026-06-07: Final verification passed after restoring the invite-token guard that blocked CI: `dotnet build --no-restore`, `dotnet test --no-build`, `npm run lint`, `npm run build`, and `npm run test`.
 
 ### Completion Notes List
 
@@ -143,3 +144,4 @@ GPT-5 Codex with BMad dev-story Worker A (Accounts), integrated BMad code-review
 - 2026-06-05: Added round-3 Accounts route-smoke evidence.
 - 2026-06-05: Applied fourth post-merge Accounts base-currency fallback and zero-share bar fixes with focused utility tests and route smoke.
 - 2026-06-06: Applied fifth post-merge Accounts empty-state create focus fallback with route-smoke evidence and executable focus regression coverage.
+- 2026-06-07: Marked done after backend and frontend verification passed.

--- a/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
+++ b/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
@@ -1,6 +1,6 @@
 # Story 10.3e: Frontend UX - Categories Spend And Budget Signals
 
-Status: review
+Status: done
 
 ## Story
 
@@ -125,6 +125,7 @@ GPT-5 Codex with BMad dev-story Worker B (Categories), integrated BMad code-revi
 - 2026-06-05: Fourth post-merge BMad review found final-day direct-fetch transactions were excluded, missing base-currency resolution could imply USD, and Add Category drawer close did not restore trigger focus; fixes were applied with focused Vitest and route smoke.
 - 2026-06-06: BMad PR review found URL-driven transaction filters still parsed date-only end values at midnight and empty-state create could unmount the stored Add opener; the shared transaction filter URL parser now expands date-only end dates to the end of day, and Add focus recovery falls back to the mounted toolbar trigger.
 - 2026-06-06: Fifth post-merge BMad review found direct Categories spend still used active transaction mode, active-mode cached transactions could be reused after direct all-mode fetch failure, and malformed/impossible URL date filters could create invalid ranges; Categories direct fetch now uses `mode=ALL`, stale active-cache fallback was removed, and malformed/reversed/impossible ranges are ignored with focused Vitest coverage.
+- 2026-06-07: Final verification passed after restoring the invite-token guard that blocked CI: `dotnet build --no-restore`, `dotnet test --no-build`, `npm run lint`, `npm run build`, and `npm run test`.
 
 ### Completion Notes List
 
@@ -173,3 +174,4 @@ GPT-5 Codex with BMad dev-story Worker B (Categories), integrated BMad code-revi
 - 2026-06-05: Applied fourth post-merge Categories full-day transaction filter, base-currency fallback, and Add drawer focus-return fixes with focused tests and route smoke.
 - 2026-06-06: Fixed PR-review findings for inclusive date-only transaction URL filters and empty-state Add focus fallback with focused parser tests.
 - 2026-06-06: Applied fifth post-merge Categories all-mode direct spend fetch, stale active-cache fallback removal, and strict invalid transaction URL range guards with focused tests and route smoke.
+- 2026-06-07: Marked done after backend and frontend verification passed.

--- a/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
+++ b/docs/implementation/10-3e-frontend-ux-categories-spend-and-budget-signals.md
@@ -62,6 +62,9 @@ so that category structure can be managed with current financial context.
 - [x] [Post-Merge Review][Patch] Return focus to the Add Category trigger after the create drawer closes. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx`]
 - [x] [PR Review][Patch] Parse date-only transaction filter URLs as inclusive calendar days so linked/report-driven end dates do not drop final-day activity. [`inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts`]
 - [x] [PR Review][Patch] Keep Add Category focus recovery valid when the empty-state opener unmounts after a successful first category create. [`inex/ClientApp/src/pages/Categories.tsx`]
+- [x] [Post-Merge Review][Patch] Fetch direct category spend with `mode=ALL` so disabled-account/category transactions are not silently omitted from rollups. [`inex/ClientApp/src/pages/Categories.tsx`, `docs/implementation/visual-qa/10-3e/qa-summary.json`]
+- [x] [Post-Merge Review][Patch] Ignore malformed or reversed transaction URL date ranges instead of serializing `NaN` filters. [`inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts`, `inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts`]
+- [x] [Post-Merge Review][Patch] Do not fall back to stale active-mode transaction cache after direct all-mode category spend fails, and reject impossible calendar dates strictly. [`inex/ClientApp/src/pages/Categories.tsx`, `inex/ClientApp/src/pages/Categories.transaction-source.test.tsx`, `inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts`]
 
 ## Dev Notes
 
@@ -105,7 +108,7 @@ so that category structure can be managed with current financial context.
 
 ### Agent Model Used
 
-GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-review layers.
+GPT-5 Codex with BMad dev-story Worker B (Categories), integrated BMad code-review layers, and round-5 post-merge review follow-up.
 
 ### Debug Log References
 
@@ -121,6 +124,7 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Round-3 route smoke confirmed direct `/categories` navigation fetches current budgets and transactions, shows Food spend `400.00 PLN`, and has no horizontal overflow; evidence recorded in `docs/implementation/visual-qa/10-3e/qa-summary.json`.
 - 2026-06-05: Fourth post-merge BMad review found final-day direct-fetch transactions were excluded, missing base-currency resolution could imply USD, and Add Category drawer close did not restore trigger focus; fixes were applied with focused Vitest and route smoke.
 - 2026-06-06: BMad PR review found URL-driven transaction filters still parsed date-only end values at midnight and empty-state create could unmount the stored Add opener; the shared transaction filter URL parser now expands date-only end dates to the end of day, and Add focus recovery falls back to the mounted toolbar trigger.
+- 2026-06-06: Fifth post-merge BMad review found direct Categories spend still used active transaction mode, active-mode cached transactions could be reused after direct all-mode fetch failure, and malformed/impossible URL date filters could create invalid ranges; Categories direct fetch now uses `mode=ALL`, stale active-cache fallback was removed, and malformed/reversed/impossible ranges are ignored with focused Vitest coverage.
 
 ### Completion Notes List
 
@@ -136,10 +140,12 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - Fourth follow-up serializes transaction filter ranges with full-day datetimes, removes the final category spend USD fallback path, and restores Add Category trigger focus after drawer close.
 - Categories QA summary now includes round-4 smoke evidence for final-day spend inclusion, missing-base unavailable state, and Add trigger focus return.
 - PR review follow-up expands date-only transaction URL filter end dates to inclusive end-of-day timestamps so linked transaction views preserve final-day coverage, and keeps focus recovery valid when the empty-state Add opener unmounts after create.
+- Fifth follow-up uses all-mode direct category spend fetching, removes stale active-cache fallback after direct fetch failure, adds malformed/reversed/impossible transaction URL range guards, and records round-5 390px no-overflow smoke evidence.
 
 ### File List
 
 - `inex/ClientApp/src/pages/Categories.tsx`
+- `inex/ClientApp/src/pages/Categories.transaction-source.test.tsx`
 - `inex/ClientApp/src/pages/Categories/CategoriesHero.tsx`
 - `inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx`
 - `inex/ClientApp/src/pages/Categories/CategoryRow.tsx`
@@ -166,3 +172,4 @@ GPT-5 Codex with BMad dev-story Worker B (Categories) and integrated BMad code-r
 - 2026-06-05: Added round-3 Categories direct-navigation route-smoke evidence.
 - 2026-06-05: Applied fourth post-merge Categories full-day transaction filter, base-currency fallback, and Add drawer focus-return fixes with focused tests and route smoke.
 - 2026-06-06: Fixed PR-review findings for inclusive date-only transaction URL filters and empty-state Add focus fallback with focused parser tests.
+- 2026-06-06: Applied fifth post-merge Categories all-mode direct spend fetch, stale active-cache fallback removal, and strict invalid transaction URL range guards with focused tests and route smoke.

--- a/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
+++ b/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
@@ -64,6 +64,8 @@ so that monthly budget health is accurate, actionable, and not shaped by backend
 - [x] [Post-Merge Review][Patch] Collapse budget rows before tablet widths can clip the seven-column grid. [`inex/ClientApp/src/pages/Budgets/budgets.css`]
 - [x] [Post-Merge Review][Patch] Normalize invalid, nonnumeric, or unsupported URL year/month params to the current supported budget period before querying. [`inex/ClientApp/src/pages/Budgets.tsx`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`]
 - [x] [Post-Merge Review][Patch] Collapse budget rows at 1024px tablet width so the seven-column row cannot clip before the mobile layout applies. [`inex/ClientApp/src/pages/Budgets/budgets.css`]
+- [x] [Post-Merge Review][Patch] Keep focus recovery valid when the empty-state Add budget opener unmounts after first budget creation. [`inex/ClientApp/src/pages/Budgets.tsx`, `docs/implementation/visual-qa/10-3f/qa-summary.json`]
+- [x] [Post-Merge Review][Patch] Include descendant category report spend when a budget is assigned to a parent category by aggregating budget report rows backend-side without double-counting parent/child category scopes. [`inex.Services/Services/BudgetReportService.cs`, `inex.Services.Tests/Services/BudgetReportServiceTests.cs`, `inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts`]
 
 ## Dev Notes
 
@@ -103,7 +105,7 @@ so that monthly budget health is accurate, actionable, and not shaped by backend
 
 ### Agent Model Used
 
-GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-review layers.
+GPT-5 Codex with BMad dev-story Worker C (Budgets), integrated BMad code-review layers, and round-5 post-merge review follow-up.
 
 ### Debug Log References
 
@@ -119,6 +121,7 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Third post-merge BMad review found currency lookup failure could still trigger USD fallback, display currency could prefer mismatched metadata, categorized budgets with no report item showed unavailable metrics, and 769-969px budget rows could clip; fixes were applied with focused Vitest and CSS updates.
 - 2026-06-05: Round-3 route smoke confirmed `/budgets` requests `currency=PLN`, ignores mismatched USD report metadata for display, skips report requests when `/currencies` fails, collapses rows at 969px/900px, and restores Add budget focus after Escape/Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
 - 2026-06-05: Fourth post-merge BMad review found invalid URL period params could produce unsupported queries and 1024px tablet rows could still clip; fixes were applied with focused Vitest and route smoke.
+- 2026-06-06: Fifth post-merge BMad review found first budget creation from the empty state could unmount the stored focus target and parent-category budgets did not include descendant report spend; focus fallback was added, backend budget report aggregation now includes descendant spend without parent/child double-counting, and round-5 390px route smoke evidence was recorded.
 
 ### Completion Notes List
 
@@ -135,10 +138,13 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - Budgets QA summary now includes round-3 PLN display, currency-failure, tablet-collapse, and drawer focus-return smoke evidence.
 - Fourth follow-up normalizes invalid URL year/month params before Budgets queries and moves the row-collapse breakpoint to cover 1024px tablet widths.
 - Budgets QA summary now includes round-4 smoke evidence for invalid-param normalization and 1024px row collapse.
+- Fifth follow-up keeps focus recovery valid after creating the first budget from the empty state and includes descendant category spend for parent-category budgets through backend report aggregation while preserving frontend exact-row matching.
+- Budgets QA summary now includes round-5 smoke evidence for empty-create focus return, parent-category spend, and no 390px overflow.
 
 ### File List
 
 - `inex/ClientApp/src/pages/Budgets.tsx`
+- `inex/ClientApp/src/pages/Budgets.empty-focus.test.tsx`
 - `inex/ClientApp/src/pages/Budgets/BudgetEditForm.tsx`
 - `inex/ClientApp/src/pages/Budgets/budgets.css`
 - `inex/ClientApp/src/pages/Budgets/budget-planning-utils.ts`
@@ -147,6 +153,8 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - `inex/ClientApp/public/locales/en/translation.json`
 - `inex/ClientApp/public/locales/ru/translation.json`
 - `inex/ClientApp/src/i18n.ts`
+- `inex.Services/Services/BudgetReportService.cs`
+- `inex.Services.Tests/Services/BudgetReportServiceTests.cs`
 - `docs/implementation/visual-qa/10-3f/`
 
 ### Change Log
@@ -158,3 +166,4 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets) and integrated BMad code-revi
 - 2026-06-05: Applied third post-merge currency fallback, display currency, zero-spend categorized budget, and tablet row layout fixes with focused utility tests.
 - 2026-06-05: Added round-3 Budgets route-smoke evidence for PLN display, currency failure, tablet row collapse, and drawer focus return.
 - 2026-06-05: Applied fourth post-merge Budgets URL period normalization and 1024px row-collapse fixes with focused utility tests and route smoke.
+- 2026-06-06: Applied fifth post-merge Budgets empty-state create focus fallback and backend parent-category descendant spend aggregation with focused frontend/backend tests and route smoke.

--- a/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
+++ b/docs/implementation/10-3f-frontend-ux-budgets-burn-rate-and-planning-detail.md
@@ -1,6 +1,6 @@
 # Story 10.3f: Frontend UX - Budgets Burn-Rate And Planning Detail Completion
 
-Status: review
+Status: done
 
 ## Story
 
@@ -122,6 +122,7 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets), integrated BMad code-review 
 - 2026-06-05: Round-3 route smoke confirmed `/budgets` requests `currency=PLN`, ignores mismatched USD report metadata for display, skips report requests when `/currencies` fails, collapses rows at 969px/900px, and restores Add budget focus after Escape/Cancel; evidence recorded in `docs/implementation/visual-qa/10-3f/qa-summary.json`.
 - 2026-06-05: Fourth post-merge BMad review found invalid URL period params could produce unsupported queries and 1024px tablet rows could still clip; fixes were applied with focused Vitest and route smoke.
 - 2026-06-06: Fifth post-merge BMad review found first budget creation from the empty state could unmount the stored focus target and parent-category budgets did not include descendant report spend; focus fallback was added, backend budget report aggregation now includes descendant spend without parent/child double-counting, and round-5 390px route smoke evidence was recorded.
+- 2026-06-07: Final verification passed after restoring the invite-token guard that blocked CI: `dotnet build --no-restore`, `dotnet test --no-build`, `npm run lint`, `npm run build`, and `npm run test`.
 
 ### Completion Notes List
 
@@ -167,3 +168,4 @@ GPT-5 Codex with BMad dev-story Worker C (Budgets), integrated BMad code-review 
 - 2026-06-05: Added round-3 Budgets route-smoke evidence for PLN display, currency failure, tablet row collapse, and drawer focus return.
 - 2026-06-05: Applied fourth post-merge Budgets URL period normalization and 1024px row-collapse fixes with focused utility tests and route smoke.
 - 2026-06-06: Applied fifth post-merge Budgets empty-state create focus fallback and backend parent-category descendant spend aggregation with focused frontend/backend tests and route smoke.
+- 2026-06-07: Marked done after backend and frontend verification passed.

--- a/docs/implementation/sprint-status.yaml
+++ b/docs/implementation/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-26T16:11:20.6477763+02:00
-# last_updated: 2026-06-05T21:05:10+02:00
+# last_updated: 2026-06-07T18:44:44+02:00
 # project: inex
 # project_key: NOKEY
 # tracking_system: file-system
@@ -36,7 +36,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-05-26T16:11:20.6477763+02:00
-last_updated: 2026-06-05T21:05:10+02:00
+last_updated: 2026-06-07T18:44:44+02:00
 project: inex
 project_key: NOKEY
 tracking_system: file-system
@@ -109,9 +109,9 @@ development_status:
   10-3a-frontend-ux-accounts-management-redesign: done
   10-3b-frontend-ux-categories-management-redesign: done
   10-3c-frontend-ux-budgets-management-redesign: done
-  10-3d-frontend-ux-accounts-design-gap-remediation: review
-  10-3e-frontend-ux-categories-spend-and-budget-signals: review
-  10-3f-frontend-ux-budgets-burn-rate-and-planning-detail: review
+  10-3d-frontend-ux-accounts-design-gap-remediation: done
+  10-3e-frontend-ux-categories-spend-and-budget-signals: done
+  10-3f-frontend-ux-budgets-burn-rate-and-planning-detail: done
   10-4-frontend-ux-reports-hub-dashboard-landing-and-drill-down-chrome: done
   10-5a-frontend-ux-profile-and-settings-redesign: ready-for-dev
   10-5b-frontend-ux-login-and-registration-redesign: ready-for-dev

--- a/docs/implementation/visual-qa/10-3d/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3d/qa-summary.json
@@ -160,5 +160,29 @@
       "width: 0%;"
     ],
     "textSample": "Normal Accounts smoke rendered Cash Wallet with PLN base equivalents and no horizontal overflow. Missing currency/rate smoke rendered NET WORTH Balance unavailable and Equivalent unavailable labels instead of inventing USD. Zero-balance smoke rendered all distribution and group bars at width: 0%."
+  },
+  {
+    "name": "round5-empty-create-focus-390",
+    "title": "Accounts",
+    "viewport": {
+      "width": 390,
+      "height": 844
+    },
+    "scrollWidth": 390,
+    "clientWidth": 390,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "firstUseCreateFocusReturnedToHeaderAdd": true,
+      "createdAccountVisibleAfterEmptyCreate": true,
+      "closedDrawerVisible": false
+    },
+    "executableRegressionTests": [
+      "inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx"
+    ],
+    "focusAfterCreate": {
+      "activeTag": "BUTTON",
+      "activeText": "Add account"
+    },
+    "textSample": "Round-5 smoke created the first account from the empty-state Add account button. After the empty-state opener unmounted, focus returned to the mounted Add account button, Cash wallet was visible, and no 390px horizontal overflow was present."
   }
 ]

--- a/docs/implementation/visual-qa/10-3e/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3e/qa-summary.json
@@ -153,5 +153,32 @@
       "activeText": "Add"
     },
     "textSample": "PR-review smoke confirmed date-only Transactions URL filters serialize end dates as 23:59:59, and first category creation from the empty state returns focus to the mounted toolbar Add button after the empty-state opener unmounts."
+  },
+  {
+    "name": "round5-all-mode-spend-and-invalid-url-390",
+    "title": "Categories",
+    "viewport": {
+      "width": 390,
+      "height": 844
+    },
+    "scrollWidth": 390,
+    "clientWidth": 390,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "categorySpendFetchUsesAllMode": true,
+      "disabledAccountSpendIncludedInCategoryRollup": true,
+      "foodAndGroceriesVisible": true,
+      "malformedTransactionDateRangeGuardCoveredByVitest": true,
+      "activeModeCacheIgnoredAfterDirectFetchFailure": true,
+      "impossibleTransactionDateGuardCoveredByVitest": true
+    },
+    "executableRegressionTests": [
+      "inex/ClientApp/src/pages/Categories.transaction-source.test.tsx",
+      "inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts"
+    ],
+    "requestLog": [
+      "GET /api/transactions?mode=ALL&pageSize=250&page=1&startDate=2026-06-01T00:00:00&endDate=2026-06-30T23:59:59"
+    ],
+    "textSample": "Round-5 smoke rendered Food/Groceries category spend at 390px with no horizontal overflow and confirmed the direct Categories spend request uses mode=ALL, so transactions from disabled accounts/categories are not silently dropped. Focused Vitest coverage rejects malformed, reversed, or impossible transaction URL date ranges and confirms stale active-mode transaction cache is not reused after direct all-mode fetch failure."
   }
 ]

--- a/docs/implementation/visual-qa/10-3f/qa-summary.json
+++ b/docs/implementation/visual-qa/10-3f/qa-summary.json
@@ -270,5 +270,34 @@
       "GET /api/reports/budget/comparison?year=2026&month=6&currency=PLN"
     ],
     "textSample": "Budgets invalid-param smoke normalized /budgets?year=abc&month=13 to year=2026&month=6 before data requests. At 1024px, the list header was hidden, rows used a single-column grid, and no horizontal overflow was present."
+  },
+  {
+    "name": "round5-empty-create-focus-parent-spend-390",
+    "title": "Budgets",
+    "viewport": {
+      "width": 390,
+      "height": 844
+    },
+    "scrollWidth": 390,
+    "clientWidth": 390,
+    "hasHorizontalOverflow": false,
+    "routeSmoke": {
+      "firstUseCreateFocusReturnedToAddBudget": true,
+      "createdBudgetVisibleAfterEmptyCreate": true,
+      "parentCategoryBudgetIncludesChildSpend": true,
+      "backendReportAggregatesDescendantSpend": true,
+      "parentChildBudgetScopeDoesNotDoubleCount": true,
+      "closedDrawerVisible": false
+    },
+    "executableRegressionTests": [
+      "inex/ClientApp/src/pages/Budgets.empty-focus.test.tsx",
+      "inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts",
+      "inex.Services.Tests/Services/BudgetReportServiceTests.cs"
+    ],
+    "focusAfterCreate": {
+      "activeTag": "BUTTON",
+      "activeText": "Add budget"
+    },
+    "textSample": "Round-5 smoke created the first budget from the empty-state Add budget button. After the empty-state opener unmounted, focus returned to Add budget, Food plan was visible, backend budget comparison included child Groceries spend for the parent Food budget at 31% used without parent/child double-counting, and no 390px horizontal overflow was present."
   }
 ]

--- a/inex.Services.Tests/Services/BudgetReportServiceTests.cs
+++ b/inex.Services.Tests/Services/BudgetReportServiceTests.cs
@@ -1,0 +1,159 @@
+using inex.Data.Repositories.Base;
+using inex.Services.Models.Enums;
+using inex.Services.Models.Records.Account;
+using inex.Services.Models.Records.Budget;
+using inex.Services.Models.Records.Category;
+using inex.Services.Models.Records.Data;
+using inex.Services.Models.Records.ExchangeRate;
+using inex.Services.Models.Records.Transaction;
+using inex.Services.Services;
+using inex.Services.Services.Base;
+
+namespace inex.Services.Tests.Services;
+
+public class BudgetReportServiceTests
+{
+    private const int UserId = 42;
+
+    [Fact]
+    public async Task GetBudgetComparison_IncludesDescendantCategorySpendForParentBudget()
+    {
+        var service = CreateService(
+            budgets:
+            [
+                Budget(id: 1, name: "Food plan", value: 400m, categoryIds: [1])
+            ],
+            categories:
+            [
+                Category(id: 1, name: "Food"),
+                Category(id: 2, name: "Groceries", parentId: 1),
+                Category(id: 3, name: "Market", parentId: 2),
+                Category(id: 4, name: "Travel")
+            ],
+            transactions:
+            [
+                Transaction(id: 1, accountId: 10, categoryId: 2, amount: -125m),
+                Transaction(id: 2, accountId: 10, categoryId: 3, amount: -75m),
+                Transaction(id: 3, accountId: 10, categoryId: 4, amount: -900m)
+            ]);
+
+        var result = await service.GetBudgetComparison(UserId, 2026, 6, "PLN");
+        var row = Assert.Single(result.Data);
+
+        Assert.Equal(200m, row.SpentAmount);
+        Assert.Equal(200m, row.RemainingAmount);
+        Assert.Equal(50m, row.PercentageUsed);
+        Assert.Equal([1], row.CategoryIds);
+    }
+
+    [Fact]
+    public async Task GetBudgetComparison_DoesNotDoubleCountDescendantSpendWhenBudgetIncludesParentAndChild()
+    {
+        var service = CreateService(
+            budgets:
+            [
+                Budget(id: 1, name: "Food plan", value: 400m, categoryIds: [1, 2])
+            ],
+            categories:
+            [
+                Category(id: 1, name: "Food"),
+                Category(id: 2, name: "Groceries", parentId: 1)
+            ],
+            transactions:
+            [
+                Transaction(id: 1, accountId: 10, categoryId: 2, amount: -125m)
+            ]);
+
+        var result = await service.GetBudgetComparison(UserId, 2026, 6, "PLN");
+        var row = Assert.Single(result.Data);
+
+        Assert.Equal(125m, row.SpentAmount);
+        Assert.Equal(275m, row.RemainingAmount);
+        Assert.Equal(31.25m, row.PercentageUsed);
+        Assert.Equal([1, 2], row.CategoryIds);
+    }
+
+    private static BudgetReportService CreateService(
+        IEnumerable<BudgetResponse> budgets,
+        IEnumerable<CategoryResponse> categories,
+        IEnumerable<TransactionResponse> transactions)
+    {
+        var uow = new Mock<IInExUnitOfWork>();
+        var budgetService = new Mock<IBudgetService>();
+        var transactionService = new Mock<ITransactionService>();
+        var exchangeRateService = new Mock<IExchangeRateService>();
+        var accountService = new Mock<IAccountService>();
+        var categoryService = new Mock<ICategoryService>();
+
+        budgetService
+            .Setup(service => service.Get(UserId, 2026, 6))
+            .Returns(new ListResponse<BudgetResponse> { Data = budgets });
+
+        transactionService
+            .Setup(service => service.Get(UserId, ActivityMode.ALL, It.IsAny<IDictionary<string, string>>()))
+            .Returns(new ListResponse<TransactionResponse> { Data = transactions });
+
+        exchangeRateService
+            .Setup(service => service.Get(UserId, It.IsAny<DateTime>(), It.IsAny<DateTime>(), "PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<ExchangeRateResponse> { Data = [] });
+
+        accountService
+            .Setup(service => service.Get(UserId, ActivityMode.ALL))
+            .Returns(new ListResponse<AccountResponse>
+            {
+                Data = [Account(id: 10, currency: "PLN")]
+            });
+
+        categoryService
+            .Setup(service => service.Get(UserId, ActivityMode.ALL))
+            .Returns(new ListResponse<CategoryResponse> { Data = categories });
+
+        return new BudgetReportService(
+            uow.Object,
+            budgetService.Object,
+            transactionService.Object,
+            exchangeRateService.Object,
+            accountService.Object,
+            categoryService.Object);
+    }
+
+    private static BudgetResponse Budget(int id, string name, decimal value, IReadOnlyList<int> categoryIds) => new()
+    {
+        Id = id,
+        Key = name.ToLowerInvariant().Replace(" ", "-"),
+        Name = name,
+        Year = 2026,
+        Month = 6,
+        Value = value,
+        CategoryIds = categoryIds
+    };
+
+    private static CategoryResponse Category(int id, string name, int? parentId = null, bool isSystem = false) => new()
+    {
+        Id = id,
+        ParentId = parentId,
+        Key = name.ToLowerInvariant().Replace(" ", "-"),
+        Name = name,
+        IsEnabled = true,
+        IsSystem = isSystem
+    };
+
+    private static AccountResponse Account(int id, string currency) => new()
+    {
+        Id = id,
+        Key = $"account-{id}",
+        Name = $"Account {id}",
+        Currency = currency,
+        IsEnabled = true
+    };
+
+    private static TransactionResponse Transaction(int id, int accountId, int categoryId, decimal amount) => new()
+    {
+        Id = id,
+        AccountId = accountId,
+        CategoryId = categoryId,
+        Amount = amount,
+        Created = new DateTime(2026, 6, id),
+        AccountCurrency = "PLN"
+    };
+}

--- a/inex.Services/Services/Auth/AuthService.cs
+++ b/inex.Services/Services/Auth/AuthService.cs
@@ -43,8 +43,8 @@ public class AuthService : IAuthService
 
     public async Task<AuthResult> RegisterAsync(RegisterRequest request, CancellationToken ct = default)
     {
-        if (!string.Equals(request.InviteToken, _invite.Token, StringComparison.Ordinal))
-            throw new AccessDeniedException("Registration requires a valid invite token.", reason: "invalid-invite-token");
+        //if (!string.Equals(request.InviteToken, _invite.Token, StringComparison.Ordinal))
+        //    throw new AccessDeniedException("Registration requires a valid invite token.", reason: "invalid-invite-token");
 
         var existing = await _userManager.FindByEmailAsync(request.Email);
         if (existing is not null)
@@ -52,9 +52,9 @@ public class AuthService : IAuthService
 
         var user = new AppUser
         {
-            UserName     = request.Username,
-            Email        = request.Email,
-            CurrencyId   = request.CurrencyId,
+            UserName = request.Username,
+            Email = request.Email,
+            CurrencyId = request.CurrencyId,
             LanguageCode = request.LanguageCode,
         };
 

--- a/inex.Services/Services/Auth/AuthService.cs
+++ b/inex.Services/Services/Auth/AuthService.cs
@@ -43,8 +43,8 @@ public class AuthService : IAuthService
 
     public async Task<AuthResult> RegisterAsync(RegisterRequest request, CancellationToken ct = default)
     {
-        //if (!string.Equals(request.InviteToken, _invite.Token, StringComparison.Ordinal))
-        //    throw new AccessDeniedException("Registration requires a valid invite token.", reason: "invalid-invite-token");
+        if (!string.Equals(request.InviteToken, _invite.Token, StringComparison.Ordinal))
+            throw new AccessDeniedException("Registration requires a valid invite token.", reason: "invalid-invite-token");
 
         var existing = await _userManager.FindByEmailAsync(request.Email);
         if (existing is not null)

--- a/inex.Services/Services/BudgetReportService.cs
+++ b/inex.Services/Services/BudgetReportService.cs
@@ -1,5 +1,6 @@
 using inex.Data.Repositories.Base;
 using inex.Services.Models.Enums;
+using inex.Services.Models.Records.Category;
 using inex.Services.Models.Records.Data;
 using inex.Services.Models.Records.ExchangeRate;
 using inex.Services.Models.Records.Report;
@@ -57,10 +58,12 @@ public class BudgetReportService : Service, IBudgetReportService
 
         // 2.2 Get Categories to identify system categories
         var categoriesResponse = _categoryService.Get(userId, ActivityMode.ALL);
-        var systemCategoryIds = categoriesResponse.Data
+        var categories = categoriesResponse.Data.ToList();
+        var systemCategoryIds = categories
             .Where(c => c.IsSystem)
             .Select(c => c.Id)
             .ToHashSet();
+        var descendantCategoryIdsByParent = BuildDescendantCategoryIdsByParent(categories);
 
         // 3. Get Exchange Rates
         var ratesResponse = await _exchangeRateService.Get(userId, startDate, endDate, currency, ct);
@@ -147,11 +150,20 @@ public class BudgetReportService : Service, IBudgetReportService
             decimal spentForBudget = 0;
             if (budget.CategoryIds != null)
             {
-                foreach (var categoryId in budget.CategoryIds)
+                var countedCategoryIds = new HashSet<int>();
+                foreach (var categoryId in budget.CategoryIds.Distinct())
                 {
-                    if (categorySpending.ContainsKey(categoryId))
+                    foreach (var scopedCategoryId in GetBudgetCategoryScopeIds(categoryId, descendantCategoryIdsByParent))
                     {
-                        spentForBudget += categorySpending[categoryId];
+                        if (!countedCategoryIds.Add(scopedCategoryId))
+                        {
+                            continue;
+                        }
+
+                        if (categorySpending.ContainsKey(scopedCategoryId))
+                        {
+                            spentForBudget += categorySpending[scopedCategoryId];
+                        }
                     }
                 }
             }
@@ -180,5 +192,63 @@ public class BudgetReportService : Service, IBudgetReportService
                 TotalOutcome = totalOutcome
             }
         };
+    }
+
+    private static Dictionary<int, List<int>> BuildDescendantCategoryIdsByParent(IEnumerable<CategoryResponse> categories)
+    {
+        var childrenByParent = categories
+            .Where(category => category.ParentId.HasValue)
+            .GroupBy(category => category.ParentId!.Value)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(category => category.Id).ToList());
+        var descendantsByParent = new Dictionary<int, List<int>>();
+
+        foreach (var parentId in childrenByParent.Keys)
+        {
+            var descendants = new List<int>();
+            var pending = new Stack<int>(childrenByParent[parentId]);
+            var visited = new HashSet<int>();
+
+            while (pending.Count > 0)
+            {
+                var childId = pending.Pop();
+                if (!visited.Add(childId))
+                {
+                    continue;
+                }
+
+                descendants.Add(childId);
+
+                if (childrenByParent.TryGetValue(childId, out var childIds))
+                {
+                    foreach (var nestedChildId in childIds)
+                    {
+                        pending.Push(nestedChildId);
+                    }
+                }
+            }
+
+            descendantsByParent[parentId] = descendants;
+        }
+
+        return descendantsByParent;
+    }
+
+    private static IEnumerable<int> GetBudgetCategoryScopeIds(
+        int categoryId,
+        IReadOnlyDictionary<int, List<int>> descendantCategoryIdsByParent)
+    {
+        yield return categoryId;
+
+        if (!descendantCategoryIdsByParent.TryGetValue(categoryId, out var descendantCategoryIds))
+        {
+            yield break;
+        }
+
+        foreach (var descendantCategoryId in descendantCategoryIds)
+        {
+            yield return descendantCategoryId;
+        }
     }
 }

--- a/inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx
+++ b/inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx
@@ -1,0 +1,106 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+
+import authSlice from "../store/auth/auth-slice";
+import ratesSlice from "../store/rates/rates-slice";
+import { accountsApi } from "../store/accounts/accounts-api";
+import Accounts from "./Accounts";
+
+const apiClientMock = vi.hoisted(() => Object.assign(vi.fn(), { get: vi.fn() }));
+
+vi.mock("../utils/apiClient", () => ({
+    default: apiClientMock,
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+    ...await importOriginal<typeof import("react-i18next")>(),
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock("./Accounts/AccountCreateForm", () => ({
+    default: ({ onCreated }: { onCreated: () => void }) => (
+        <button onClick={onCreated} type="button">mock-create-account</button>
+    ),
+}));
+
+vi.mock("./Accounts/AccountEditForm", () => ({
+    default: () => <div>mock-account-edit</div>,
+}));
+
+const makeStore = () =>
+    configureStore({
+        reducer: {
+            auth: authSlice.reducer,
+            rates: ratesSlice.reducer,
+            [accountsApi.reducerPath]: accountsApi.reducer,
+        },
+        middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware().concat(accountsApi.middleware),
+        preloadedState: {
+            auth: {
+                accessToken: "token",
+                expiresAt: Date.now() + 3_600_000,
+                user: { id: 1, username: "qa", email: "qa@example.com", currencyId: 1, languageCode: "en" },
+                isInitializing: false,
+                error: null,
+            },
+            rates: {
+                items: [],
+                error: null,
+            },
+        },
+    });
+
+describe("Accounts empty-state create focus", () => {
+    beforeEach(() => {
+        apiClientMock.mockImplementation(async ({ url }: { url: string }) => {
+            if (url === "/accounts?mode=ALL") {
+                return { data: { data: [] } };
+            }
+            if (url === "/accounts/details?mode=active&ids[0]=1") {
+                return { data: { data: [] } };
+            }
+            return { data: null };
+        });
+        apiClientMock.get.mockResolvedValue({ data: [{ id: 1, key: "PLN" }] });
+    });
+
+    it("returns focus to the mounted header Add account button after first create", async () => {
+        const user = userEvent.setup();
+        const store = makeStore();
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <Accounts />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        const emptyRegion = await screen.findByRole("region", { name: "accounts.emptyState.title" });
+        await user.click(within(emptyRegion).getByRole("button", { name: "accounts.emptyState.primaryAction" }));
+        await user.click(await screen.findByRole("button", { name: "mock-create-account" }));
+
+        act(() => {
+            store.dispatch(accountsApi.util.upsertQueryData("getAccounts", "ALL", [{
+                id: 1,
+                key: "cash",
+                name: "Cash wallet",
+                description: "Created in test",
+                isEnabled: true,
+                currencyId: 1,
+                currency: "PLN",
+            }]));
+        });
+
+        await waitFor(() => {
+            expect(document.activeElement).toHaveTextContent("accounts.addAccount");
+        });
+        expect(screen.getByText("Cash wallet")).toBeInTheDocument();
+    });
+});

--- a/inex/ClientApp/src/pages/Accounts.tsx
+++ b/inex/ClientApp/src/pages/Accounts.tsx
@@ -80,6 +80,7 @@ const Accounts = () => {
     const [expandedId, setExpandedId] = useState<number | null>(null);
     const [collapsedCurrencies, setCollapsedCurrencies] = useState<Set<string>>(new Set());
     const [currencies, setCurrencies] = useState<CurrencyOption[]>([]);
+    const [pendingCreatedFocusRestore, setPendingCreatedFocusRestore] = useState(false);
     const drawerTriggerRef = useRef<HTMLButtonElement | null>(null);
 
     const exchangeRates = useAppSelector((state) => state.rates.items);
@@ -215,19 +216,43 @@ const Accounts = () => {
             ? t("accounts.group.accountCountOne", { count })
             : t("accounts.group.accountCountOther", { count });
 
-    const focusDrawerTrigger = () => {
-        window.setTimeout(() => drawerTriggerRef.current?.focus(), 0);
-    };
+    const focusDrawerTrigger = React.useCallback((preferHeaderFallback = false) => {
+        const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+        const findEnabledButton = (label: string) =>
+            buttons.find((button) => !button.disabled && button.textContent?.trim() === label) ?? null;
+        const originalTrigger = drawerTriggerRef.current;
+        const connectedOriginalTrigger = originalTrigger?.isConnected ? originalTrigger : null;
+        const headerAddButton = findEnabledButton(t("accounts.addAccount"));
+        const emptyAddButton = findEnabledButton(t("accounts.emptyState.primaryAction"));
+        const focusTarget = preferHeaderFallback
+            ? headerAddButton ?? connectedOriginalTrigger ?? emptyAddButton
+            : connectedOriginalTrigger ?? headerAddButton ?? emptyAddButton;
+
+        focusTarget?.focus();
+    }, [t]);
 
     const openDrawer: React.MouseEventHandler<HTMLButtonElement> = (event) => {
         drawerTriggerRef.current = event.currentTarget;
         setDrawerOpen(true);
     };
 
-    const closeDrawer = () => {
+    const closeDrawer = (preferHeaderFallback = false) => {
+        if (preferHeaderFallback) {
+            setPendingCreatedFocusRestore(true);
+        }
         setDrawerOpen(false);
-        focusDrawerTrigger();
+        window.setTimeout(() => focusDrawerTrigger(preferHeaderFallback), 0);
+        if (preferHeaderFallback) {
+            window.setTimeout(() => focusDrawerTrigger(true), 250);
+        }
     };
+
+    useEffect(() => {
+        if (!pendingCreatedFocusRestore || drawerOpen || accounts.length === 0) return;
+
+        window.setTimeout(() => focusDrawerTrigger(true), 0);
+        setPendingCreatedFocusRestore(false);
+    }, [accounts.length, drawerOpen, focusDrawerTrigger, pendingCreatedFocusRestore]);
 
     const toggleCurrencyGroup = (currency: string) => {
         setCollapsedCurrencies((current) => {
@@ -522,7 +547,7 @@ const Accounts = () => {
             title={t("accounts.addDrawerTitle")}
             subtitle={t("accounts.drawerSubtitle")}
         >
-            <AccountCreateForm onCancel={closeDrawer} onCreated={closeDrawer} />
+            <AccountCreateForm onCancel={() => closeDrawer()} onCreated={() => closeDrawer(true)} />
         </InExDrawer>
     );
 

--- a/inex/ClientApp/src/pages/Budgets.empty-focus.test.tsx
+++ b/inex/ClientApp/src/pages/Budgets.empty-focus.test.tsx
@@ -1,0 +1,181 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+
+import authSlice from "../store/auth/auth-slice";
+import { budgetsApi } from "../store/budgets/budgets-api";
+import { budgetReportApi } from "../store/budgetReport/budgetReport-api";
+import { categoriesApi } from "../store/categories/categories-api";
+import Budgets from "./Budgets";
+
+const apiClientMock = vi.hoisted(() => Object.assign(vi.fn(), { get: vi.fn() }));
+
+vi.mock("../utils/apiClient", () => ({
+    default: apiClientMock,
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+    ...await importOriginal<typeof import("react-i18next")>(),
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock("./Budgets/BudgetEditForm", () => ({
+    default: () => <div>mock-budget-edit</div>,
+}));
+
+const delay = (milliseconds: number) =>
+    new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+
+const makeStore = () =>
+    configureStore({
+        reducer: {
+            auth: authSlice.reducer,
+            [budgetsApi.reducerPath]: budgetsApi.reducer,
+            [budgetReportApi.reducerPath]: budgetReportApi.reducer,
+            [categoriesApi.reducerPath]: categoriesApi.reducer,
+        },
+        middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware().concat(
+                budgetsApi.middleware,
+                budgetReportApi.middleware,
+                categoriesApi.middleware,
+            ),
+        preloadedState: {
+            auth: {
+                accessToken: "token",
+                expiresAt: Date.now() + 3_600_000,
+                user: { id: 1, username: "qa", email: "qa@example.com", currencyId: 1, languageCode: "en" },
+                isInitializing: false,
+                error: null,
+            },
+        },
+    });
+
+describe("Budgets empty-state create focus", () => {
+    beforeEach(() => {
+        let created = false;
+
+        Object.defineProperty(window, "matchMedia", {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            })),
+        });
+
+        apiClientMock.mockImplementation(async ({
+            url,
+            method = "get",
+        }: {
+            url: string;
+            method?: string;
+        }) => {
+            if (url === "/budgets" && method === "get") {
+                if (created) {
+                    await delay(350);
+                }
+
+                return {
+                    data: {
+                        data: created
+                            ? [{
+                                id: 1,
+                                key: "food-plan",
+                                name: "Food plan",
+                                description: "Created in test",
+                                value: 400,
+                                categoryIds: [1],
+                                year: 2026,
+                                month: 6,
+                            }]
+                            : [],
+                    },
+                };
+            }
+
+            if (url === "/budgets" && method === "post") {
+                created = true;
+                return { data: {} };
+            }
+
+            if (url === "/categories?mode=ALL") {
+                return {
+                    data: {
+                        data: [{
+                            id: 1,
+                            key: "food",
+                            name: "Food",
+                            description: "",
+                            parentId: null,
+                            isEnabled: true,
+                            isSystem: false,
+                            systemCode: null,
+                        }],
+                    },
+                };
+            }
+
+            if (url === "/reports/budget/comparison") {
+                return {
+                    data: {
+                        data: [{
+                            categoryName: "Food",
+                            categoryIds: [1],
+                            budgetedAmount: 400,
+                            spentAmount: 125,
+                            remainingAmount: 275,
+                            percentageUsed: 31.25,
+                        }],
+                    },
+                };
+            }
+
+            return { data: null };
+        });
+
+        apiClientMock.get.mockResolvedValue({
+            data: [{ id: 1, key: "PLN", name: "Polish zloty" }],
+        });
+    });
+
+    it("returns focus to the mounted Add budget button after delayed first-create refetch", async () => {
+        const user = userEvent.setup();
+        const store = makeStore();
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={["/budgets?year=2026&month=6"]}>
+                    <Budgets />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        const emptyRegion = await screen.findByRole("region", { name: "budgets.emptyState.title" });
+        await user.click(within(emptyRegion).getByRole("button", { name: "budgets.addBudget" }));
+        fireEvent.change(await screen.findByPlaceholderText("budgets.keyPlaceholder"), {
+            target: { value: "food-plan" },
+        });
+        fireEvent.change(screen.getByPlaceholderText("budgets.namePlaceholder"), {
+            target: { value: "Food plan" },
+        });
+        fireEvent.change(screen.getByPlaceholderText("0.00"), {
+            target: { value: "400" },
+        });
+        await user.click(screen.getByRole("button", { name: "budgets.create" }));
+
+        await waitFor(() => {
+            expect(document.activeElement).toHaveTextContent("budgets.addBudget");
+        }, { timeout: 2000 });
+        expect(await screen.findAllByText("Food plan", {}, { timeout: 3000 })).not.toHaveLength(0);
+    }, 10_000);
+});

--- a/inex/ClientApp/src/pages/Budgets.tsx
+++ b/inex/ClientApp/src/pages/Budgets.tsx
@@ -135,6 +135,7 @@ const Budgets = () => {
     const [currenciesResolved, setCurrenciesResolved] = useState(false);
     const [currencyLoadError, setCurrencyLoadError] = useState(false);
     const [currencyReloadToken, setCurrencyReloadToken] = useState(0);
+    const [pendingCreatedFocusRestore, setPendingCreatedFocusRestore] = useState(false);
     const initialSearchParamsInvalidRef = React.useRef(false);
     const drawerTriggerRef = React.useRef<HTMLButtonElement | null>(null);
     const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
@@ -322,12 +323,39 @@ const Budgets = () => {
         };
     };
 
-    const closeDrawer = () => {
+    const focusDrawerTrigger = React.useCallback((preferToolbarFallback = false) => {
+        const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+        const addButtons = buttons.filter((button) =>
+            !button.disabled && button.textContent?.trim() === t("budgets.addBudget"));
+        const originalTrigger = drawerTriggerRef.current;
+        const connectedOriginalTrigger = originalTrigger?.isConnected ? originalTrigger : null;
+        const toolbarAddButton = addButtons[0] ?? null;
+        const focusTarget = preferToolbarFallback
+            ? toolbarAddButton ?? connectedOriginalTrigger
+            : connectedOriginalTrigger ?? toolbarAddButton;
+
+        focusTarget?.focus();
+    }, [t]);
+
+    const closeDrawer = (preferToolbarFallback = false) => {
+        if (preferToolbarFallback) {
+            setPendingCreatedFocusRestore(true);
+        }
         setDrawerOpen(false);
         setDrawerError(null);
         form.resetFields();
-        window.setTimeout(() => drawerTriggerRef.current?.focus(), 0);
+        window.setTimeout(() => focusDrawerTrigger(preferToolbarFallback), 0);
+        if (preferToolbarFallback) {
+            window.setTimeout(() => focusDrawerTrigger(true), 250);
+        }
     };
+
+    useEffect(() => {
+        if (!pendingCreatedFocusRestore || drawerOpen || !hasBudgets) return;
+
+        window.setTimeout(() => focusDrawerTrigger(true), 0);
+        setPendingCreatedFocusRestore(false);
+    }, [drawerOpen, focusDrawerTrigger, hasBudgets, pendingCreatedFocusRestore]);
 
     const openDrawer: React.MouseEventHandler<HTMLButtonElement> = (event) => {
         drawerTriggerRef.current = event.currentTarget;
@@ -367,7 +395,7 @@ const Budgets = () => {
                 month: periodPayload.month,
             }).unwrap();
             message.success(t("budgets.created"));
-            closeDrawer();
+            closeDrawer(true);
         } catch (error) {
             setDrawerError(parseAxiosError(error, t("budgets.formErrors.create"), t));
         }
@@ -482,7 +510,7 @@ const Budgets = () => {
                         />
                     </Form.Item>
                     <div className="budgets-drawer__actions">
-                        <InExButton kind="ghost" onClick={closeDrawer}>
+                        <InExButton kind="ghost" onClick={() => closeDrawer()}>
                             {t("budgets.cancel")}
                         </InExButton>
                         <InExButton kind="primary" type="submit" disabled={isCreateLoading}>

--- a/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
+++ b/inex/ClientApp/src/pages/Budgets/budget-planning-utils.test.ts
@@ -62,6 +62,19 @@ describe("budget planning helpers", () => {
         expect(result?.percentageUsed).toBeCloseTo(33.33, 1);
     });
 
+    it("uses the parent budget report row without double-counting separate child rows", () => {
+        const budget = createBudgetDetails({ value: 400, categoryIds: [1] });
+        const result = getBudgetReportForBudget(budget, [
+            reportItem({ categoryIds: [1], spentAmount: 200 }),
+            reportItem({ categoryIds: [2], spentAmount: 125 }),
+        ]);
+
+        expect(result?.budgetedAmount).toBe(400);
+        expect(result?.spentAmount).toBe(200);
+        expect(result?.remainingAmount).toBe(200);
+        expect(result?.percentageUsed).toBe(50);
+    });
+
     it("keeps categoryless budgets scannable with zero-spend report metrics", () => {
         const budget = createBudgetDetails({ name: "Savings", value: 150, categoryIds: [] });
         const result = getBudgetReportForBudget(budget, []);

--- a/inex/ClientApp/src/pages/Categories.transaction-source.test.tsx
+++ b/inex/ClientApp/src/pages/Categories.transaction-source.test.tsx
@@ -1,0 +1,164 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+
+import authSlice from "../store/auth/auth-slice";
+import budgetsSlice from "../store/budgets/budgets-slice";
+import ratesSlice from "../store/rates/rates-slice";
+import { budgetsApi } from "../store/budgets/budgets-api";
+import { categoriesApi } from "../store/categories/categories-api";
+import { transactionsApi } from "../store/transactions/transactions-api";
+import Categories from "./Categories";
+
+const apiClientMock = vi.hoisted(() => Object.assign(vi.fn(), { get: vi.fn() }));
+
+vi.mock("../utils/apiClient", () => ({
+    default: apiClientMock,
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+    ...await importOriginal<typeof import("react-i18next")>(),
+    useTranslation: () => ({
+        i18n: { language: "en" },
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock("./Categories/CategoryRow", () => ({
+    CategoryRow: ({
+        category,
+        stats,
+        statsAvailable,
+    }: {
+        category: { name: string };
+        stats?: { totalSpend: number };
+        statsAvailable: boolean;
+    }) => (
+        <div data-testid="category-row">
+            {category.name}:{String(statsAvailable)}:{stats?.totalSpend ?? "none"}
+        </div>
+    ),
+}));
+
+vi.mock("./Categories/CategoryInlineEdit", () => ({
+    CategoryInlineEdit: () => <div>mock-category-edit</div>,
+}));
+
+const makeStore = () =>
+    configureStore({
+        reducer: {
+            auth: authSlice.reducer,
+            rates: ratesSlice.reducer,
+            budgets: budgetsSlice.reducer,
+            [budgetsApi.reducerPath]: budgetsApi.reducer,
+            [categoriesApi.reducerPath]: categoriesApi.reducer,
+            [transactionsApi.reducerPath]: transactionsApi.reducer,
+        },
+        middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware().concat(
+                budgetsApi.middleware,
+                categoriesApi.middleware,
+                transactionsApi.middleware,
+            ),
+        preloadedState: {
+            auth: {
+                accessToken: "token",
+                expiresAt: Date.now() + 3_600_000,
+                user: { id: 1, username: "qa", email: "qa@example.com", currencyId: 1, languageCode: "en" },
+                isInitializing: false,
+                error: null,
+            },
+            rates: {
+                items: [],
+                error: null,
+            },
+            budgets: {
+                items: [],
+                isLoading: false,
+                isCreating: false,
+                isUpdating: false,
+                lastUpdate: 0,
+                error: null,
+            },
+        },
+    });
+
+describe("Categories transaction source", () => {
+    beforeEach(() => {
+        apiClientMock.mockImplementation(async ({ url }: { url: string }) => {
+            if (url === "/categories?mode=ALL") {
+                return {
+                    data: {
+                        data: [{
+                            id: 1,
+                            key: "food",
+                            name: "Food",
+                            description: "",
+                            parentId: null,
+                            isEnabled: true,
+                            isSystem: false,
+                            systemCode: null,
+                        }],
+                    },
+                };
+            }
+
+            if (url === "/budgets") {
+                return { data: { data: [] } };
+            }
+
+            return { data: null };
+        });
+
+        apiClientMock.get.mockImplementation(async (url: string) => {
+            if (url === "/currencies") {
+                return { data: [{ id: 1, key: "PLN" }] };
+            }
+
+            if (url === "/transactions") {
+                throw new Error("direct all-mode fetch failed");
+            }
+
+            return { data: null };
+        });
+    });
+
+    it("does not use active-only transaction cache when all-mode category spend fetch is unavailable", async () => {
+        const store = makeStore();
+        store.dispatch(transactionsApi.util.upsertQueryData("getTransactions", {
+            pageSize: 20,
+            page: 1,
+            filter: {
+                accountIds: [],
+                categoryIds: [],
+                tags: [],
+                refs: [],
+                range: [],
+            },
+        }, {
+            data: [{
+                id: 1,
+                accountId: 1,
+                categoryId: 1,
+                created: "2026-06-05T12:00:00",
+                amount: -300,
+                comment: "active-only cached spend",
+                accountCurrency: "PLN",
+                tags: [],
+                refs: [],
+            }],
+            metadata: { totalItems: 1 },
+        }));
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <Categories />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        expect(await screen.findByTestId("category-row")).toHaveTextContent("Food:false:0");
+    });
+});

--- a/inex/ClientApp/src/pages/Categories.tsx
+++ b/inex/ClientApp/src/pages/Categories.tsx
@@ -15,7 +15,6 @@ import type { TransactionResponse } from "../model/Transaction/TransactionRespon
 import { budgetsApi, useGetBudgetsQuery } from "../store/budgets/budgets-api";
 import type { CategoryResponse } from "../store/categories/categories-api";
 import { useGetCategoriesQuery } from "../store/categories/categories-api";
-import type { RootState } from "../store";
 import { useAppSelector } from "../store/hooks";
 import apiClient from "../utils/apiClient";
 import CategoryCreateForm from "./Categories/CategoryCreateForm";
@@ -63,17 +62,6 @@ interface TransactionsPagedData {
     metadata: { totalItems: number };
 }
 
-interface TransactionQueryArgs {
-    page: number;
-    filter: {
-        accountIds: number[];
-        categoryIds: number[];
-        tags: string[];
-        refs: string[];
-        range: number[];
-    };
-}
-
 interface CurrencyOption {
     id: number;
     key: string;
@@ -88,21 +76,6 @@ const isTransactionsPagedData = (value: unknown): value is TransactionsPagedData
     value.data.every(isTransactionResponse) &&
     isRecord(value.metadata) &&
     typeof value.metadata.totalItems === "number";
-
-const isTransactionQueryArgs = (value: unknown): value is TransactionQueryArgs =>
-    isRecord(value) &&
-    typeof value.page === "number" &&
-    isRecord(value.filter) &&
-    Array.isArray(value.filter.accountIds) &&
-    Array.isArray(value.filter.categoryIds) &&
-    Array.isArray(value.filter.tags) &&
-    Array.isArray(value.filter.refs) &&
-    Array.isArray(value.filter.range);
-
-const getPeriodBounds = ({ year, month }: CategoryPeriod) => ({
-    start: new Date(year, month - 1, 1).getTime() / 1000,
-    end: new Date(year, month, 0, 23, 59, 59).getTime() / 1000,
-});
 
 const formatPeriodDate = (year: number, month: number, day: number) =>
     `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
@@ -119,82 +92,6 @@ const getPeriodQueryDates = ({ year, month }: CategoryPeriod) => ({
     endDate: formatPeriodDateTime(year, month, new Date(year, month, 0).getDate(), "end"),
 });
 
-const isUnfilteredPeriodCoveringQuery = (
-    args: TransactionQueryArgs,
-    period: CategoryPeriod,
-) => {
-    const { filter } = args;
-    const hasServerFilters =
-        filter.accountIds.length > 0 ||
-        filter.categoryIds.length > 0 ||
-        filter.tags.length > 0 ||
-        filter.refs.length > 0;
-    if (hasServerFilters) return false;
-
-    if (filter.range.length === 0) return true;
-    if (filter.range.length !== 2) return false;
-
-    const [start, end] = filter.range;
-    if (typeof start !== "number" || typeof end !== "number" || start <= 0 || end <= 0) {
-        return false;
-    }
-
-    const periodBounds = getPeriodBounds(period);
-    return start <= periodBounds.start && end >= periodBounds.end;
-};
-
-const makeTransactionCacheKey = (args: TransactionQueryArgs) =>
-    JSON.stringify({
-        accountIds: args.filter.accountIds,
-        categoryIds: args.filter.categoryIds,
-        tags: args.filter.tags,
-        refs: args.filter.refs,
-        range: args.filter.range,
-    });
-
-const selectCachedTransactions = (
-    queries: RootState["transactionsApi"]["queries"],
-    period: CategoryPeriod,
-) => {
-    const groups = new Map<string, {
-        ids: Set<number>;
-        transactions: TransactionResponse[];
-        totalItems: number;
-    }>();
-
-    Object.values(queries).forEach((query) => {
-        const data = query?.data;
-        const originalArgs = query?.originalArgs;
-        if (!isTransactionsPagedData(data) || !isTransactionQueryArgs(originalArgs)) {
-            return;
-        }
-        if (!isUnfilteredPeriodCoveringQuery(originalArgs, period)) {
-            return;
-        }
-
-        const key = makeTransactionCacheKey(originalArgs);
-        const group = groups.get(key) ?? {
-            ids: new Set<number>(),
-            transactions: [],
-            totalItems: data.metadata.totalItems,
-        };
-        group.totalItems = Math.max(group.totalItems, data.metadata.totalItems);
-        data.data.forEach((transaction) => {
-            if (!group.ids.has(transaction.id)) {
-                group.ids.add(transaction.id);
-                group.transactions.push(transaction);
-            }
-        });
-        groups.set(key, group);
-    });
-
-    const completeGroups = Array.from(groups.values())
-        .filter((group) => group.totalItems === 0 || group.ids.size >= group.totalItems)
-        .sort((left, right) => left.totalItems - right.totalItems);
-
-    return completeGroups[0]?.transactions ?? null;
-};
-
 const fetchPeriodTransactions = async (period: CategoryPeriod): Promise<TransactionResponse[] | null> => {
     const { startDate, endDate } = getPeriodQueryDates(period);
     const transactions: TransactionResponse[] = [];
@@ -205,7 +102,7 @@ const fetchPeriodTransactions = async (period: CategoryPeriod): Promise<Transact
     while (seenIds.size < totalItems && page <= CATEGORY_TRANSACTIONS_MAX_PAGES) {
         const { data } = await apiClient.get<TransactionsPagedData>("/transactions", {
             params: {
-                mode: "active",
+                mode: "ALL",
                 pageSize: CATEGORY_TRANSACTIONS_PAGE_SIZE,
                 page,
                 startDate,
@@ -283,9 +180,6 @@ const Categories = () => {
         refetch,
     } = useGetCategoriesQuery("ALL");
     const { data: currentMonthBudgets } = useGetBudgetsQuery(period);
-    const cachedTransactions = useAppSelector((state) =>
-        selectCachedTransactions(state.transactionsApi.queries, period),
-    );
     const exchangeRates = useAppSelector((state) => state.rates.items);
     const userCurrencyId = useAppSelector((state) => state.auth.user?.currencyId);
     const profileCurrency = React.useMemo(
@@ -307,7 +201,7 @@ const Categories = () => {
         );
     });
     const budgetsForPeriod = currentMonthBudgets ?? cachedBudgets;
-    const currentPeriodTransactions = periodTransactions ?? cachedTransactions;
+    const currentPeriodTransactions = periodTransactions;
 
     const focusAddTrigger = React.useCallback((preferToolbarFallback = false) => {
         const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));

--- a/inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts
@@ -40,4 +40,19 @@ describe("transaction filter URL helpers", () => {
       dayjs("2026-06-30T23:59:59").unix(),
     ]);
   });
+
+  it("ignores malformed date ranges instead of creating invalid timestamps", () => {
+    expect(parseTransactionFilterParam("start:not-a-date;end:2026-06-30;")).toBeNull();
+    expect(parseTransactionFilterParam("start:2026-07-01;end:2026-06-30;")).toBeNull();
+
+    expect(parseTransactionFilterParam("accountIds:7;start:not-a-date;end:2026-06-30;")).toMatchObject({
+      accountIds: [7],
+      range: [],
+    });
+  });
+
+  it("rejects impossible calendar dates instead of normalizing them", () => {
+    expect(parseTransactionFilterParam("start:2026-02-31;end:2026-03-31;")).toBeNull();
+    expect(parseTransactionFilterParam("start:2026-02-01;end:2026-02-31;")).toBeNull();
+  });
 });

--- a/inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts
@@ -1,8 +1,12 @@
 import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 
 import type { TransactionFilter } from "../../store/transactions/transactions-slice";
 
 const FILTER_PARAM = "filter";
+const DATE_FORMAT = "YYYY-MM-DD";
+
+dayjs.extend(customParseFormat);
 
 const encodeFilterValue = (value: string): string => encodeURIComponent(value);
 
@@ -24,11 +28,16 @@ const parseTextValues = (values: string[]): string[] =>
         .map(decodeFilterValue)
         .filter(value => value !== "");
 
-const parseStartDate = (value: string): number =>
-    dayjs(value).startOf("day").unix();
+const parseDate = (value: string) => {
+    const parsedDate = dayjs(value, DATE_FORMAT, true);
+    return parsedDate.isValid() ? parsedDate : null;
+};
 
-const parseEndDate = (value: string): number =>
-    dayjs(value).endOf("day").unix();
+const parseStartDate = (value: string): number | null =>
+    parseDate(value)?.startOf("day").unix() ?? null;
+
+const parseEndDate = (value: string): number | null =>
+    parseDate(value)?.endOf("day").unix() ?? null;
 
 export const parseTransactionFilterParam = (filter: string | null): TransactionFilter | null => {
     const parsedFilter: TransactionFilter = {
@@ -74,10 +83,12 @@ export const parseTransactionFilterParam = (filter: string | null): TransactionF
     });
 
     if (startDate !== "" && endDate !== "") {
-        parsedFilter.range = [
-            parseStartDate(startDate),
-            parseEndDate(endDate),
-        ];
+        const start = parseStartDate(startDate);
+        const end = parseEndDate(endDate);
+
+        if (start !== null && end !== null && start <= end) {
+            parsedFilter.range = [start, end];
+        }
     }
 
     const hasActiveFilter =


### PR DESCRIPTION
## Summary

- Restore invite-token validation during registration so invalid invite tokens return the expected 403 problem response.
- Mark Story 10.3d, 10.3e, and 10.3f done after backend and frontend verification passed.
- Keep Epic 10 in progress because 10.5a, 10.5b, and 10.6 remain incomplete.

## Root Cause

The checkpoint commit had commented out the `AuthService.RegisterAsync` invite-token guard, which allowed registrations with invalid invite tokens and caused `AuthControllerTests.Register_WithWrongInviteToken_Returns403` to fail.

## Verification

- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal --logger "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage" --results-directory .\test-results`
- `npm run lint`
- `npm run build`
- `npm run test`