### PR TITLE
Align Accounts row density

### DIFF
--- a/inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx
+++ b/inex/ClientApp/src/pages/Accounts.empty-focus.test.tsx
@@ -208,6 +208,7 @@ describe("Accounts empty-state create focus", () => {
         expect(screen.queryByText("2 / 3")).not.toBeInTheDocument();
         expect(screen.queryByText("cash WALLET")).not.toBeInTheDocument();
         expect(screen.getByText("Daily card")).toBeVisible();
+        expect(document.querySelector(".accounts-share-bar")).not.toBeInTheDocument();
     });
 
     it("renders fixture currency groups expanded by default and supports collapsed-state QA", async () => {

--- a/inex/ClientApp/src/pages/Accounts.tsx
+++ b/inex/ClientApp/src/pages/Accounts.tsx
@@ -424,9 +424,6 @@ const Accounts = () => {
                         {account.currency}
                     </span>
                     <span className="accounts-row__share">
-                        <span className="accounts-share-bar" aria-hidden="true">
-                            <span style={{ width: `${Math.min(100, Math.max(0, share ?? 0))}%` }} />
-                        </span>
                         <span>
                             {share === null
                                 ? t("accounts.equivalent.unavailable")

--- a/inex/ClientApp/src/pages/Accounts/accounts.css
+++ b/inex/ClientApp/src/pages/Accounts/accounts.css
@@ -218,9 +218,7 @@
     width: 9px;
 }
 
-.accounts-distribution__bar,
-.accounts-group__bar,
-.accounts-share-bar {
+.accounts-group__bar {
     background: var(--bg-muted);
     border-radius: var(--radius-pill);
     overflow: hidden;
@@ -230,8 +228,7 @@
     height: 8px;
 }
 
-.accounts-group__bar span,
-.accounts-share-bar span {
+.accounts-group__bar span {
     background: var(--income-500);
     border-radius: inherit;
     display: block;
@@ -447,10 +444,10 @@
     display: grid;
     font-size: 10px;
     font-weight: 800;
-    gap: 14px;
+    gap: 10px;
     grid-template-columns: minmax(220px, 1.8fr) 100px minmax(120px, 130px) minmax(120px, 130px) 24px;
     letter-spacing: 0;
-    padding: 11px 36px 8px;
+    padding: 9px 34px 7px;
 }
 
 .accounts-list-header span:nth-child(3),
@@ -480,9 +477,9 @@
     cursor: pointer;
     display: grid;
     font-family: var(--font-sans);
-    gap: 12px;
+    gap: 10px;
     grid-template-columns: minmax(220px, 1.8fr) 100px minmax(120px, 130px) minmax(120px, 130px) 24px;
-    padding: 11px 14px;
+    padding: 9px 14px;
     text-align: left;
     transition: background var(--dur-1) var(--ease-standard);
     width: 100%;
@@ -519,7 +516,7 @@
     flex-wrap: wrap;
     font-size: 12px;
     gap: 6px;
-    margin-top: 3px;
+    margin-top: 2px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -533,17 +530,14 @@
     color: var(--fg-3);
     display: grid;
     font-size: 11px;
-    gap: 5px;
+    gap: 2px;
+    line-height: 1.25;
     text-align: right;
-}
-
-.accounts-share-bar {
-    height: 5px;
 }
 
 .accounts-row__balance {
     display: grid;
-    gap: 4px;
+    gap: 2px;
     justify-items: end;
     font-weight: 700;
     text-align: right;
@@ -763,9 +757,9 @@
     }
 
     .accounts-row {
-        gap: 8px;
+        gap: 6px;
         grid-template-columns: minmax(0, 1fr) auto;
-        padding: 12px;
+        padding: 10px 12px;
     }
 
     .accounts-list-header {
@@ -793,6 +787,7 @@
     .accounts-row__share {
         grid-column: 1 / 3;
         grid-row: 4;
+        gap: 2px;
         text-align: left;
     }
 


### PR DESCRIPTION
## Summary
- remove row-level share bars from Accounts rows while preserving share text and base equivalents
- tighten desktop and mobile Accounts row spacing
- add regression coverage that row-level share bars are not rendered

Closes #198.

## Validation
- npm run test -- Accounts.empty-focus.test.tsx accounts-utils.test.ts
- npm run lint
- npm run build
- no added `any` scan
- git diff --check (line-ending warnings only)

## Visual QA
- Existing fixture evidence remains under `docs/implementation/visual-qa/10-3g/`.
- This environment could not refresh fixture screenshots because the in-app browser lacks request interception, port 5000 is occupied by the live backend, and bundled Playwright is incomplete. Row-bar removal is covered by focused RTL assertions.

## Notes
- Base branch: `feature/accounts-toolbar-controls-alignment`.
- Draft until #219 is merged and CI passes.
