### PR TITLE
Define Accounts visual QA baseline

### DIFF
--- a/docs/implementation/10-3g-frontend-ux-accounts-mockup-alignment-delta.md
+++ b/docs/implementation/10-3g-frontend-ux-accounts-mockup-alignment-delta.md
@@ -151,6 +151,7 @@ Conditional/shared files only if the orchestrator expands scope:
 - Do not revert or rewrite the 10.3d fixes for base equivalents, group sorting, first-use empty, filter-empty context, drawer focus, or zero-share handling.
 - Do not remove Dashboard, sign-out, or `/dashboard` redirect as a page-local "fix"; record those as shared decisions unless reassigned.
 - Do not fabricate March 2026 or April 2026 fixture values in live UI.
+- For #199 and follow-up PRs, use `docs/implementation/visual-qa/accounts-fixture-baseline.md` as the Accounts fixture-mode QA contract. Fixture mode is authoritative for mockup parity; live data is smoke/regression only.
 - Do not show dead controls for unsupported starting balance, update balance, bank connect, or view-transactions actions.
 - Do not weaken account API payloads or mutate backend contracts.
 - Do not add new dependencies.
@@ -206,6 +207,7 @@ Conditional/shared files only if the orchestrator expands scope:
 - `inex/ClientApp/src/pages/Accounts/accounts.css`
 - `inex/ClientApp/src/pages/Accounts/accounts-utils.ts`
 - `inex/ClientApp/src/store/accounts/accounts-api.ts`
+- `docs/implementation/visual-qa/accounts-fixture-baseline.md`
 - `inex/ClientApp/src/components/primitives/SegmentedControl.tsx`
 - `inex/ClientApp/src/layouts/AppShell.tsx`
 - `inex/ClientApp/src/App.tsx`

--- a/docs/implementation/10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist.md
+++ b/docs/implementation/10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist.md
@@ -74,6 +74,8 @@ This is the capstone story for Epic 10. **All of the following stories must reac
 
 **Data mode setup:** choose either fixed April 2026 mockup fixtures or live seeded user data before a QA pass starts. Use the same mode across Transactions, Accounts, Categories, and Budgets for a comparable pass, and record the mode in every checklist row. If fixture mode is used, route/query/period/currency values must match the mockup fixture. If live-seed mode is used, account balances, transaction amounts, category totals, budget usage, and currency values may differ from the mockup, but visual structure, labels, affordances, responsive behavior, and empty/filter/drawer states must still match the accepted design contract.
 
+**Accounts fixture baseline:** Accounts mockup parity uses fixture mode as the source of truth. Follow `docs/implementation/visual-qa/accounts-fixture-baseline.md` for the Accounts fixture values, default-expanded group rule, collapsed-group state, and live-smoke limitations. Do not accept or reject Accounts value parity from a developer's live account data.
+
 ## Epic Context
 
 Epic 10 rebuilds the production React app to implement the `docs/design` visual system. Story 10.6 is the final story and acts as the acceptance gate for the entire epic. The acceptance gate is defined in `docs/planning/design-update-plan.md` (Acceptance Gate For The Design Track section):

