### PR TITLE
fix(categories): align visual layout and split response DTO

### DIFF
--- a/inex.Services.Tests/Models/Mappers/CustomMapperTests.cs
+++ b/inex.Services.Tests/Models/Mappers/CustomMapperTests.cs
@@ -2,6 +2,7 @@ using inex.Data.Models;
 using inex.Services.Models.Mappers;
 using inex.Services.Models.Records.Account;
 using inex.Services.Models.Records.Budget;
+using inex.Services.Models.Records.Category;
 using inex.Services.Models.Records.Transaction;
 
 namespace inex.Services.Tests.Models.Mappers;
@@ -59,5 +60,33 @@ public class CustomMapperTests
         Assert.Equal(3, transaction.AccountId);
         Assert.Equal(-42, transaction.Value);
         Assert.Equal("move", transaction.Comment);
+    }
+
+    [Fact]
+    public void CategoryResponse_ToSummary_CopiesResponseFields()
+    {
+        var response = new CategoryResponse
+        {
+            Id = 7,
+            ParentId = 3,
+            Key = "groceries",
+            Name = "Groceries",
+            Description = "Food shopping",
+            IsEnabled = true,
+            IsSystem = false,
+            SystemCode = null
+        };
+
+        CategorySummary summary = response.ToSummary();
+
+        Assert.Equal(response.Id, summary.Id);
+        Assert.Equal(response.ParentId, summary.ParentId);
+        Assert.Equal(response.Key, summary.Key);
+        Assert.Equal(response.Name, summary.Name);
+        Assert.Equal(response.Description, summary.Description);
+        Assert.Equal(response.IsEnabled, summary.IsEnabled);
+        Assert.Equal(response.IsSystem, summary.IsSystem);
+        Assert.Equal(response.SystemCode, summary.SystemCode);
+        Assert.Equal(0, summary.Value);
     }
 }

--- a/inex.Services.Tests/Models/Records/ResponseContractTests.cs
+++ b/inex.Services.Tests/Models/Records/ResponseContractTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using inex.Services.Models.Records.Account;
+using inex.Services.Models.Records.Category;
+
+namespace inex.Services.Tests.Models.Records;
+
+public class ResponseContractTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void AccountResponse_SerializesExpectedApiShape()
+    {
+        var response = new AccountResponse
+        {
+            Id = 12,
+            CurrencyId = 1,
+            Key = "cash",
+            Name = "Cash",
+            Description = "Daily wallet",
+            IsEnabled = true,
+            Currency = "USD"
+        };
+
+        JsonElement json = JsonSerializer.SerializeToElement(response, JsonOptions);
+
+        AssertJsonProperties(json,
+            "id",
+            "currencyId",
+            "key",
+            "name",
+            "description",
+            "isEnabled",
+            "currency");
+        Assert.Equal(12, json.GetProperty("id").GetInt32());
+        Assert.Equal(1, json.GetProperty("currencyId").GetInt32());
+        Assert.Equal("cash", json.GetProperty("key").GetString());
+        Assert.Equal("Cash", json.GetProperty("name").GetString());
+        Assert.Equal("Daily wallet", json.GetProperty("description").GetString());
+        Assert.True(json.GetProperty("isEnabled").GetBoolean());
+        Assert.Equal("USD", json.GetProperty("currency").GetString());
+    }
+
+    [Fact]
+    public void CategoryResponse_DoesNotInheritRequestContracts()
+    {
+        Assert.Equal(typeof(object), typeof(CategoryResponse).BaseType);
+    }
+
+    [Fact]
+    public void CategoryResponse_SerializesExpectedApiShape()
+    {
+        var response = new CategoryResponse
+        {
+            Id = 7,
+            ParentId = 3,
+            Key = "groceries",
+            Name = "Groceries",
+            Description = "Food shopping",
+            IsEnabled = true,
+            IsSystem = false,
+            SystemCode = null
+        };
+
+        JsonElement json = JsonSerializer.SerializeToElement(response, JsonOptions);
+
+        AssertJsonProperties(json,
+            "id",
+            "parentId",
+            "key",
+            "name",
+            "description",
+            "isEnabled",
+            "isSystem",
+            "systemCode");
+        Assert.Equal(7, json.GetProperty("id").GetInt32());
+        Assert.Equal(3, json.GetProperty("parentId").GetInt32());
+        Assert.Equal("groceries", json.GetProperty("key").GetString());
+        Assert.Equal("Groceries", json.GetProperty("name").GetString());
+        Assert.Equal("Food shopping", json.GetProperty("description").GetString());
+        Assert.True(json.GetProperty("isEnabled").GetBoolean());
+        Assert.False(json.GetProperty("isSystem").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, json.GetProperty("systemCode").ValueKind);
+    }
+
+    private static void AssertJsonProperties(JsonElement json, params string[] expectedNames)
+    {
+        string[] actualNames = json.EnumerateObject()
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(expectedNames.OrderBy(name => name), actualNames);
+    }
+}

