### PR TITLE
fix(exchange-rates): repair cache misses and quota fallback

### DIFF
--- a/docs/operations/exchange-rate-cache-repair.md
+++ b/docs/operations/exchange-rate-cache-repair.md
@@ -1,0 +1,63 @@
+# Exchange-rate cache repair
+
+## Scope
+
+The exchange-rate cache fix promotes past temporary rows during normal rate synchronization when a prior non-temporary rate exists for the same base and target currency. That means most existing rows should self-heal the next time the affected date and target currency are requested.
+
+Manual repair is only needed when operations wants to repair existing past temporary rows before user traffic touches them.
+
+## Verification query
+
+Use a read-only query first and review the result set before any write. Replace `CURRENT_DATE()` with the deployment date if the database session timezone is not UTC.
+
+```sql
+SELECT
+  created,
+  from_code,
+  to_code,
+  rate,
+  is_temporary
+FROM exchange_rate
+WHERE is_temporary = 1
+  AND created < CURRENT_DATE()
+ORDER BY created, from_code, to_code;
+```
+
+## Safe repair option
+
+For each past temporary row, promote only when a prior non-temporary rate exists for the same `from_code` and `to_code`. This matches the application carry-forward behavior and preserves today's temporary placeholders.
+
+```sql
+UPDATE exchange_rate stale
+JOIN (
+  SELECT
+    candidate.exchange_rate_pk,
+    prior.rate
+  FROM exchange_rate candidate
+  JOIN exchange_rate prior
+    ON prior.from_code = candidate.from_code
+   AND prior.to_code = candidate.to_code
+   AND prior.is_temporary = 0
+   AND prior.created = (
+      SELECT MAX(prior_match.created)
+      FROM exchange_rate prior_match
+      WHERE prior_match.from_code = candidate.from_code
+        AND prior_match.to_code = candidate.to_code
+        AND prior_match.is_temporary = 0
+        AND prior_match.created < candidate.created
+   )
+  WHERE candidate.is_temporary = 1
+    AND candidate.created < CURRENT_DATE()
+) repair
+  ON repair.exchange_rate_pk = stale.exchange_rate_pk
+SET stale.rate = repair.rate,
+    stale.is_temporary = 0
+WHERE stale.is_temporary = 1
+  AND stale.created < CURRENT_DATE();
+```
+
+## Post-repair validation
+
+Run the verification query again. Remaining rows mean there is no prior actual rate to carry forward for that `(created, from_code, to_code)` pair, so the application should resolve them through provider data or leave them unresolved if providers do not cover them.
+
+Do not update rows where `created = CURRENT_DATE()`. Same-day rows are intentionally temporary until historical rates are available.

--- a/inex.Services.Tests/Services/ExchangeRateServiceTests.cs
+++ b/inex.Services.Tests/Services/ExchangeRateServiceTests.cs
@@ -4,6 +4,9 @@ using inex.Services.Exceptions;
 using inex.Services.Infrastructure.ExternalClients.ExchangeRate;
 using inex.Services.Services;
 using inex.Services.Tests.Helpers;
+using inex.Data;
+using inex.Data.Repositories;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System.Linq.Expressions;
@@ -32,6 +35,7 @@ public class ExchangeRateServiceTests
         _uowMock.Setup(u => u.ExchangeRateRepository).Returns(_exchangeRateRepoMock.Object);
         _uowMock.Setup(u => u.AccountRepository).Returns(_accountRepoMock.Object);
         _uowMock.Setup(u => u.UserRepository).Returns(_userRepoMock.Object);
+        _uowMock.Setup(u => u.SaveAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
     }
 
     // --- Helpers ---
@@ -53,6 +57,10 @@ public class ExchangeRateServiceTests
     private static IQueryable<Account> AccountsFor(int userId, params string[] currencyCodes) =>
         currencyCodes.Select(c => new Account { UserId = userId, IsEnabled = true, Currency = new Currency { Key = c } })
                      .AsAsyncQueryable();
+
+    private static IQueryable<Account> AccountsFor(int userId, params (string CurrencyCode, bool IsEnabled)[] accounts) =>
+        accounts.Select(account => new Account { UserId = userId, IsEnabled = account.IsEnabled, Currency = new Currency { Key = account.CurrencyCode } })
+                .AsAsyncQueryable();
 
     private static IQueryable<Account> EmptyAccounts() =>
         Enumerable.Empty<Account>().AsAsyncQueryable();
@@ -591,17 +599,14 @@ public class ExchangeRateServiceTests
         _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>())) 
             .Returns(AccountsFor(1, accountCurrency));
 
-        // First call: no rates cached yet — provider will be called.
-        // Second call: rates exist — provider must NOT be called.
-        var usdRate = new ExchangeRate { FromCode = baseCurrency, ToCode = accountCurrency, Rate = 1.1m, Created = pastDate.Date, IsTemporary = false };
-        var callCount = 0;
+        // First call: no rates cached yet, so the provider will be called.
+        // CreateAsync mutates the in-memory list so the second call observes the cached row.
+        var rates = new List<ExchangeRate>();
         _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
