### PR TITLE
Fix Transactions summary and toolbar alignment

### DIFF
--- a/inex/ClientApp/src/pages/Transactions.tsx
+++ b/inex/ClientApp/src/pages/Transactions.tsx
@@ -18,6 +18,7 @@ import {
     SegmentedControl,
     type MoneyKind,
 } from "../components/primitives";
+import type { Signage } from "../components/primitives";
 import TransactionCreate from "./Transactions/TransactionCreate";
 import TransactionFilterForm from "./Transactions/TransactionFilterForm";
 import TransactionList from "./Transactions/TransactionList";
@@ -183,20 +184,23 @@ const Transactions = () => {
     const kpiItems = [
         {
             label: t("transactions.kpi.income"),
-            value: ledgerMetrics.income,
+            value: Math.abs(ledgerMetrics.income),
             kind: "income" as MoneyKind,
+            signage: "color-only" as Signage,
             sub: t("transactions.kpi.visibleRows", { count: ledgerMetrics.visibleCount, period: periodLabel }),
         },
         {
             label: t("transactions.kpi.expenses"),
-            value: ledgerMetrics.expense,
+            value: Math.abs(ledgerMetrics.expense),
             kind: "expense" as MoneyKind,
+            signage: "color-only" as Signage,
             sub: t("transactions.kpi.visibleRows", { count: ledgerMetrics.visibleCount, period: periodLabel }),
         },
         {
             label: t("transactions.kpi.netFlow"),
             value: ledgerMetrics.net,
             kind: ledgerMetrics.net > 0 ? "income" as MoneyKind : ledgerMetrics.net < 0 ? "expense" as MoneyKind : "neutral" as MoneyKind,
+            signage: "signed" as Signage,
             sub: t("transactions.kpi.baseCurrencyContext", { currency: baseCurrency }),
         },
     ];
@@ -221,7 +225,7 @@ const Transactions = () => {
                                     {ledgerInitialLoading ? (
                                         <span className="transactions-kpi__skeleton" />
                                     ) : (
-                                        <Num currency={baseCurrency} currencySize="sm" kind={item.kind} signage="signed" size={30} value={item.value} />
+                                        <Num currency={baseCurrency} currencySize="sm" kind={item.kind} signage={item.signage} size={34} value={item.value} />
                                     )}
                                 </div>
                                 <div className="transactions-kpi__sub">{item.sub}</div>
@@ -276,6 +280,7 @@ const Transactions = () => {
                                 className="transactions-search"
                                 onChange={(event) => setLedgerFilter(prev => ({ ...prev, search: event.target.value }))}
                                 placeholder={t("transactions.searchPlaceholder")}
+                                style={{ flex: "0 1 280px", minWidth: 220 }}
                                 value={ledgerFilter.search}
                                 variant="search"
                             />

--- a/inex/ClientApp/src/pages/Transactions/transactions-ledger.css
+++ b/inex/ClientApp/src/pages/Transactions/transactions-ledger.css
@@ -23,7 +23,7 @@
     display: grid;
     gap: 8px;
     min-width: 0;
-    padding: 22px 24px;
+    padding: 24px 28px;
 }
 
 .transactions-kpi + .transactions-kpi {
@@ -128,11 +128,14 @@
 }
 
 .transactions-ledger-controls {
+    gap: 14px;
     justify-content: flex-start;
+    padding: 10px 20px;
 }
 
 .transactions-search {
     margin-left: auto;
+    min-width: 220px;
 }
 
 .transactions-filter-chips {


### PR DESCRIPTION
## Summary
- Normalize Transactions KPI values page-locally: income and expenses show unsigned magnitudes, net flow remains signed.
- Keep currency suffix treatment via `currencySize="sm"` without changing global `Num` behavior.
- Align the ledger header/control rows and search sizing to the design source.

Closes #192.
Closes #193.

## Validation
- `npm run lint` passed.
- `npm run build` passed.
- `npm run test` passed: 24 files, 110 tests.

## Review
- BMad review layers completed locally: Blind Hunter, Edge Case Hunter, Acceptance Auditor.
- Findings: none.