--- a/inex.Services/Models/Mappers/CategoryMapper.cs
+++ b/inex.Services/Models/Mappers/CategoryMapper.cs
@@ -45,16 +45,6 @@ public static class CategoryMapper
 
     public static CategorySummary ToSummary(this CategoryResponse source)
     {
-        return new CategorySummary
-        {
-            Id = source.Id,
-            ParentId = source.ParentId,
-            Key = source.Key,
-            Name = source.Name,
-            Description = source.Description,
-            IsEnabled = source.IsEnabled,
-            IsSystem = source.IsSystem,
-            SystemCode = source.SystemCode
-        };
+        return new CategorySummary(source);
     }
 }

--- a/inex.Services/Models/Records/Category/CategoryResponse.cs
+++ b/inex.Services/Models/Records/Category/CategoryResponse.cs
@@ -1,5 +1,14 @@
 namespace inex.Services.Models.Records.Category;
 
-public record CategoryResponse : UpdateCategoryRequest
+public record CategoryResponse
 {
+    public int Id { get; init; }
+    public int? ParentId { get; init; }
+
+    public string Key { get; init; } = null!;
+    public string Name { get; init; } = null!;
+    public string? Description { get; init; }
+    public bool IsEnabled { get; init; }
+    public bool IsSystem { get; init; }
+    public string? SystemCode { get; init; }
 }

--- a/inex.Services/Models/Records/Category/CategorySummary.cs
+++ b/inex.Services/Models/Records/Category/CategorySummary.cs
@@ -2,5 +2,14 @@ namespace inex.Services.Models.Records.Category;
 
 public record CategorySummary : CategoryResponse
 {
+    public CategorySummary()
+    {
+    }
+
+    public CategorySummary(CategoryResponse source)
+        : base(source)
+    {
+    }
+
     public decimal Value { get; init; }
 }

--- a/inex/ClientApp/public/locales/en/translation.json
+++ b/inex/ClientApp/public/locales/en/translation.json
@@ -461,7 +461,7 @@
     "delete": "Delete",
     "cancel": "Cancel",
     "update": "Update",
-    "listTitle": "Category structure",
+    "listTitle": "Categories",
     "countSummary": "{{visible}} of {{total}} categories · {{scope}}",
     "parent": "Parent",
     "budgeted": "Budgeted",
@@ -489,6 +489,7 @@
     },
     "scope": {
       "active": "Active",
+      "activeOnly": "Active only",
       "all": "All"
     },
     "activity": {
@@ -499,6 +500,7 @@
       "lastActive": "last {{date}}",
       "periodCurrency": "{{currency}} · {{period}}",
       "noTransactions": "No activity",
+      "noSpend": "No spend",
       "unavailable": "Activity unavailable",
       "spendUnavailable": "Spend unavailable"
     },

--- a/inex/ClientApp/public/locales/ru/translation.json
+++ b/inex/ClientApp/public/locales/ru/translation.json
@@ -463,7 +463,7 @@
     "delete": "Удалить",
     "cancel": "Отмена",
     "update": "Обновить",