-            .Returns(() =>
-            {
-                // On the first invocation the cache is empty; after saving we expose the persisted rate.
-                callCount++;
-                return callCount == 1 ? EmptyRates() : new[] { usdRate }.AsAsyncQueryable();
-            });
+            .Returns(() => rates.AsAsyncQueryable());
+        _exchangeRateRepoMock.Setup(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()))
+            .Callback<ExchangeRate, CancellationToken>((rate, _) => rates.Add(rate))
+            .ReturnsAsync((Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ExchangeRate>)null!);
 
         _fallbackClientMock
             .Setup(c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
@@ -629,5 +634,455 @@ public class ExchangeRateServiceTests
         _fallbackClientMock.Verify(
             c => c.GetRatesForRangeAsync(pastDate, pastDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()),
             Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Single(rates);
+        Assert.Equal(accountCurrency, rates.Single().ToCode);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenPastTemporaryRowsExistAndProviderOmitsDate_PromotesCarryForwardRates()
+    {
+        var priorDate = new DateTime(2026, 5, 1);
+        var requestedDate = new DateTime(2026, 5, 3);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>
+        {
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = priorDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "BYN", Rate = 3.1m, Created = priorDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.8m, Created = requestedDate, IsTemporary = true },
+            new() { FromCode = baseCurrency, ToCode = "BYN", Rate = 3.0m, Created = requestedDate, IsTemporary = true }
+        };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>());
+        _clientMock.Setup(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ExchangeRateResponse?)null);
+
+        var sut = CreateSut();
+
+        await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+
+        _exchangeRateRepoMock.Verify(r => r.Update(It.Is<ExchangeRate>(e => e.Created == requestedDate && e.ToCode == "EUR" && e.Rate == 0.9m && !e.IsTemporary)), Times.Once);
+        _exchangeRateRepoMock.Verify(r => r.Update(It.Is<ExchangeRate>(e => e.Created == requestedDate && e.ToCode == "BYN" && e.Rate == 3.1m && !e.IsTemporary)), Times.Once);
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == requestedDate), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(u => u.SaveAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_SecondCall_WhenPastTemporaryRowsWereCarriedForward_DoesNotRetryProvider()
+    {
+        var priorDate = new DateTime(2026, 5, 1);
+        var requestedDate = new DateTime(2026, 5, 3);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>
+        {
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = priorDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.8m, Created = requestedDate, IsTemporary = true }
+        };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>());
+        _clientMock.Setup(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ExchangeRateResponse?)null);
+
+        var sut = CreateSut();
+
+        await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+        await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.False(rates.Single(r => r.Created == requestedDate && r.ToCode == "EUR").IsTemporary);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenRowCountMatchesButTargetMissing_FetchesMissingTarget()
+    {
+        var priorDate = new DateTime(2026, 5, 1);
+        var requestedDate = new DateTime(2026, 5, 2);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>
+        {
+            new() { FromCode = baseCurrency, ToCode = "BYN", Rate = 3.1m, Created = priorDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = requestedDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "PLN", Rate = 4.0m, Created = requestedDate, IsTemporary = false }
+        };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>());
+        _clientMock.Setup(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ExchangeRateResponse?)null);
+        _exchangeRateRepoMock.Setup(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()))
+            .Callback<ExchangeRate, CancellationToken>((rate, _) => rates.Add(rate))
+            .ReturnsAsync((Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ExchangeRate>)null!);
+
+        var sut = CreateSut();
+
+        await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+        await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == requestedDate && e.ToCode == "BYN" && e.Rate == 3.1m && !e.IsTemporary), It.IsAny<CancellationToken>()), Times.Once);
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.Is<string[]>(targets => targets.SequenceEqual(new[] { "BYN" })), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenByrAccountDisabled_DoesNotRequireByrCoverage()
+    {
+        var requestedDate = new DateTime(2026, 5, 2);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>
+        {
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = requestedDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "BYR", Rate = 2.9m, Created = requestedDate, IsTemporary = true }
+        };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, ("EUR", true), ("BYR", false)));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+
+        var sut = CreateSut();
+
+        await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _clientMock.Verify(c => c.GetRatesAsync(It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenMissingDatesAreSparse_DoesNotCallCurrencyApiForCompleteInteriorDates()
+    {
+        var start = new DateTime(2026, 5, 1);
+        var end = new DateTime(2026, 5, 10);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>();
+
+        foreach (var date in Enumerable.Range(0, 10).Select(offset => start.AddDays(offset)))
+        {
+            rates.Add(new ExchangeRate { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = date, IsTemporary = false });
+            if (date != start && date != end)
+            {
+                rates.Add(new ExchangeRate { FromCode = baseCurrency, ToCode = "BYN", Rate = 3.1m, Created = date, IsTemporary = false });
+            }
+        }
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime requestedStart, DateTime requestedEnd, string _, string[] _, CancellationToken _) =>
+                EnumerateDatesForTest(requestedStart, requestedEnd).ToDictionary(
+                    date => date,
+                    date => new ExchangeRateResponse
+                    {
+                        Data = new Dictionary<string, ExchangeDateData>
+                        {
+                            ["EUR"] = new() { Code = "EUR", Value = 0.9m }
+                        }
+                    }));
+        _clientMock.Setup(c => c.GetRatesAsync(It.IsAny<DateTime>(), baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime date, string _, string[] targets, CancellationToken _) => new ExchangeRateResponse
+            {
+                Data = targets.ToDictionary(target => target, target => new ExchangeDateData { Code = target, Value = 3.1m })
+            });
+
+        var sut = CreateSut();
+
+        await sut.Get(1, start, end, baseCurrency);
+
+        _clientMock.Verify(c => c.GetRatesAsync(start, baseCurrency, It.Is<string[]>(targets => targets.SequenceEqual(new[] { "BYN" })), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(end, baseCurrency, It.Is<string[]>(targets => targets.SequenceEqual(new[] { "BYN" })), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(It.Is<DateTime>(date => date > start && date < end), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenFrankfurterOmitsMissingHoliday_DoesNotCallCurrencyApiForOmittedDate()
+    {
+        var tradingDate = new DateTime(2026, 5, 1);
+        var omittedDate = new DateTime(2026, 5, 2);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>();
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _exchangeRateRepoMock.Setup(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()))
+            .Callback<ExchangeRate, CancellationToken>((rate, _) => rates.Add(rate))
+            .ReturnsAsync((Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ExchangeRate>)null!);
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(tradingDate, omittedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>
+            {
+                [tradingDate] = new()
+                {
+                    Data = new Dictionary<string, ExchangeDateData>
+                    {
+                        ["EUR"] = new() { Code = "EUR", Value = 0.9m }
+                    }
+                }
+            });
+        _clientMock.Setup(c => c.GetRatesAsync(tradingDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExchangeRateResponse
+            {
+                Data = new Dictionary<string, ExchangeDateData>
+                {
+                    ["BYN"] = new() { Code = "BYN", Value = 3.1m }
+                }
+            });
+
+        var sut = CreateSut();
+
+        await sut.Get(1, tradingDate, omittedDate, baseCurrency);
+
+        _clientMock.Verify(c => c.GetRatesAsync(tradingDate, baseCurrency, It.Is<string[]>(targets => targets.SequenceEqual(new[] { "BYN" })), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(omittedDate, It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenTodayHasPartialTemporaryCoverage_FillsMissingTargetFromLatestActual()
+    {
+        var today = _clock.UtcNow.Date;
+        var priorDate = today.AddDays(-1);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>
+        {
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = priorDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "BYN", Rate = 3.1m, Created = priorDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = today, IsTemporary = true }
+        };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _exchangeRateRepoMock.Setup(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()))
+            .Callback<ExchangeRate, CancellationToken>((rate, _) => rates.Add(rate))
+            .ReturnsAsync((Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ExchangeRate>)null!);
+
+        var sut = CreateSut();
+
+        await sut.Get(1, today, today, baseCurrency);
+
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == today && e.ToCode == "BYN" && e.Rate == 3.1m && e.IsTemporary), It.IsAny<CancellationToken>()), Times.Once);
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _clientMock.Verify(c => c.GetRatesAsync(It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_Range_WhenTodayMissingTargetHasOlderPriorRate_FillsFromLatestPriorRatePerTarget()
+    {
+        var today = _clock.UtcNow.Date;
+        var yesterday = today.AddDays(-1);
+        var olderDate = today.AddDays(-3);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>
+        {
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = yesterday, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "BYN", Rate = 3.1m, Created = olderDate, IsTemporary = false },
+            new() { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = today, IsTemporary = true }
+        };
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() => rates.AsAsyncQueryable());
+        _exchangeRateRepoMock.Setup(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()))
+            .Callback<ExchangeRate, CancellationToken>((rate, _) => rates.Add(rate))
+            .ReturnsAsync((Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ExchangeRate>)null!);
+
+        var sut = CreateSut();
+
+        await sut.Get(1, today, today, baseCurrency);
+
+        _exchangeRateRepoMock.Verify(r => r.CreateAsync(It.Is<ExchangeRate>(e => e.Created == today && e.ToCode == "BYN" && e.Rate == 3.1m && e.IsTemporary), It.IsAny<CancellationToken>()), Times.Once);
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _clientMock.Verify(c => c.GetRatesAsync(It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_ConcurrentCalls_ForSameMissingRange_RechecksCacheBeforeProviderCalls()
+    {
+        var requestedDate = new DateTime(2026, 5, 2);
+        var baseCurrency = "USD";
+        var rates = new List<ExchangeRate>();
+        var ratesGate = new object();
+
+        _userRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<AppUser, object>>>()))
+            .Returns(AppUsersFor(1, baseCurrency));
+        _accountRepoMock.Setup(r => r.Get(true, null, It.IsAny<Expression<Func<Account, object>>>()))
+            .Returns(AccountsFor(1, "EUR", "BYN"));
+        _exchangeRateRepoMock.Setup(r => r.Get(It.IsAny<bool>(), null))
+            .Returns(() =>
+            {
+                lock (ratesGate)
+                {
+                    return rates.ToList().AsAsyncQueryable();
+                }
+            });
+        _exchangeRateRepoMock.Setup(r => r.CreateAsync(It.IsAny<ExchangeRate>(), It.IsAny<CancellationToken>()))
+            .Callback<ExchangeRate, CancellationToken>((rate, _) =>
+            {
+                lock (ratesGate)
+                {
+                    rates.Add(rate);
+                }
+            })
+            .ReturnsAsync((Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ExchangeRate>)null!);
+        _fallbackClientMock.Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                await Task.Delay(50);
+                return new Dictionary<DateTime, ExchangeRateResponse>
+                {
+                    [requestedDate] = new()
+                    {
+                        Data = new Dictionary<string, ExchangeDateData>
+                        {
+                            ["EUR"] = new() { Code = "EUR", Value = 0.9m }
+                        }
+                    }
+                };
+            });
+        _clientMock.Setup(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExchangeRateResponse
+            {
+                Data = new Dictionary<string, ExchangeDateData>
+                {
+                    ["BYN"] = new() { Code = "BYN", Value = 3.1m }
+                }
+            });
+
+        var sut = CreateSut();
+
+        await Task.WhenAll(
+            sut.Get(1, requestedDate, requestedDate, baseCurrency),
+            sut.Get(1, requestedDate, requestedDate, baseCurrency),
+            sut.Get(1, requestedDate, requestedDate, baseCurrency));
+
+        _fallbackClientMock.Verify(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _clientMock.Verify(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        var requestedDateRates = rates
+            .Where(rate => rate.Created == requestedDate && rate.FromCode == baseCurrency)
+            .ToList();
+        Assert.Equal(new[] { "BYN", "EUR" }, requestedDateRates.Select(rate => rate.ToCode).OrderBy(code => code));
+        Assert.All(requestedDateRates, rate => Assert.False(rate.IsTemporary));
+        Assert.Equal(requestedDateRates.Count, requestedDateRates.Select(rate => rate.ToCode).Distinct().Count());
+    }
+
+    [Fact]
+    public async Task Get_WithRealUnitOfWork_WhenPastTemporaryRowsArePromoted_SecondCallDoesNotRetryProvider()
+    {
+        var priorDate = new DateTime(2026, 5, 1);
+        var requestedDate = new DateTime(2026, 5, 3);
+        var baseCurrency = "USD";
+        var databaseName = Guid.NewGuid().ToString();
+        await using (var seedDb = CreateContext(databaseName))
+        {
+            await SeedExchangeRateContext(seedDb, baseCurrency, priorDate, requestedDate);
+        }
+
+        var fallbackClient = new Mock<IExchangeRateClient>();
+        var currencyApiClient = new Mock<IExchangeRateClient>();
+        var nbrbClient = new Mock<INbrbApiClient>();
+
+        fallbackClient
+            .Setup(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, ExchangeRateResponse>());
+        currencyApiClient
+            .Setup(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ExchangeRateResponse?)null);
+
+        await using (var firstCallDb = CreateContext(databaseName))
+        {
+            var sut = new ExchangeRateService(
+                new InExUnitOfWork(firstCallDb),
+                currencyApiClient.Object,
+                fallbackClient.Object,
+                nbrbClient.Object,
+                NullLogger<ExchangeRateService>.Instance,
+                _clock);
+            await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+        }
+
+        await using (var secondCallDb = CreateContext(databaseName))
+        {
+            var sut = new ExchangeRateService(
+                new InExUnitOfWork(secondCallDb),
+                currencyApiClient.Object,
+                fallbackClient.Object,
+                nbrbClient.Object,
+                NullLogger<ExchangeRateService>.Instance,
+                _clock);
+            await sut.Get(1, requestedDate, requestedDate, baseCurrency);
+        }
+
+        await using var assertionDb = CreateContext(databaseName);
+        var promotedRate = await assertionDb.ExchangeRates.AsNoTracking().SingleAsync(rate => rate.Created == requestedDate && rate.FromCode == baseCurrency && rate.ToCode == "EUR");
+        Assert.Equal(0.9m, promotedRate.Rate);
+        Assert.False(promotedRate.IsTemporary);
+        fallbackClient.Verify(c => c.GetRatesForRangeAsync(requestedDate, requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        currencyApiClient.Verify(c => c.GetRatesAsync(requestedDate, baseCurrency, It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static IEnumerable<DateTime> EnumerateDatesForTest(DateTime start, DateTime end)
+    {
+        for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
+        {
+            yield return date;
+        }
+    }
+
+    private static InExDbContext CreateContext() =>
+        CreateContext(Guid.NewGuid().ToString());
+
+    private static InExDbContext CreateContext(string databaseName) =>
+        new(new DbContextOptionsBuilder<InExDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options);
+
+    private static async Task SeedExchangeRateContext(InExDbContext db, string baseCurrency, DateTime priorDate, DateTime requestedDate)
+    {
+        var usd = new Currency { Id = 1, Key = baseCurrency, Name = baseCurrency, Created = DateTime.UtcNow, Updated = DateTime.UtcNow };
+        var eur = new Currency { Id = 2, Key = "EUR", Name = "EUR", Created = DateTime.UtcNow, Updated = DateTime.UtcNow };
+        var user = new AppUser { Id = 1, UserName = "exchange-test", CurrencyId = usd.Id, Currency = usd };
+        var account = new Account { Id = 1, UserId = user.Id, User = user, CurrencyId = eur.Id, Currency = eur, IsEnabled = true, Key = "eur", Name = "EUR" };
+
+        db.Currencies.AddRange(usd, eur);
+        db.Users.Add(user);
+        db.Accounts.Add(account);
+        db.ExchangeRates.AddRange(
+            new ExchangeRate { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.9m, Created = priorDate, IsTemporary = false, CreatedBy = user.Id },
+            new ExchangeRate { FromCode = baseCurrency, ToCode = "EUR", Rate = 0.8m, Created = requestedDate, IsTemporary = true, CreatedBy = user.Id });
+        await db.SaveChangesAsync();
     }
 }

--- a/inex.Services/Services/ExchangeRateService.cs
+++ b/inex.Services/Services/ExchangeRateService.cs
@@ -10,6 +10,7 @@ using inex.Services.Services.Base;
 using inex.Services.Infrastructure.Time;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 
 namespace inex.Services.Services;
 
@@ -59,59 +60,25 @@ public class ExchangeRateService : Service, IExchangeRateService
 
         baseCurrency = ResolveBaseCurrency(userId, baseCurrency);
         IList<string> targetCurrencyCodes = await ResolveTargetCurrencyCodes(userId, baseCurrency, ct);
+        targetCurrencyCodes = targetCurrencyCodes
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(currencyCode => currencyCode, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
         DateTime startDate = start.Date;
         DateTime endDate = end.Date;
         DateTime today = _clock.UtcNow.Date;
         endDate = endDate <= today ? endDate : today;
 
-        // One query to find which dates already have a full set of actual rates cached.
-        var cachedDates = (await DbInEx.ExchangeRateRepository.Get(true)
-            .Where(r => r.Created >= startDate && r.Created < today
-                     && r.FromCode == baseCurrency && !r.IsTemporary)
-            .GroupBy(r => r.Created)
-            .Select(g => new { Date = g.Key, Count = g.Count() })
-            .ToListAsync(ct))
-            .Where(x => x.Count >= targetCurrencyCodes.Count)
-            .Select(x => x.Date)
-            .ToHashSet();
-
-        var missingDates = Enumerable
-            .Range(0, (endDate - startDate).Days + 1)
-            .Select(i => startDate.AddDays(i))
-            .Where(d => d < today && !cachedDates.Contains(d))
+        var pastDates = EnumerateDates(startDate, endDate)
+            .Where(d => d < today)
             .ToList();
 
-        if (missingDates.Count > 0)
-        {
-            var rangeStart = missingDates.Min();
-            var rangeEnd   = missingDates.Max();
-            var rangeRates = await FetchRatesForRange(rangeStart, rangeEnd, baseCurrency, targetCurrencyCodes.ToArray(), ct);
-
-            bool hasChanges = false;
-            var missingDatesSet = missingDates.ToHashSet();
-            foreach (var (date, response) in rangeRates)
-            {
-                if (!missingDatesSet.Contains(date)) continue;
-                hasChanges |= await UpsertRatesForDate(userId, date, baseCurrency, response, ct);
-            }
-
-            if (hasChanges)
-                await DbInEx.SaveAsync(ct);
-
-            // Carry forward missing currencies for non-trading days or partial provider data.
-            bool hasCarryForwardChanges = false;
-            foreach (var date in missingDates.OrderBy(d => d))
-            {
-                hasCarryForwardChanges |= await CarryForwardMissingRatesFromPriorDay(userId, date, baseCurrency, targetCurrencyCodes, ct);
-            }
-
-            if (hasCarryForwardChanges)
-                await DbInEx.SaveAsync(ct);
-        }
+        if (pastDates.Count > 0 && targetCurrencyCodes.Count > 0)
+            await SynchronizeMissingRates(userId, pastDates, baseCurrency, targetCurrencyCodes, ct);
 
         if (endDate >= today)
-            await CreateTemporaryRatesForTodayIfNeeded(userId, today, baseCurrency, ct);
+            await CreateTemporaryRatesForTodayIfNeeded(userId, today, baseCurrency, targetCurrencyCodes, ct);
 
         IQueryable<ExchangeRate> rates = DbInEx.ExchangeRateRepository.Get(true).Where(i => i.Created >= startDate && i.Created <= endDate && i.FromCode == baseCurrency);
         return BuildDataResponse<ExchangeRate, ExchangeRateResponse>(rates, ExchangeRateMapper.ToResponse);
@@ -156,6 +123,124 @@ public class ExchangeRateService : Service, IExchangeRateService
             .ToListAsync(ct);
     }
 
+    private async Task SynchronizeMissingRates(
+        int userId,
+        IReadOnlyCollection<DateTime> candidateDates,
+        string baseCurrency,
+        IList<string> targetCurrencyCodes,
+        CancellationToken ct = default)
+    {
+        var initialMissingTargetsByDate = await GetMissingTargetsByDate(candidateDates, baseCurrency, targetCurrencyCodes, ct);
+        if (initialMissingTargetsByDate.Count == 0)
+        {
+            return;
+        }
+
+        var acquiredLocks = await AcquireSyncLocks(baseCurrency, initialMissingTargetsByDate.Keys, ct);
+        try
+        {
+            // Another request may have populated the cache while this request was waiting.
+            var missingTargetsByDate = await GetMissingTargetsByDate(candidateDates, baseCurrency, targetCurrencyCodes, ct);
+            if (missingTargetsByDate.Count == 0)
+            {
+                return;
+            }
+
+            bool hasProviderChanges = false;
+            foreach (var range in GetContiguousRanges(missingTargetsByDate.Keys))
+            {
+                var rangeMissingTargetsByDate = missingTargetsByDate
+                    .Where(item => item.Key >= range.Start && item.Key <= range.End)
+                    .ToDictionary(item => item.Key, item => (IReadOnlySet<string>)item.Value);
+                var rangeTargetCodes = rangeMissingTargetsByDate.Values
+                    .SelectMany(targets => targets)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                var rangeRates = await FetchRatesForRange(range.Start, range.End, baseCurrency, rangeTargetCodes, rangeMissingTargetsByDate, ct);
+
+                foreach (var (date, response) in rangeRates)
+                {
+                    if (!rangeMissingTargetsByDate.TryGetValue(date.Date, out var missingTargetCodes))
+                    {
+                        continue;
+                    }
+
+                    hasProviderChanges |= await UpsertRatesForDate(userId, date, baseCurrency, response, missingTargetCodes, ct);
+                }
+            }
+
+            if (hasProviderChanges)
+                await DbInEx.SaveAsync(ct);
+
+            // Carry forward missing currencies for non-trading days or partial provider data.
+            missingTargetsByDate = await GetMissingTargetsByDate(candidateDates, baseCurrency, targetCurrencyCodes, ct);
+            bool hasCarryForwardChanges = false;
+            foreach (var (date, missingTargetCodes) in missingTargetsByDate.OrderBy(item => item.Key))
+            {
+                hasCarryForwardChanges |= await CarryForwardMissingRatesFromPriorDay(userId, date, baseCurrency, missingTargetCodes.ToList(), ct);
+            }
+
+            if (hasCarryForwardChanges)
+                await DbInEx.SaveAsync(ct);
+        }
+        finally
+        {
+            ReleaseSyncLocks(acquiredLocks);
+        }
+    }
+
+    private async Task<Dictionary<DateTime, HashSet<string>>> GetMissingTargetsByDate(
+        IReadOnlyCollection<DateTime> dates,
+        string baseCurrency,
+        IList<string> targetCurrencyCodes,
+        CancellationToken ct = default)
+    {
+        var normalizedDates = dates
+            .Select(d => d.Date)
+            .Distinct()
+            .OrderBy(d => d)
+            .ToList();
+        var normalizedTargets = targetCurrencyCodes
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (normalizedDates.Count == 0 || normalizedTargets.Count == 0)
+        {
+            return new Dictionary<DateTime, HashSet<string>>();
+        }
+
+        var cachedRates = await DbInEx.ExchangeRateRepository.Get(true)
+            .Where(r => normalizedDates.Contains(r.Created)
+                     && r.FromCode == baseCurrency
+                     && !r.IsTemporary
+                     && normalizedTargets.Contains(r.ToCode))
+            .Select(r => new { r.Created, r.ToCode })
+            .ToListAsync(ct);
+
+        var cachedTargetsByDate = cachedRates
+            .GroupBy(r => r.Created.Date)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(r => r.ToCode).ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+        var missingTargetsByDate = new Dictionary<DateTime, HashSet<string>>();
+        foreach (var date in normalizedDates)
+        {
+            cachedTargetsByDate.TryGetValue(date, out var cachedTargets);
+            var missingTargets = normalizedTargets
+                .Where(targetCode => cachedTargets is null || !cachedTargets.Contains(targetCode))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            if (missingTargets.Count > 0)
+            {
+                missingTargetsByDate[date] = missingTargets;
+            }
+        }
+
+        return missingTargetsByDate;
+    }
+
     /// <summary>
     /// Fetches exchange rates for the given date range using a two-pass merge strategy:
     /// 1. Frankfurter range call — one HTTP request, covers ECB currencies (EUR, PLN, …).
@@ -165,7 +250,12 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// If Frankfurter fails entirely, falls back to CurrencyAPI day-by-day for all currencies.
     /// </summary>
     private async Task<Dictionary<DateTime, ExchangeApiResponse>> FetchRatesForRange(
-        DateTime start, DateTime end, string baseCurrency, string[] targetCurrencies, CancellationToken ct = default)
+        DateTime start,
+        DateTime end,
+        string baseCurrency,
+        string[] targetCurrencies,
+        IReadOnlyDictionary<DateTime, IReadOnlySet<string>>? requiredTargetsByDate = null,
+        CancellationToken ct = default)
     {
         var nbrbTargetCurrencies = targetCurrencies
             .Where(targetCurrency => IsBynRubPath(baseCurrency, targetCurrency))
@@ -190,35 +280,44 @@ public class ExchangeRateService : Service, IExchangeRateService
             }
 
             // Pass 2: supplement currencies not returned by Frankfurter (e.g. BYN) via CurrencyAPI.
-            var coveredCurrencies = result.Values
-                .SelectMany(r => r.Data.Keys)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var uncoveredCurrencies = standardTargetCurrencies
-                .Where(c => !coveredCurrencies.Contains(c))
-                .ToArray();
+            var datesToFetch = GetCurrencyApiFallbackDates(start, end, result, requiredTargetsByDate);
 
-            if (uncoveredCurrencies.Length > 0)
+            foreach (var date in datesToFetch)
             {
-                // Only iterate dates Frankfurter returned (trading days); weekends/holidays get carry-forward.
-                // If Frankfurter returned nothing at all, fall back to all dates in range.
-                var datesToFetch = result.Count > 0
-                    ? result.Keys.ToList()
-                    : Enumerable.Range(0, (end.Date - start.Date).Days + 1).Select(i => start.Date.AddDays(i)).ToList();
+                var requiredStandardCurrencies = requiredTargetsByDate is not null
+                    ? requiredTargetsByDate[date]
+                        .Where(targetCurrency => standardTargetCurrencies.Contains(targetCurrency, StringComparer.OrdinalIgnoreCase))
+                        .ToArray()
+                    : standardTargetCurrencies;
 
-                foreach (var date in datesToFetch)
+                if (requiredStandardCurrencies.Length == 0)
                 {
-                    try
+                    continue;
+                }
+
+                var coveredCurrencies = result.TryGetValue(date.Date, out var dateResponse)
+                    ? dateResponse.Data.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase)
+                    : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var uncoveredCurrencies = requiredStandardCurrencies
+                    .Where(c => !coveredCurrencies.Contains(c))
+                    .ToArray();
+
+                if (uncoveredCurrencies.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var singleDay = await _apiClient.GetRatesAsync(date, baseCurrency, uncoveredCurrencies, ct);
+                    if (singleDay?.Data?.Count > 0)
                     {
-                        var singleDay = await _apiClient.GetRatesAsync(date, baseCurrency, uncoveredCurrencies, ct);
-                        if (singleDay?.Data?.Count > 0)
-                        {
-                            MergeRates(result, date, singleDay);
-                        }
+                        MergeRates(result, date, singleDay);
                     }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "CurrencyAPI fetch failed for {Date}/{BaseCurrency}/{Currencies}.", date, baseCurrency, string.Join(",", uncoveredCurrencies));
-                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "CurrencyAPI fetch failed for {Date}/{BaseCurrency}/{Currencies}.", date, baseCurrency, string.Join(",", uncoveredCurrencies));
                 }
             }
         }
@@ -262,9 +361,18 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// Existing temporary rates are overwritten with actual values.
     /// Returns <see langword="true"/> if any record was inserted or updated (caller must save).
     /// </summary>
-    private async Task<bool> UpsertRatesForDate(int userId, DateTime date, string baseCurrency, ExchangeApiResponse response, CancellationToken ct = default)
+    private async Task<bool> UpsertRatesForDate(
+        int userId,
+        DateTime date,
+        string baseCurrency,
+        ExchangeApiResponse response,
+        IReadOnlySet<string>? requiredTargetCodes = null,
+        CancellationToken ct = default)
     {
         DateTime createdDate = date.Date;
+        var requiredTargets = requiredTargetCodes is null
+            ? null
+            : new HashSet<string>(requiredTargetCodes, StringComparer.OrdinalIgnoreCase);
 
         List<ExchangeRate> existingRates = DbInEx.ExchangeRateRepository.Get(false)
             .Where(i => i.Created == createdDate && i.FromCode == baseCurrency)
@@ -276,6 +384,11 @@ public class ExchangeRateService : Service, IExchangeRateService
         {
             string toCode = string.IsNullOrWhiteSpace(item.Value.Code) ? item.Key : item.Value.Code;
             decimal value = item.Value.Value;
+
+            if (requiredTargets is not null && !requiredTargets.Contains(toCode))
+            {
+                continue;
+            }
 
             ExchangeRate? existingRate = existingRates.FirstOrDefault(i => i.ToCode == toCode);
 
@@ -313,50 +426,66 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// by copying the most recent available rates from a prior date and marking them as temporary.
     /// Does nothing when rates already exist for today, or when no prior rates are found.
     /// </summary>
-    private async Task CreateTemporaryRatesForTodayIfNeeded(int userId, DateTime date, string baseCurrency, CancellationToken ct = default)
+    private async Task CreateTemporaryRatesForTodayIfNeeded(int userId, DateTime date, string baseCurrency, IList<string> targetCurrencyCodes, CancellationToken ct = default)
     {
         DateTime today = date.Date;
-
-        bool ratesExist = DbInEx.ExchangeRateRepository.Get(true)
-            .Any(i => i.Created == today && i.FromCode == baseCurrency);
-
-        if (ratesExist)
+        var acquiredLocks = await AcquireSyncLocks(baseCurrency, [today], ct);
+        try
         {
-            return;
-        }
+            List<ExchangeRate> existingRates = DbInEx.ExchangeRateRepository.Get(true)
+                .Where(i => i.Created == today && i.FromCode == baseCurrency)
+                .ToList();
+            var existingTargetCodes = existingRates
+                .Select(rate => rate.ToCode)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        // Find the most recent date before today that has rates for this base currency.
-        DateTime? latestDate = DbInEx.ExchangeRateRepository.Get(true)
-            .Where(i => i.Created < today && i.FromCode == baseCurrency)
-            .OrderByDescending(i => i.Created)
-            .Select(i => (DateTime?)i.Created)
-            .FirstOrDefault();
+            var missingTargetCodes = targetCurrencyCodes
+                .Where(targetCode => !existingTargetCodes.Contains(targetCode))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        if (!latestDate.HasValue)
-        {
-            return;
-        }
-
-        List<ExchangeRate> latestRates = DbInEx.ExchangeRateRepository.Get(true)
-            .Where(i => i.Created == latestDate.Value && i.FromCode == baseCurrency)
-            .ToList();
-
-        foreach (ExchangeRate rate in latestRates)
-        {
-            await DbInEx.ExchangeRateRepository.CreateAsync(new ExchangeRate()
+            if (existingRates.Count > 0 && missingTargetCodes.Count == 0)
             {
-                FromCode = rate.FromCode,
-                ToCode = rate.ToCode,
-                Rate = rate.Rate,
-                IsTemporary = true,
-                CreatedBy = userId,
-                Created = today
-            }, ct);
-        }
+                return;
+            }
 
-        if (latestRates.Count > 0)
+            List<ExchangeRate> latestRates = DbInEx.ExchangeRateRepository.Get(true)
+                .Where(i => i.Created < today
+                         && i.FromCode == baseCurrency
+                         && !i.IsTemporary
+                         && missingTargetCodes.Contains(i.ToCode))
+                .OrderByDescending(i => i.Created)
+                .GroupBy(i => i.ToCode)
+                .Select(g => g.First())
+                .ToList();
+
+            if (existingRates.Count == 0 && missingTargetCodes.Count == 0)
+            {
+                missingTargetCodes = latestRates
+                    .Select(rate => rate.ToCode)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+
+            foreach (ExchangeRate rate in latestRates.Where(rate => missingTargetCodes.Contains(rate.ToCode)))
+            {
+                await DbInEx.ExchangeRateRepository.CreateAsync(new ExchangeRate()
+                {
+                    FromCode = rate.FromCode,
+                    ToCode = rate.ToCode,
+                    Rate = rate.Rate,
+                    IsTemporary = true,
+                    CreatedBy = userId,
+                    Created = today
+                }, ct);
+            }
+
+            if (latestRates.Any(rate => missingTargetCodes.Contains(rate.ToCode)))
+            {
+                await DbInEx.SaveAsync(ct);
+            }
+        }
+        finally
         {
-            await DbInEx.SaveAsync(ct);
+            ReleaseSyncLocks(acquiredLocks);
         }
     }
 
@@ -368,13 +497,17 @@ public class ExchangeRateService : Service, IExchangeRateService
     /// </summary>
     private async Task<bool> CarryForwardMissingRatesFromPriorDay(int userId, DateTime date, string baseCurrency, IList<string> targetCurrencyCodes, CancellationToken ct = default)
     {
-        var existingTargetCodes = DbInEx.ExchangeRateRepository.Get(true)
+        List<ExchangeRate> existingRates = DbInEx.ExchangeRateRepository.Get(false)
             .Where(r => r.Created == date.Date && r.FromCode == baseCurrency)
+            .ToList();
+
+        var existingActualTargetCodes = existingRates
+            .Where(r => !r.IsTemporary)
             .Select(r => r.ToCode)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var missingTargetCodes = targetCurrencyCodes
-            .Where(targetCode => !existingTargetCodes.Contains(targetCode))
+            .Where(targetCode => !existingActualTargetCodes.Contains(targetCode))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         if (missingTargetCodes.Count == 0) return false;
 
@@ -388,18 +521,135 @@ public class ExchangeRateService : Service, IExchangeRateService
 
         foreach (var rate in priorRates)
         {
-            await DbInEx.ExchangeRateRepository.CreateAsync(new ExchangeRate
+            var existingRate = existingRates.FirstOrDefault(r => string.Equals(r.ToCode, rate.ToCode, StringComparison.OrdinalIgnoreCase));
+            if (existingRate is null)
             {
-                FromCode = rate.FromCode,
-                ToCode = rate.ToCode,
-                Rate = rate.Rate,
-                IsTemporary = false,
-                CreatedBy = userId,
-                Created = date.Date
-            }, ct);
+                await DbInEx.ExchangeRateRepository.CreateAsync(new ExchangeRate
+                {
+                    FromCode = rate.FromCode,
+                    ToCode = rate.ToCode,
+                    Rate = rate.Rate,
+                    IsTemporary = false,
+                    CreatedBy = userId,
+                    Created = date.Date
+                }, ct);
+
+                continue;
+            }
+
+            if (existingRate.Rate != rate.Rate || existingRate.IsTemporary)
+            {
+                existingRate.Rate = rate.Rate;
+                existingRate.IsTemporary = false;
+                DbInEx.ExchangeRateRepository.Update(existingRate);
+            }
         }
 
         return priorRates.Count > 0;
+    }
+
+    private static IEnumerable<DateTime> EnumerateDates(DateTime start, DateTime end)
+    {
+        if (end < start)
+        {
+            yield break;
+        }
+
+        for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
+        {
+            yield return date;
+        }
+    }
+
+    private static IEnumerable<(DateTime Start, DateTime End)> GetContiguousRanges(IEnumerable<DateTime> dates)
+    {
+        DateTime? rangeStart = null;
+        DateTime? previous = null;
+
+        foreach (var date in dates.Select(d => d.Date).Distinct().OrderBy(d => d))
+        {
+            if (rangeStart is null)
+            {
+                rangeStart = date;
+                previous = date;
+                continue;
+            }
+
+            if (previous!.Value.AddDays(1) == date)
+            {
+                previous = date;
+                continue;
+            }
+
+            yield return (rangeStart.Value, previous.Value);
+            rangeStart = date;
+            previous = date;
+        }
+
+        if (rangeStart.HasValue && previous.HasValue)
+        {
+            yield return (rangeStart.Value, previous.Value);
+        }
+    }
+
+    private static List<DateTime> GetCurrencyApiFallbackDates(
+        DateTime start,
+        DateTime end,
+        IReadOnlyDictionary<DateTime, ExchangeApiResponse> providerResult,
+        IReadOnlyDictionary<DateTime, IReadOnlySet<string>>? requiredTargetsByDate)
+    {
+        if (requiredTargetsByDate is null)
+        {
+            return providerResult.Count > 0
+                ? providerResult.Keys.OrderBy(d => d).ToList()
+                : EnumerateDates(start, end).ToList();
+        }
+
+        if (providerResult.Count == 0)
+        {
+            return requiredTargetsByDate.Keys.OrderBy(d => d).ToList();
+        }
+
+        var providerDates = providerResult.Keys.ToHashSet();
+        return requiredTargetsByDate.Keys
+            .Where(providerDates.Contains)
+            .OrderBy(d => d)
+            .ToList();
+    }
+
+    private static async Task<List<SemaphoreSlim>> AcquireSyncLocks(string baseCurrency, IEnumerable<DateTime> dates, CancellationToken ct)
+    {
+        var keys = dates
+            .Select(date => $"{baseCurrency.ToUpperInvariant()}:{date.Date:yyyy-MM-dd}")
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToList();
+        var acquiredLocks = new List<SemaphoreSlim>();
+
+        try
+        {
+            foreach (var key in keys)
+            {
+                var syncLock = SyncLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+                await syncLock.WaitAsync(ct);
+                acquiredLocks.Add(syncLock);
+            }
+        }
+        catch
+        {
+            ReleaseSyncLocks(acquiredLocks);
+            throw;
+        }
+
+        return acquiredLocks;
+    }
+
+    private static void ReleaseSyncLocks(IEnumerable<SemaphoreSlim> syncLocks)
+    {
+        foreach (var syncLock in syncLocks.Reverse())
+        {
+            syncLock.Release();
+        }
     }
 
     private static bool IsBynRubPath(string baseCurrency, string targetCurrency) =>
@@ -417,6 +667,7 @@ public class ExchangeRateService : Service, IExchangeRateService
     private readonly INbrbApiClient _nbrbClient;
     private readonly ILogger<ExchangeRateService> _logger;
     private readonly IClock _clock;
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> SyncLocks = new(StringComparer.Ordinal);
 
     #endregion Private Fields
 }


### PR DESCRIPTION
## Summary
- Replace exchange-rate cache completeness row counts with exact required `(date, target currency)` coverage.
- Promote past temporary carry-forward rows in place when prior actual rates exist, preserving today temporary behavior.
- Recheck the database under per-base/date in-process locks before provider fallback to reduce duplicate concurrent syncs.
- Narrow provider fallback to sparse missing chunks and avoid CurrencyAPI calls for dates already cached or omitted by Frankfurter trading-day data.
- Document an optional safe repair path for existing past temporary rows.

## Issues fixed
Fixes #226
Fixes #227
Fixes #228
Fixes #229
Fixes #230

## Tests run
- `dotnet test inex.Services.Tests` - passed, 88/88
- `dotnet test inex.sln` - passed, Services.Tests 88/88 and inex.Tests 102/102

## Review result
- Fresh-context issue audit, architecture review, test strategy, and code risk review completed before implementation.
- Fresh-context code review and QA review completed after implementation.
- All high/medium findings were addressed.
- Final focused code review reported no remaining high/medium correctness findings.

## Risk notes
- In-process locking protects a single API process. Multi-instance deployments still rely on the database unique key for idempotency and may need distributed coordination if duplicate provider calls across instances become material.
- Provider behavior remains mocked in tests; no live CurrencyAPI, Frankfurter, or NBRB APIs were called.
- Cash-flow broad date demand is not reshaped in this PR; the exchange-rate service now handles sparse missing dates more safely.

## DB repair
Existing past temporary rows should self-heal when requested if prior actual rates exist. Manual repair is optional and documented in `docs/operations/exchange-rate-cache-repair.md` for pre-traffic cleanup.