### PR TITLE
Fix transaction account currency in list responses

### DIFF
--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -247,7 +247,11 @@ public class TransactionService : InExService, ITransactionService
 
     internal IQueryable<Transaction> GetTransactions(int userId, ActivityMode mode, IDictionary<string, string> filters)
     {
-        IQueryable<Transaction> items = ApplyFilters(DbInEx.TransactionRepository.Get(true, null, i => i.Account, i => i.Category).Where(i => i.UserId == userId).OrderByDescending(i => i.Created).ThenByDescending(i => i.Id), filters);
+        IQueryable<Transaction> items = ApplyFilters(DbInEx.TransactionRepository
+            .GetWithIncludePaths(true, null, "Account.Currency", "Category")
+            .Where(i => i.UserId == userId)
+            .OrderByDescending(i => i.Created)
+            .ThenByDescending(i => i.Id), filters);
 
         return mode switch
         {
@@ -260,7 +264,11 @@ public class TransactionService : InExService, ITransactionService
 
     internal IQueryable<Transaction> GetTransactions(int userId, ActivityMode mode, TransactionFilterQuery filter)
     {
-        IQueryable<Transaction> items = ApplyFilters(DbInEx.TransactionRepository.Get(true, null, i => i.Account, i => i.Category).Where(i => i.UserId == userId).OrderByDescending(i => i.Created).ThenByDescending(i => i.Id), filter);
+        IQueryable<Transaction> items = ApplyFilters(DbInEx.TransactionRepository
+            .GetWithIncludePaths(true, null, "Account.Currency", "Category")
+            .Where(i => i.UserId == userId)
+            .OrderByDescending(i => i.Created)
+            .ThenByDescending(i => i.Id), filter);
 
         return mode switch
         {

--- a/inex.Tests/Transactions/TransactionsControllerTests.cs
+++ b/inex.Tests/Transactions/TransactionsControllerTests.cs
@@ -326,6 +326,20 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
     }
 
     [Fact]
+    public async Task List_IncludesAccountCurrency()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        var ids = await CreateTransactionFixtureAsync(client, "list-account-currency");
+
+        var response = await client.GetAsync("/api/transactions?pageSize=20&page=1");
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var transaction = Assert.Single(body.GetProperty("data").EnumerateArray(), item => item.GetProperty("id").GetInt32() == ids.TransactionId);
+        Assert.Equal("USD", transaction.GetProperty("accountCurrency").GetString());
+    }
+
+    [Fact]
     public async Task List_WithUrlEncodedTag_ReturnsMatchingTransactions()
     {
         var client = await CreateAuthenticatedClientAsync();

--- a/inex/ClientApp/src/pages/Categories/categories.components.test.tsx
+++ b/inex/ClientApp/src/pages/Categories/categories.components.test.tsx
@@ -93,4 +93,22 @@ describe("Category row", () => {
         expect(getByRole("button")).toHaveClass("category-row--leaf");
         expect(getByRole("button")).not.toHaveClass("category-row--parent");
     });
+
+    it("renders activity and spend values when stats are available", () => {
+        renderRow({
+            stats: {
+                categoryId: 1,
+                transactionCount: 3,
+                totalSpend: 42.5,
+                lastActiveDate: "2026-06-08T12:00:00Z",
+            },
+            statsAvailable: true,
+        });
+
+        const row = screen.getByRole("button");
+        expect(row).toHaveTextContent("3 categories.activity.txns");
+        expect(row).toHaveTextContent("42.50 USD");
+        expect(screen.queryByLabelText("categories.activity.unavailable")).not.toBeInTheDocument();
+        expect(screen.queryByLabelText("categories.activity.spendUnavailable")).not.toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
## Summary
- Load account currency when building transaction list responses so `accountCurrency` is populated.
- Add API regression coverage for `/api/transactions` list response account currency.
- Add Categories row coverage for rendering activity and spend values when stats are available.

Closes #215

## Verification
- `dotnet test inex.Tests\inex.Tests.csproj --filter FullyQualifiedName~TransactionsControllerTests --artifacts-path .artifacts\issue-215-tests`
- `dotnet test inex.sln --artifacts-path .artifacts\issue-215-solution-tests`
- `npm test -- Categories`
- `npm run build`
- `npm run lint`