--- a/docs/implementation/visual-qa/accounts-fixture-baseline.md
+++ b/docs/implementation/visual-qa/accounts-fixture-baseline.md
@@ -1,0 +1,58 @@
+# Accounts Visual QA Fixture Baseline
+
+Status: active for Accounts mockup-alignment PRs.
+Source issue: #199.
+
+## Policy
+
+- Fixture mode is the source of truth for Accounts mockup parity.
+- Live account data is smoke/regression coverage only. Live values, account names, currencies, and user profile labels must not be used to accept or reject mockup value parity.
+- Fixture data must stay outside production Accounts data flow. Production continues to read `/accounts?mode=ALL`, `/accounts/details?...`, `/currencies`, profile currency, and exchange-rate state.
+- English is the parity locale. RU remains a responsive long-label stress pass.
+- Dashboard navigation, sign-out, protected routes, API contracts, and accessible row expansion remain accepted production behavior unless a shared shell story changes them.
+
+## Fixture Contract
+
+The executable fixture lives in `inex/ClientApp/src/test/fixtures/accountsVisualFixture.ts`.
+
+| Field | Value |
+| --- | --- |
+| `dataMode` | `fixture` |
+| Base currency | `USD` |
+| Net worth | `33,968.12 USD` |
+| Currencies | `UZS`, `USD`, `PLN`, `RUB`, `BYN`, `GEL` |
+| Comparison period label | `Mar 2026` |
+| Default collapsed currencies | none |
+| Collapsed-state coverage currency | `UZS` |
+
+Concrete period labels may be rendered only when sourced from fixture metadata or reliable app data. Live mode must not invent `Mar 2026` or any other period label.
+
+## Group Expansion Rule
+
+Production Accounts groups default expanded. The component initializes collapsed groups as an empty set and preserves the existing accessible expand/collapse button behavior.
+
+Visual QA must include both:
+
+- `expanded-groups`: initial fixture render, all currency groups expanded.
+- `collapsed-group`: fixture render after collapsing the `UZS` group; the group button must expose `aria-expanded="false"` and the group rows must be hidden.
+
+## Required Accounts State Matrix
+
+Every Accounts mockup-alignment PR must update or cite this matrix.
+
+| State | Viewports | Data mode | Notes |
+| --- | --- | --- | --- |
+| populated grouped | 1440, 390, 360 | fixture | Default groups expanded. |
+| populated flat | 1024 | fixture | Uses the same fixture, switched to flat view. |
+| filter-empty | 390 | fixture | Hero/distribution context remains visible. |
+| first-use empty | 390 | fixture | Empty account response; no unavailable hero chrome. |
+| drawer-open | 390, 360 | fixture | Drawer stays inside viewport and actions remain visible. |
+| expanded-row | 1440, 390 | fixture | Row expansion remains keyboard/screen-reader accessible. |
+| collapsed-group | 1440, 390 | fixture | Collapse one currency group; rows hide without changing distribution. |
+| live smoke | 1440, 390 | live-seed | Regression only; value parity is not asserted. |
+
+## Verification
+
+- `npm run test -- Accounts.empty-focus.test.tsx accounts-utils.test.ts` covers fixture value/order stability, default expanded groups, collapsed-state interaction, duplicate-description suppression, toolbar labels, headers, and active-scope count semantics.
+- `npm run build`, `npm run lint`, and the Accounts-focused tests remain required from `inex/ClientApp`.
+- Search touched TypeScript diffs for added `any`; none are allowed.

--- a/inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx
+++ b/inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx
@@ -8,6 +8,13 @@ import authSlice from "../store/auth/auth-slice";
 import ratesSlice from "../store/rates/rates-slice";
 import { accountsApi } from "../store/accounts/accounts-api";
 import Accounts from "./Accounts";
+import {
+    accountsVisualFixtureAccounts,
+    accountsVisualFixtureCurrencies,
+    accountsVisualFixtureMeta,
+    accountsVisualFixtureRates,
+    accountsVisualFixtureSummaries,
+} from "../test/fixtures/accountsVisualFixture";
 
 const apiClientMock = vi.hoisted(() => Object.assign(vi.fn(), { get: vi.fn() }));
 
@@ -50,7 +57,7 @@ vi.mock("./Accounts/AccountEditForm", () => ({
     default: () => <div>mock-account-edit</div>,
 }));
 
