### PR TITLE
Fix transfer ownership enforcement

### DIFF
--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -79,8 +79,8 @@ public class TransactionService : InExService, ITransactionService
 
         Category transferCategory = DbInEx.CategoryRepository.Get(true).First(i => i.UserId == userId && i.SystemCode!.ToLower() == "transfer");
 
-        Account accountFrom = DbInEx.AccountRepository.Get(true).First(i => i.Id == itemDTO.AccountFromId);
-        Account accountTo = DbInEx.AccountRepository.Get(true).First(i => i.Id == itemDTO.AccountToId);
+        Account accountFrom = await GetTransferAccountForUserAsync(itemDTO.AccountFromId, userId, ct);
+        Account accountTo = await GetTransferAccountForUserAsync(itemDTO.AccountToId, userId, ct);
 
         TransferFromData transferFrom = itemDTO.ToTransferFromData();
         TransferToData transferTo = itemDTO.ToTransferToData();
@@ -349,6 +349,14 @@ public class TransactionService : InExService, ITransactionService
         {
             throw new ResourceNotFoundException($"Category {categoryId} was not found.", "Category", categoryId);
         }
+    }
+
+    private async Task<Account> GetTransferAccountForUserAsync(int accountId, int userId, CancellationToken ct)
+    {
+        return await DbInEx.AccountRepository
+            .Get(true, i => i.Id == accountId && i.UserId == userId)
+            .SingleOrDefaultAsync(ct)
+            ?? throw new ResourceNotFoundException($"Account {accountId} was not found.", "Account", accountId);
     }
 
     #endregion Private Methods

--- a/inex.Tests/Transactions/TransactionsControllerTests.cs
+++ b/inex.Tests/Transactions/TransactionsControllerTests.cs
@@ -119,6 +119,48 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
     }
 
     [Fact]
+    public async Task CreateTransfer_WithOtherUsersSourceAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int otherSourceAccountId = await CreateAccountAsync(userB, "other-transfer-source-account");
+        int ownDestinationAccountId = await CreateAccountAsync(userA, "own-transfer-destination-account");
+
+        var response = await userA.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = otherSourceAccountId,
+            accountToId   = ownDestinationAccountId,
+            created       = DateTime.UtcNow,
+            amountFrom    = 10m,
+            amountTo      = 10m,
+            comment       = "attempted transfer source",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
+    public async Task CreateTransfer_WithOtherUsersDestinationAccount_Returns404Problem()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int ownSourceAccountId = await CreateAccountAsync(userA, "own-transfer-source-account");
+        int otherDestinationAccountId = await CreateAccountAsync(userB, "other-transfer-destination-account");
+
+        var response = await userA.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = ownSourceAccountId,
+            accountToId   = otherDestinationAccountId,
+            created       = DateTime.UtcNow,
+            amountFrom    = 10m,
+            amountTo      = 10m,
+            comment       = "attempted transfer destination",
+        });
+
+        await ProblemDetailsAssertions.AssertNotFoundProblemAsync(response);
+    }
+
+    [Fact]
     public async Task Update_WithOtherUsersAccount_Returns404Problem()
     {
         var userA = await CreateAuthenticatedClientAsync();


### PR DESCRIPTION
## Summary
- Require transfer source and destination accounts to belong to the current user.
- Return the same not-found problem-details behavior used for other non-owned transaction relations.
- Add integration regression coverage for non-owned source and destination transfer accounts.

Closes #158.

## Validation
- `dotnet test inex.sln -p:BaseOutputPath=D:\work\inex\.tmp\dotnet-test-bin\` passed: 179 tests.

## Review
- BMad review layers completed locally: Blind Hunter, Edge Case Hunter, Acceptance Auditor.
- Findings: none.