### PR TITLE
Define shared shell navigation policy

### DIFF
--- a/inex/ClientApp/public/assets/mark.svg
+++ b/inex/ClientApp/public/assets/mark.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60" width="100" height="60" role="img" aria-label="InEx mark">
+  <defs>
+    <linearGradient id="inexIncome" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4FA592"></stop>
+      <stop offset="55%" stop-color="#2F8F82"></stop>
+      <stop offset="100%" stop-color="#1E6154"></stop>
+    </linearGradient>
+    <linearGradient id="inexExpense" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#D57766"></stop>
+      <stop offset="55%" stop-color="#C35A4A"></stop>
+      <stop offset="100%" stop-color="#8B3729"></stop>
+    </linearGradient>
+  </defs>
+  <g fill="none" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 52 38 C 60 56, 80 52, 80 30 C 80 8, 60 4, 44 22" stroke="url(#inexIncome)"></path>
+    <path d="M 44 22 l -4 -4 M 44 22 l 5 -3" stroke="url(#inexIncome)"></path>
+    <path d="M 44 22 C 36 4, 16 8, 16 30 C 16 52, 36 56, 52 38" stroke="url(#inexExpense)"></path>
+    <path d="M 52 38 l 4 4 M 52 38 l -5 3" stroke="url(#inexExpense)"></path>
+  </g>
+</svg>

--- a/inex/ClientApp/src/layouts/AppShell.css
+++ b/inex/ClientApp/src/layouts/AppShell.css
@@ -36,17 +36,10 @@
 }
 
 .inex-logo__mark {
-    width: 32px;
-    height: 32px;
-    border-radius: var(--radius-2);
-    background: var(--brand-ink);
-    color: #fff;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 17px;
-    font-weight: 800;
-    line-height: 1;
+    display: block;
+    width: 36px;
+    height: 22px;
+    object-fit: contain;
 }
 
 .inex-logo__wordmark {
@@ -155,6 +148,11 @@
     font-weight: 500;
     color: var(--fg-1);
     white-space: nowrap;
+}
+
+.inex-user-pill__chevron {
+    color: var(--fg-3);
+    flex: 0 0 auto;
 }
 
 .inex-shell-icon-button {
@@ -387,9 +385,8 @@
     }
 
     .inex-logo__mark {
-        width: 28px;
-        height: 28px;
-        font-size: 15px;
+        width: 34px;
+        height: 20px;
     }
 
     .inex-logo__wordmark {
@@ -405,7 +402,7 @@
     }
 
     .r-user-pill {
-        padding: 4px;
+        padding: 4px 8px 4px 4px;
     }
 
     .r-user-pill-name {

--- a/inex/ClientApp/src/layouts/AppShell.tsx
+++ b/inex/ClientApp/src/layouts/AppShell.tsx
@@ -1,13 +1,17 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
+import { Dropdown } from "antd";
+import type { MenuProps } from "antd";
 import {
     ArrowLeftRight,
     BarChart3,
+    ChevronDown,
     LayoutDashboard,
     LogOut,
     Target,
     Tag,
+    UserRound,
     Wallet,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -52,7 +56,7 @@ const getInitials = (username?: string) => {
 
 const Logo = () => (
     <div className="inex-logo" aria-label="InEx">
-        <span className="inex-logo__mark" aria-hidden="true">I</span>
+        <img className="inex-logo__mark" src="/assets/mark.svg" alt="" aria-hidden="true" />
         <span className="inex-logo__wordmark">InEx</span>
     </div>
 );
@@ -72,6 +76,30 @@ const AppShell = ({ title, subtitle, extra, children }: AppShellProps) => {
 
     const handleLogout = async () => {
         await dispatch(logoutUser());
+    };
+
+    const profileMenuItems: MenuProps["items"] = [
+        {
+            key: "profile",
+            icon: <UserRound size={15} aria-hidden="true" />,
+            label: t("nav.profile"),
+        },
+        {
+            key: "logout",
+            icon: <LogOut size={15} aria-hidden="true" />,
+            label: t("nav.signOut"),
+        },
+    ];
+
+    const handleProfileMenuClick: MenuProps["onClick"] = async ({ key }) => {
+        if (key === "profile") {
+            handleNavigate("/profile");
+            return;
+        }
+
+        if (key === "logout") {
+            await handleLogout();
+        }
     };
 
     return (
@@ -102,25 +130,21 @@ const AppShell = ({ title, subtitle, extra, children }: AppShellProps) => {
                 </nav>
 
                 <div className="inex-topnav__actions r-topnav-actions">
-                    <button
-                        type="button"
-                        className="inex-user-pill r-user-pill"
-                        aria-label={t("nav.profile")}
-                        onClick={() => handleNavigate("/profile")}
+                    <Dropdown
+                        menu={{ items: profileMenuItems, onClick: handleProfileMenuClick }}
+                        placement="bottomRight"
+                        trigger={["click"]}
                     >
-                        <span className="inex-user-pill__avatar" aria-hidden="true">{initials}</span>
-                        {username && <span className="inex-user-pill__name r-user-pill-name">{username}</span>}
-                    </button>
-
-                    <button
-                        type="button"
-                        className="inex-shell-icon-button"
-                        aria-label={t("nav.signOut")}
-                        title={t("nav.signOut")}
-                        onClick={handleLogout}
-                    >
-                        <LogOut size={16} aria-hidden="true" />
-                    </button>
+                        <button
+                            type="button"
+                            className="inex-user-pill r-user-pill"
+                            aria-label={t("nav.profile")}
+                        >
+                            <span className="inex-user-pill__avatar" aria-hidden="true">{initials}</span>
+                            {username && <span className="inex-user-pill__name r-user-pill-name">{username}</span>}
+                            <ChevronDown className="inex-user-pill__chevron" size={14} strokeWidth={1.9} aria-hidden="true" />
+                        </button>
+                    </Dropdown>
                 </div>
             </header>
 


### PR DESCRIPTION
## Summary
- Use the approved multicolor InEx mark in the authenticated shell.
- Keep Dashboard in desktop and mobile navigation and preserve `/` redirect to Dashboard.
- Move sign out into the profile menu while keeping the profile pill.

Closes #191.

## Validation
- `npm run lint` passed.
- `npm run build` passed.
- `npm run test` passed: 24 files, 110 tests.

## Review
- BMad review layers completed locally: Blind Hunter, Edge Case Hunter, Acceptance Auditor.
- Findings: none.