-const makeStore = () =>
+const makeStore = (rates = [] as typeof accountsVisualFixtureRates) =>
     configureStore({
         reducer: {
             auth: authSlice.reducer,
@@ -68,7 +75,7 @@ const makeStore = () =>
                 error: null,
             },
             rates: {
-                items: [],
+                items: rates,
                 error: null,
             },
         },
@@ -192,5 +199,39 @@ describe("Accounts empty-state create focus", () => {
         expect(screen.queryByText("2 / 3")).not.toBeInTheDocument();
         expect(screen.queryByText("cash WALLET")).not.toBeInTheDocument();
         expect(screen.getByText("Daily card")).toBeVisible();
+    });
+
+    it("renders fixture currency groups expanded by default and supports collapsed-state QA", async () => {
+        apiClientMock.mockImplementation(async ({ url }: { url: string }) => {
+            if (url === "/accounts?mode=ALL") {
+                return { data: { data: accountsVisualFixtureAccounts } };
+            }
+            if (url.startsWith("/accounts/details?mode=active")) {
+                return { data: { data: accountsVisualFixtureSummaries } };
+            }
+            return { data: null };
+        });
+        apiClientMock.get.mockResolvedValue({ data: accountsVisualFixtureCurrencies });
+        const store = makeStore(accountsVisualFixtureRates);
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <Accounts />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        expect(await screen.findByText("UZS main wallet")).toBeVisible();
+        const fixtureGroup = (await screen.findAllByRole("button", {
+            name: "accounts.group.collapse",
+        }))[0];
+        expect(fixtureGroup).toHaveAttribute("aria-expanded", "true");
+
+        await userEvent.setup().click(fixtureGroup);
+
+        expect(fixtureGroup).toHaveAttribute("aria-expanded", "false");
+        expect(screen.queryByText("UZS main wallet")).not.toBeInTheDocument();
+        expect(accountsVisualFixtureMeta.collapsedStateCurrency).toBe("UZS");
     });
 });

--- a/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
+++ b/inex/ClientApp/src/pages/Accounts/accounts-utils.test.ts
@@ -5,10 +5,18 @@ import {
   buildDisplayAccounts,
   getAccountDisplayDescription,
   getBaseCurrency,
+  getTotalBaseValue,
   makeCurrencyGroups,
   sortAccountsByBaseValue,
+  toFixedMoney,
   toBaseCurrencyAmount,
 } from "./accounts-utils";
+import {
+  accountsVisualFixtureAccounts,
+  accountsVisualFixtureMeta,
+  accountsVisualFixtureRates,
+  accountsVisualFixtureSummaries,
+} from "../../test/fixtures/accountsVisualFixture";
 
 const accounts: AccountResponse[] = [
   {
@@ -129,5 +137,22 @@ describe("accounts value helpers", () => {
     expect(getAccountDisplayDescription("Cash wallet", "   ")).toBeNull();
     expect(getAccountDisplayDescription("Cash wallet", " cash WALLET ")).toBeNull();
     expect(getAccountDisplayDescription("Cash wallet", "Daily spending")).toBe("Daily spending");
+  });
+
+  it("keeps the Accounts visual QA fixture stable without production data fallbacks", () => {
+    const activeFixtureAccounts = accountsVisualFixtureAccounts.filter((account) => account.isEnabled);
+    const activeFixtureSummaries = accountsVisualFixtureSummaries.filter((summary) => summary.isEnabled);
+    const displayAccounts = buildDisplayAccounts(
+      activeFixtureAccounts,
+      activeFixtureSummaries,
+      accountsVisualFixtureMeta.expectedBaseCurrency,
+      accountsVisualFixtureRates,
+    );
+    const groups = makeCurrencyGroups(displayAccounts, 33968.12);
+
+    expect(toFixedMoney(getTotalBaseValue(displayAccounts))).toBe(accountsVisualFixtureMeta.expectedNetWorth);
+    expect(groups.map((group) => group.currency)).toEqual(accountsVisualFixtureMeta.expectedDistributionOrder);
+    expect(accountsVisualFixtureMeta.defaultCollapsedCurrencies).toEqual([]);
+    expect(accountsVisualFixtureMeta.comparisonPeriodLabel).toBe("Mar 2026");
   });
 });