-    "listTitle": "Структура категорий",
+    "listTitle": "Категории",
     "countSummary": "{{visible}} из {{total}} категорий · {{scope}}",
     "parent": "Родитель",
     "budgeted": "С бюджетом",
@@ -491,6 +491,7 @@
     },
     "scope": {
       "active": "Активные",
+      "activeOnly": "Только активные",
       "all": "Все"
     },
     "activity": {
@@ -501,6 +502,7 @@
       "lastActive": "посл. {{date}}",
       "periodCurrency": "{{currency}} · {{period}}",
       "noTransactions": "Нет активности",
+      "noSpend": "Нет расходов",
       "unavailable": "Активность недоступна",
       "spendUnavailable": "Расходы недоступны"
     },

--- a/inex/ClientApp/src/pages/Categories/CategoriesHero.tsx
+++ b/inex/ClientApp/src/pages/Categories/CategoriesHero.tsx
@@ -6,7 +6,6 @@ import type { CategoryResponse } from "../../store/categories/categories-api";
 import {
     categoryPaletteColor,
     type CategorySpendStats,
-    isSystemCategory,
 } from "./categories.utils";
 
 interface CategoriesHeroProps {
@@ -23,27 +22,13 @@ export const CategoriesHero: React.FC<CategoriesHeroProps> = ({
     stats,
 }) => {
     const { t } = useTranslation();
-    const activeUserCategories = categories.filter(
-        (category) => category.isEnabled && !isSystemCategory(category),
-    );
-    const parentCategories = activeUserCategories.filter(
-        (category) => category.parentId == null,
-    );
-    const childCount = activeUserCategories.length - parentCategories.length;
 
     if (loading) {
         return (
             <section className="categories-hero r-categories-hero" aria-label={t("categories.loading.initial")}>
                 <div className="categories-hero__summary categories-hero__skeleton" />
                 <div className="categories-hero__details">
-                    <div className="categories-hero__metric-grid">
-                        <div className="categories-hero__skeleton" />
-                        <div className="categories-hero__skeleton" />
-                        <div className="categories-hero__skeleton" />
-                    </div>
-                    <div className="categories-hero__empty">
-                        {t("categories.loading.initial")}
-                    </div>
+                    <div className="categories-hero__distribution categories-hero__skeleton" />
                 </div>
             </section>
         );
@@ -89,20 +74,6 @@ export const CategoriesHero: React.FC<CategoriesHeroProps> = ({
                 </div>
             </div>
             <div className="categories-hero__details">
-                <div className="categories-hero__metric-grid">
-                    <div>
-                        <span>{t("categories.metrics.active")}</span>
-                        <strong>{activeUserCategories.length}</strong>
-                    </div>
-                    <div>
-                        <span>{t("categories.metrics.parents")}</span>
-                        <strong>{parentCategories.length}</strong>
-                    </div>
-                    <div>
-                        <span>{t("categories.metrics.children")}</span>
-                        <strong>{Math.max(0, childCount)}</strong>
-                    </div>
-                </div>
                 {hasSpend ? (
                     <div className="categories-hero__distribution" aria-label={t("categories.hero.byCategory")}>
                         <div className="categories-hero__distribution-head">
@@ -143,9 +114,22 @@ export const CategoriesHero: React.FC<CategoriesHeroProps> = ({
 
                                 return (
                                     <div className="categories-hero__legend-item" key={item.key}>
-                                        <span style={{ background: color }} />
-                                        <strong>{label}</strong>
-                                        <small>{Math.round(item.share * 100)}%</small>
+                                        <span className="categories-hero__legend-swatch" style={{ background: color }} />
+                                        <span className="categories-hero__legend-copy">
+                                            <strong>{label}</strong>
+                                            <small>
+                                                <Num
+                                                    value={item.value}
+                                                    currency={stats.currency}
+                                                    kind="expense"
+                                                    size={11}
+                                                    currencySize="sm"
+                                                />
+                                            </small>
+                                        </span>
+                                        <small className="categories-hero__legend-share">
+                                            {Math.round(item.share * 100)}%
+                                        </small>
                                     </div>
                                 );
                             })}

--- a/inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx
+++ b/inex/ClientApp/src/pages/Categories/CategoriesToolbar.tsx
@@ -39,7 +39,7 @@ export const CategoriesToolbar: React.FC<CategoriesToolbarProps> = ({
         visible,
         total,
         scope: activeOnly
-            ? t("categories.scope.active").toLowerCase()
+            ? t("categories.scope.activeOnly").toLowerCase()
             : t("categories.scope.all").toLowerCase(),
     });
 

--- a/inex/ClientApp/src/pages/Categories/CategoryRow.tsx
+++ b/inex/ClientApp/src/pages/Categories/CategoryRow.tsx
@@ -52,6 +52,9 @@ export const CategoryRow: React.FC<CategoryRowProps> = ({
     const noActivityLabel = statsAvailable
         ? t("categories.activity.noTransactions")
         : t("categories.activity.unavailable");
+    const noSpendLabel = statsAvailable
+        ? t("categories.activity.noSpend")
+        : t("categories.activity.spendUnavailable");
     const rowKindClass = hasChildren
         ? "category-row--parent"
         : depth > 0
@@ -75,7 +78,7 @@ export const CategoryRow: React.FC<CategoryRowProps> = ({
             onClick={onToggle}
             type="button"
         >
-            <span className="category-row__name" style={{ paddingLeft: indent }}>
+            <span className="category-row__name" style={{ paddingLeft: `calc(16px + ${indent}px)` }}>
                 {depth > 0 ? <span className="category-row__connector" /> : null}
                 <span
                     className="category-row__swatch"
@@ -127,10 +130,13 @@ export const CategoryRow: React.FC<CategoryRowProps> = ({
                         </small>
                     </React.Fragment>
                 ) : (
-                    <React.Fragment>
-                        <strong>-</strong>
-                        <small>{noActivityLabel}</small>
-                    </React.Fragment>
+                    <strong
+                        className="category-row__placeholder"
+                        aria-label={noActivityLabel}
+                        title={noActivityLabel}
+                    >
+                        —
+                    </strong>
                 )}
             </span>
             <span className="category-row__spent">
@@ -147,14 +153,13 @@ export const CategoryRow: React.FC<CategoryRowProps> = ({
                         </small>
                     </React.Fragment>
                 ) : (
-                    <React.Fragment>
-                        <strong>-</strong>
-                        <small>
-                            {statsAvailable
-                                ? t("categories.hero.baseEquivalent", { currency })
-                                : t("categories.activity.spendUnavailable")}
-                        </small>
-                    </React.Fragment>
+                    <strong
+                        className="category-row__placeholder"
+                        aria-label={noSpendLabel}
+                        title={noSpendLabel}
+                    >
+                        —
+                    </strong>
                 )}
             </span>
             <span className="category-row__icon" aria-hidden="true">

--- a/inex/ClientApp/src/pages/Categories/categories.css
+++ b/inex/ClientApp/src/pages/Categories/categories.css
@@ -16,7 +16,13 @@
     display: grid;
     gap: 32px;
     grid-template-columns: 320px minmax(0, 1fr);
-    padding: 24px;
+    padding: 24px 28px;
+}
+
+.categories-hero__summary {
+    border-right: 1px solid var(--border-1);
+    min-width: 0;
+    padding-right: 32px;
 }
 
 .categories-eyebrow {
@@ -29,7 +35,7 @@
 }
 
 .categories-hero__amount {
-    font-size: 28px;
+    font-size: 34px;
     font-weight: 700;
     margin-bottom: 8px;
 }
@@ -55,6 +61,7 @@
     display: flex;
     flex-direction: column;
     gap: 18px;
+    justify-content: center;
     min-width: 0;
 }
 
@@ -128,12 +135,9 @@
 }
 
 .categories-hero__distribution {
-    background: var(--bg-muted);
-    border-radius: var(--radius-2);
     display: grid;
-    gap: 12px;
+    gap: 14px;
     min-width: 0;
-    padding: 14px;
 }
 
 .categories-hero__distribution-head {
@@ -146,7 +150,9 @@
 
 .categories-hero__distribution-head strong {
     color: var(--fg-1);
-    font-size: 13px;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .categories-hero__distribution-head span {
@@ -176,20 +182,27 @@
 }
 
 .categories-hero__legend-item {
-    align-items: center;
+    align-items: start;
     display: grid;
     gap: 8px;
     grid-template-columns: 8px minmax(0, 1fr) auto;
     min-width: 0;
 }
 
-.categories-hero__legend-item span {
+.categories-hero__legend-swatch {
     border-radius: 2px;
     height: 8px;
+    margin-top: 4px;
     width: 8px;
 }
 
-.categories-hero__legend-item strong {
+.categories-hero__legend-copy {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+}
+
+.categories-hero__legend-copy strong {
     color: var(--fg-2);
     font-size: 12px;
     font-weight: 600;
@@ -198,7 +211,8 @@
     white-space: nowrap;
 }
 
-.categories-hero__legend-item small {
+.categories-hero__legend-copy small,
+.categories-hero__legend-share {
     color: var(--fg-4);
     font-family: var(--font-num);
     font-size: 11px;
@@ -213,9 +227,27 @@
 }
 
 .categories-search {
-    flex: 1 1 220px;
+    flex: 0 1 260px;
+    margin-left: auto;
     max-width: 260px;
     min-width: min(220px, 100%);
+}
+
+.categories-list .inex-list-panel__header {
+    padding: 14px 20px 12px;
+}
+
+.categories-list .inex-list-panel__title-block h2 {
+    font-size: 15px;
+}
+
+.categories-list .inex-list-panel__title-block p {
+    font-size: 12px;
+}
+
+.categories-list .inex-list-panel__filters {
+    gap: 14px;
+    padding: 10px 20px;
 }
 
 .categories-list {
@@ -275,6 +307,7 @@
 
 .category-row__name {
     gap: 10px;
+    padding-right: 0;
 }
 
 .category-row__connector {
@@ -345,6 +378,7 @@
 .category-row__chip--budget {
     background: var(--income-50);
     color: var(--income-600);
+    margin-left: auto;
 }
 
 .category-row__activity,
@@ -360,6 +394,10 @@
     font-family: var(--font-num);
     font-size: 14px;
     font-variant-numeric: tabular-nums;
+}
+
+.category-row__placeholder {
+    color: var(--fg-4);
 }
 
 .category-row__icon {
@@ -485,6 +523,11 @@
         padding: 18px 16px;
     }
 
+    .categories-hero__summary {
+        border-right: 0;
+        padding-right: 0;
+    }
+
     .categories-hero__details {
         gap: 12px;
     }
@@ -495,6 +538,8 @@
     }
 
     .categories-search {
+        flex-basis: auto;
+        margin-left: 0;
         max-width: none;
         width: 100%;
     }


### PR DESCRIPTION
## Summary
- Align Categories hero, toolbar, row placeholders, and budget chip placement with visual QA issues.
- Preserve live-data behavior and avoid mockup data/date/value hardcoding.
- Split CategoryResponse from category request inheritance.
- Add response-shape contract tests and simplify CategorySummary mapping.

Closes #201
Closes #203
Closes #204
Closes #171
Closes #172
Related #165

## Verification
- npm run lint
- npm test -- Categories
- npm run build
- dotnet test inex.Services.Tests/inex.Services.Tests.csproj --no-restore
- dotnet test --no-restore

## Notes
- Categories visual parity remains data-mode aware: live-seed data values/names/dates/counts are not treated as visual defects.
- Existing unrelated local changes were not included in this PR.