--- a/inex/ClientApp/src/test/fixtures/accountsVisualFixture.ts
+++ b/inex/ClientApp/src/test/fixtures/accountsVisualFixture.ts
@@ -1,0 +1,113 @@
+import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
+import type { ExchangeRateLike } from "../../pages/Accounts/accounts-utils";
+
+interface AccountsVisualFixtureRate extends ExchangeRateLike {
+  id: number;
+  date: string;
+  isTemporary: boolean;
+}
+
+export const accountsVisualFixtureMeta = {
+  dataMode: "fixture",
+  locale: "en",
+  baseline: "Accounts mockup parity",
+  comparisonPeriodLabel: "Mar 2026",
+  expectedBaseCurrency: "USD",
+  expectedNetWorth: 33968.12,
+  expectedDistributionOrder: ["UZS", "USD", "PLN", "RUB", "BYN", "GEL"],
+  defaultCollapsedCurrencies: [],
+  collapsedStateCurrency: "UZS",
+} as const;
+
+export const accountsVisualFixtureCurrencies = [
+  { id: 1, key: "USD" },
+  { id: 2, key: "UZS" },
+  { id: 3, key: "PLN" },
+  { id: 4, key: "BYN" },
+  { id: 5, key: "RUB" },
+  { id: 6, key: "GEL" },
+] as const;
+
+export const accountsVisualFixtureRates: AccountsVisualFixtureRate[] = [
+  { id: 1, currencyFrom: "USD", currencyTo: "UZS", date: "2026-04-30", rate: 12000, isTemporary: false },
+  { id: 2, currencyFrom: "USD", currencyTo: "PLN", date: "2026-04-30", rate: 4, isTemporary: false },
+  { id: 3, currencyFrom: "USD", currencyTo: "BYN", date: "2026-04-30", rate: 3.1, isTemporary: false },
+  { id: 4, currencyFrom: "USD", currencyTo: "RUB", date: "2026-04-30", rate: 92, isTemporary: false },
+  { id: 5, currencyFrom: "USD", currencyTo: "GEL", date: "2026-04-30", rate: 2.95, isTemporary: false },
+];
+
+export const accountsVisualFixtureAccounts: AccountResponse[] = [
+  {
+    id: 201,
+    key: "uzs-main",
+    name: "UZS main wallet",
+    description: "Cash reserves",
+    isEnabled: true,
+    currencyId: 2,
+    currency: "UZS",
+  },
+  {
+    id: 202,
+    key: "usd-operating",
+    name: "USD operating",
+    description: "Payroll and vendors",
+    isEnabled: true,
+    currencyId: 1,
+    currency: "USD",
+  },
+  {
+    id: 203,
+    key: "pln-card",
+    name: "PLN card",
+    description: "Poland expenses",
+    isEnabled: true,
+    currencyId: 3,
+    currency: "PLN",
+  },
+  {
+    id: 204,
+    key: "byn-reserve",
+    name: "BYN reserve",
+    description: "Belarus reserve",
+    isEnabled: true,
+    currencyId: 4,
+    currency: "BYN",
+  },
+  {
+    id: 205,
+    key: "rub-savings",
+    name: "RUB savings",
+    description: "RUB savings",
+    isEnabled: true,
+    currencyId: 5,
+    currency: "RUB",
+  },
+  {
+    id: 206,
+    key: "gel-travel",
+    name: "GEL travel",
+    description: "Travel buffer",
+    isEnabled: true,
+    currencyId: 6,
+    currency: "GEL",
+  },
+  {
+    id: 207,
+    key: "usd-closed",
+    name: "USD closed card",
+    description: "Disabled card",
+    isEnabled: false,
+    currencyId: 1,
+    currency: "USD",
+  },
+];
+
+export const accountsVisualFixtureSummaries: AccountSummary[] = [
+  { ...accountsVisualFixtureAccounts[0], value: 199093440, thisMonthNet: 1200000 },
+  { ...accountsVisualFixtureAccounts[1], value: 9200, thisMonthNet: 140 },
+  { ...accountsVisualFixtureAccounts[2], value: 14500, thisMonthNet: -180 },
+  { ...accountsVisualFixtureAccounts[3], value: 4200, thisMonthNet: 0 },
+  { ...accountsVisualFixtureAccounts[4], value: 240000, thisMonthNet: 9200 },
+  { ...accountsVisualFixtureAccounts[5], value: 1735.96, thisMonthNet: 260 },
+  { ...accountsVisualFixtureAccounts[6], value: 0, thisMonthNet: 0 },
+];


### PR DESCRIPTION
## Summary
- define the Accounts visual QA fixture baseline and fixture/live-data policy
- add fixture data under test-only paths and focused Accounts coverage for default-expanded groups and collapsed-group QA
- document fixture mode as the source of truth for mockup parity while keeping live data as smoke/regression only

Closes #199.

## Validation
- npm run test -- Accounts.empty-focus.test.tsx accounts-utils.test.ts
- npm run lint
- npm run build
- no added `any` scan
- git diff --check (line-ending warnings only)

## Notes
- Draft until CI completes and this branch is merged first in the Accounts delivery chain.
