### PR TITLE
docs: add agent session workflow rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ InEx is a full-stack financial management application built with .NET 8 + React 
 
 ### Project Structure
 - **`inex/`** - Main ASP.NET Core web application with React SPA
-- **`inex.Services/`** - Business logic layer with AutoMapper profiles and service contracts  
+- **`inex.Services/`** - Business logic layer with response records, static mappers, and service contracts
 - **`inex.Data/`** - Data access layer with Entity Framework and repositories
 - **`inex/ClientApp/`** - React TypeScript frontend with Redux Toolkit state management
 
@@ -18,11 +18,11 @@ public const string RoutePrefix = "api/transactions";
 public const string GetSingleRoute = "{id}";
 ```
 
-**Services**: Follow interface-based dependency injection registered in `WalletServicesExtension.cs`. All services inherit from `IInExService`. Business logic returns standardized `ResponseDTO` objects with message collections.
+**Services**: Follow interface-based dependency injection registered in `WalletServicesExtension.cs`. All services inherit from `IInExService`. Business logic returns domain `XxxResponse` records or wrappers such as `ListResponse<T>`, `PagedResponse<T,TMeta>`, and `CreatedResponse`.
 
-**Error Handling**: Uses custom `InExException` with `MessageCode` enums. Controllers call `BuildErrorMessage()` to create consistent error responses.
+**Error Handling**: Uses custom `InExException` with global RFC 7807 Problem Details handling.
 
-**Data Transfer**: Extensive use of record-based DTOs (e.g., `TransactionDetailsDTO`, `TransactionCreateDTO`) with AutoMapper profiles for entity mapping.
+**Data Transfer**: Uses record-based request/response contracts under `inex.Services/Models/Records/` with static mapper extensions under `inex.Services/Models/Mappers/`.
 
 ### Frontend Patterns
 
@@ -52,7 +52,7 @@ public const string GetSingleRoute = "{id}";
 
 **Multi-Currency**: Exchange rate service with date-based rate fetching.
 
-**AutoMapper**: All entity-DTO mappings configured in `ConfigProfiles/` directory.
+**Static Mappers**: Entity-contract mappings use static mapper extensions in `inex.Services/Models/Mappers/`.
 
 ### Database Context
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ docker/mysql/initdb/*.sql
 docker/mysql/mysql_data/
 docker/mysql/backup/
 scripts
+!/scripts/
+/scripts/*
+!/scripts/doctor.ps1
 docs/*
 !docs/brainstorming/
 !docs/brainstorming/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# InEx Agent Instructions
+
+InEx is a multi-user personal finance app. Treat user data isolation as a hard invariant: every backend query and service path must remain scoped to the current user.
+
+Use `CLAUDE.md` and `README.md` for broader project context. This file defines agent behavior and project-specific guardrails.
+
+## Documentation Sources
+
+- Before implementation, read the applicable active story/spec and directly relevant docs under `docs/implementation`, `docs/planning`, or `docs/operations`.
+- Treat `docs/project-context.md` as the extended AI-agent rule source when a change touches architecture, security, testing, frontend migration, or database behavior.
+- Use `docs/design/docs/design-implementation-guide.md` and `docs/design/*` as visual references for frontend visual work, not as runtime source code.
+- This project uses BMad-generated planning and implementation artifacts.
+- Before story-sized work, read the active story/spec in `docs/implementation` and relevant planning docs in `docs/planning`.
+- Treat accepted BMad decisions as project constraints unless current code contradicts them or the user explicitly changes direction.
+- Do not rewrite Dev Agent Records, Change Logs, or completed story history unless explicitly asked.
+- For small bug fixes or mechanical edits, use BMad docs only when they are directly relevant to the touched area.
+
+## Communication
+
+- Do not open criticism with softening preambles. State the concern directly.
+- Do not thank, compliment, echo, or restate the user's request before answering.
+- Start with the answer or action. Every sentence must add information.
+- For automatically created branches, never use `codex/`. Use `feature/`, `fix/`, `refactor/`, or `docs/`.
+
+## Safety
+
+- Do not start the application or trigger live external API calls during investigation unless explicitly approved.
+- Do not call live CurrencyAPI, Frankfurter, NBRB, or other paid/external providers from tests or exploratory work.
+- Never print secrets, connection strings, tokens, `.env` contents, or credentials.
+- Preserve unrelated user changes. Do not revert files unless explicitly requested.
+- Prefer narrow, reviewable changes that match existing patterns.
+
+## GitHub Issues
+
+- Follow `docs/operations/github-issue-guidelines.md` when creating or editing GitHub issues.
+- Keep issue content public-safe: do not include local absolute paths, localhost evidence URLs, credentials, tokens, or user-local details.
+- Prefer repo-relative source references such as `inex/ClientApp/src/pages/Accounts.tsx`.
+- Issue titles should start with an action verb and should not use prefixes such as `fix(...)`, `refactor(...)`, `docs(...)`, or `[Feature]`.
+- Open issues should have exactly one allowed type label and one priority label.
+- Keep each issue uniquely scoped; avoid mixing decision work, implementation work, and test-only work unless intentionally grouped.
+
+## Security And Ownership
+
+- For user-owned data, never query, update, delete, aggregate, or report by entity ID alone.
+- Include `UserId` or an equivalent ownership predicate before returning or mutating user-owned data.
+- Never trust client-supplied ownership fields such as `UserId`; derive the current user from the authenticated principal.
+- Cross-user single-entity access should use the same `404 Not Found` path as missing resources.
+- Transfer creation has historically loaded source/destination accounts by ID only. Any transfer work must verify both accounts belong to the current user.
+
+## Database Access
+
+When database access is needed for inspection, validation, debugging, or data analysis, use MySQL MCP first.
+
+- Prefer `mcp_server_mysql.mysql_query` / `mysql_query` for all read-only SQL.
+- Use read-only SQL only: `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN`.
+- Do not use Docker, app startup, local `mysql` CLI, migrations, or direct connection strings before checking whether MySQL MCP is available.
+- If MySQL MCP is unavailable or insufficient, state that explicitly before using a fallback.
+- Do not run write SQL unless explicitly requested and separately approved.
+- EF InMemory tests do not prove MySQL translation, migrations, constraints, collation, transactions, or concurrency.
+- For schema, provider-specific query, transaction, or concurrency changes, verify against MySQL before treating the change as complete.
+
+## Common Commands
+
+Run from repo root unless noted:
+
+```powershell
+dotnet test
+dotnet test inex.Services.Tests/
+dotnet test inex.Tests/
+dotnet build
+```
+
+Frontend commands from `inex/ClientApp/`:
+
+```powershell
+npm run build
+npm run lint
+npm start
+```
+
+Local dependencies:
+
+```powershell
+docker compose up -d mysql
+```
+
+Migrations:
+
+```powershell
+dotnet ef migrations add <Name> --project inex.Data --startup-project inex
+dotnet ef database update --project inex.Data --startup-project inex
+```
+
+## Backend Conventions
+
+- ASP.NET Core 8, EF Core 8, Pomelo MySQL, Repository + Unit of Work.
+- Controllers inherit `ApiControllerBase`, use `CurrentUserId`, and return typed response records through `ActionResult`.
+- Services implement `IInExService`, return domain `XxxResponse` records or wrappers such as `ListResponse<T>`, `PagedResponse<T,TMeta>`, and `CreatedResponse`, and throw `InExException` for domain errors.
+- DTOs live in `inex.Services/Models/Records/`.
+- New backend contract records should use `CreateXxxRequest`, `UpdateXxxRequest`, `DeleteXxxRequest`, `XxxResponse`, or intentional `XxxSummary`. Do not introduce new `*DTO` contract types.
+- Preserve JSON property names, routes, status codes, enum values, validation keys, and response shapes unless the active story explicitly changes the contract.
+- Mappings use static extension methods under `inex.Services/Models/Mappers/`. Do not reintroduce mapping libraries or `IMapper` without an explicit architecture decision.
+- Validators live in `inex.Services/Validators/` and use machine-readable error codes.
+- Config uses options classes with `ValidateOnStart()`.
+- Transaction `Comment` encodes `#hashtags` and `@references`; parse on read and do not store parsed values separately.
+- Schema changes require EF migrations with explicit indexes, relationships, and delete behavior.
+
+## Frontend Conventions
+
+- For frontend work, also read `inex/ClientApp/AGENTS.md`.
+- Authenticated API calls must preserve shared `apiClient`, auth headers, and refresh-token behavior.
+- All user-visible strings must use i18n.
+- Frontend visual work must follow `docs/design/docs/design-implementation-guide.md`.
+
+## Testing
+
+- Unit tests in `inex.Services.Tests/` should cover pure service logic and avoid DB access.
+- Integration tests in `inex.Tests/` may hit a real DB.
+- Exchange-rate provider behavior must be mocked.
+- For backend service changes, run focused `dotnet test inex.Services.Tests/` first, then broader tests when feasible.
+
+## Project Gotchas
+
+- `InExDbContextFactory.cs` has hardcoded MySQL credentials for design-time only; do not treat it as the production path.
+- Exchange-rate behavior is quota-sensitive. For cache repair or provider-call changes, read `docs/operations/exchange-rate-cache-repair.md` before editing.
+- Registration is invite-token gated through `InviteOptions:Token` until proper email-confirmed registration exists.
+
+## Agent File Maintenance
+
+- If `Backend Conventions` grows beyond 20 bullet lines, remind the user to consider splitting backend-specific rules into `inex.Services/AGENTS.md` and/or `inex.Data/AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,13 @@ Use `CLAUDE.md` and `README.md` for broader project context. This file defines a
 - Do not rewrite Dev Agent Records, Change Logs, or completed story history unless explicitly asked.
 - For small bug fixes or mechanical edits, use BMad docs only when they are directly relevant to the touched area.
 
+## Session Workflow
+
+- Before UI/browser work, run the project doctor if available; see `docs/operations/project-doctor.md`. If it fails, report setup blockers before continuing.
+- For frontend visual changes, produce or update visual QA evidence before code review. Missing visual QA tooling is a blocker for visual-parity claims.
+- When given more than 10 UI findings, classify and group them into implementation-owned issues before coding.
+- After sessions with repeated environment or tool friction, propose one durable doc, script, or skill update.
+
 ## Communication
 
 - Do not open criticism with softening preambles. State the concern directly.
@@ -29,6 +36,11 @@ Use `CLAUDE.md` and `README.md` for broader project context. This file defines a
 - Never print secrets, connection strings, tokens, `.env` contents, or credentials.
 - Preserve unrelated user changes. Do not revert files unless explicitly requested.
 - Prefer narrow, reviewable changes that match existing patterns.
+
+## Tool Priority
+
+- Use MySQL MCP for read-only DB inspection before Docker, app startup, local `mysql`, migrations, or connection-string fallbacks. See `docs/operations/codex-mcp.md`.
+- Use the GitHub connector for issue and PR operations when available; use `gh` only for connector gaps.
 
 ## GitHub Issues
 
@@ -49,11 +61,10 @@ Use `CLAUDE.md` and `README.md` for broader project context. This file defines a
 
 ## Database Access
 
-When database access is needed for inspection, validation, debugging, or data analysis, use MySQL MCP first.
+When database access is needed for inspection, validation, debugging, or data analysis, keep it read-only unless explicitly approved.
 
 - Prefer `mcp_server_mysql.mysql_query` / `mysql_query` for all read-only SQL.
 - Use read-only SQL only: `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN`.
-- Do not use Docker, app startup, local `mysql` CLI, migrations, or direct connection strings before checking whether MySQL MCP is available.
 - If MySQL MCP is unavailable or insufficient, state that explicitly before using a fallback.
 - Do not run write SQL unless explicitly requested and separately approved.
 - EF InMemory tests do not prove MySQL translation, migrations, constraints, collation, transactions, or concurrency.

--- a/docs/operations/ai-session-effectiveness-implementation-prompts.md
+++ b/docs/operations/ai-session-effectiveness-implementation-prompts.md
@@ -1,0 +1,668 @@
+# AI Session Effectiveness Implementation Prompts
+
+This document turns the session-effectiveness audit into implementation-agent prompts. Use the stages in order unless a later stage is explicitly independent.
+
+## Stage Order
+
+1. **Stage 0 - Intake and branch hygiene**
+2. **Stage 1 - Project doctor helper**
+3. **Stage 2 - AGENTS.md and instruction updates**
+4. **Stage 3 - Issue-shaper skill/checklist**
+5. **Stage 4 - Visual QA harness**
+6. **Stage 5 - BMAD delivery orchestrator skill**
+7. **Stage 6 - Prompt template library**
+8. **Stage 7 - Retrospective loop and maintenance automation**
+
+Stages 1 and 2 are prerequisites for the rest. Stage 3 can run after Stage 2. Stage 4 can run after Stage 1. Stage 5 should run after Stages 2 and 3. Stages 6 and 7 can be implemented after Stage 2.
+
+## Global Implementation Rules
+
+Every implementation agent must follow these rules:
+
+- Read `AGENTS.md`, `inex/ClientApp/AGENTS.md` when touching frontend, and directly relevant docs under `docs/operations`.
+- Preserve unrelated worktree changes.
+- Do not start the app or call live external APIs unless the task explicitly requires and allows it.
+- Use MySQL MCP for read-only DB validation before Docker, local `mysql`, or app startup.
+- Keep docs public-safe: no local absolute paths, localhost evidence URLs, credentials, tokens, or secrets.
+- Use semantic branch names if creating branches: `feature/`, `fix/`, `refactor/`, or `docs/`.
+- For docs-only changes, do not run full tests unless the task changes executable scripts or validation commands.
+
+## Stage 0 - Intake And Branch Hygiene
+
+Goal: make every implementation session start from a known state without losing user work.
+
+### Prompt
+
+```text
+You are implementing the AI session effectiveness setup for InEx.
+
+Stage: 0 - Intake and branch hygiene.
+
+Objective:
+Inspect the current repository state and prepare a safe implementation path without modifying unrelated files.
+
+Required steps:
+1. Read `AGENTS.md`.
+2. Run `git status --short --branch`.
+3. If the worktree is dirty, inspect changed paths and classify them:
+   - related to this stage
+   - unrelated user work
+   - generated/local artifacts
+   - possible secrets or local-only files
+4. Do not revert or delete unrelated changes.
+5. Recommend a branch name for the stage if branch creation is requested.
+6. Produce a short implementation note that names:
+   - current branch
+   - dirty files
+   - files this stage is allowed to touch
+   - verification commands to run
+
+Allowed files for this stage:
+- Documentation only, unless explicitly asked to create helper scripts.
+
+Acceptance criteria:
+- No unrelated files are changed.
+- The user can see what will be touched before implementation starts.
+- Any secret-bearing or local-only files are identified without printing secret values.
+```
+
+## Stage 1 - Project Doctor Helper
+
+Goal: prevent UI/browser/database sessions from being derailed by missing Vite shims, locked backend DLLs, port conflicts, GitHub auth issues, or unavailable MySQL MCP.
+
+Recommended artifact:
+
+- `scripts/doctor.ps1`
+- Optional docs: `docs/operations/project-doctor.md`
+
+### Prompt
+
+```text
+You are implementing Stage 1 - Project doctor helper.
+
+Objective:
+Create a non-destructive PowerShell project doctor that checks local development readiness before UI, browser, DB, or GitHub work.
+
+Read first:
+- `AGENTS.md`
+- `docs/operations/codex-mcp.md`
+- `inex/ClientApp/AGENTS.md`
+
+Create:
+- `scripts/doctor.ps1`
+- `docs/operations/project-doctor.md` if usage needs documentation
+
+Doctor requirements:
+1. Do not print secrets, connection strings, tokens, `.env` contents, or user-secrets values.
+2. Support switches:
+   - `-Ui`
+   - `-Db`
+   - `-GitHub`
+   - `-All`
+3. UI checks:
+   - `inex/ClientApp/package.json` exists.
+   - `node_modules/.bin/vite.cmd` exists on Windows.
+   - `npm` is available.
+   - frontend scripts include `start`, `build`, and `lint`.
+   - report whether common frontend ports are listening: `3000`, `5173`, `5177`.
+4. Backend checks:
+   - `dotnet` is available.
+   - solution file exists.
+   - report if port `5000` is listening.
+   - detect likely locked build outputs by checking for running `inex` processes, but do not kill them.
+5. DB checks:
+   - Check whether MySQL MCP is available if callable from this environment.
+   - If MCP is not callable from a script, document that Codex agents must run `SELECT 1 AS ok` through MCP.
+   - Do not use Docker or local MySQL as the first path.
+6. GitHub checks:
+   - `gh` is available.
+   - `gh auth status` succeeds, without printing tokens.
+7. Output:
+   - A compact table of checks.
+   - Clear remediation hints.
+   - Exit code `0` when all selected checks pass.
+   - Non-zero exit code when selected checks fail.
+
+Implementation details:
+- Use native PowerShell.
+- Avoid destructive commands.
+- Avoid reading `.env` values.
+- Keep functions small: `Test-Ui`, `Test-Backend`, `Test-Db`, `Test-GitHub`, `Write-Check`.
+- Use `Get-Command`, `Test-Path`, `Get-NetTCPConnection` or a safe fallback if unavailable.
+
+Verification:
+- Run `powershell -ExecutionPolicy Bypass -File scripts/doctor.ps1 -All`.
+- Run individual switches.
+- Confirm no secrets are printed.
+
+Acceptance criteria:
+- The script identifies missing frontend command shims before `npm start`.
+- The script identifies occupied app ports.
+- The script identifies missing `gh` auth.
+- The script is safe to run in normal investigation sessions.
+```
+
+## Stage 2 - AGENTS.md And Instruction Updates
+
+Goal: encode durable session workflow rules without bloating the agent file.
+
+Recommended artifacts:
+
+- Root `AGENTS.md`
+- `inex/ClientApp/AGENTS.md` only if frontend-specific rules change
+- Optional docs under `docs/operations`
+
+### Prompt
+
+```text
+You are implementing Stage 2 - AGENTS.md and instruction updates.
+
+Objective:
+Add concise durable rules that prevent repeated session friction, without duplicating long operational docs.
+
+Read first:
+- `AGENTS.md`
+- `inex/ClientApp/AGENTS.md`
+- `docs/operations/codex-mcp.md`
+- `docs/operations/github-issue-guidelines.md`
+
+Required AGENTS.md additions or validation:
+1. Add a `Session Workflow` section if absent:
+   - Before UI/browser work, run the project doctor if available; if it fails, report setup blockers before continuing.
+   - For frontend visual changes, produce or update visual QA evidence before code review. Missing visual QA tooling is a blocker for visual-parity claims.
+   - When given more than 10 UI findings, classify and group them into implementation-owned issues before coding.
+   - After sessions with repeated environment/tool friction, propose one durable doc, script, or skill update.
+2. Add or confirm `Tool Priority` rules:
+   - Use MySQL MCP for read-only DB inspection before Docker, app startup, local mysql CLI, or connection-string fallbacks.
+   - Use GitHub connector for issue/PR operations when available; use `gh` only for connector gaps.
+3. Keep the root file concise:
+   - Do not paste long issue templates into AGENTS.md.
+   - Link to `docs/operations/github-issue-guidelines.md` for details.
+   - Link to `docs/operations/project-doctor.md` if created.
+
+Implementation details:
+- Preserve existing branch naming, security, ownership, testing, and frontend rules.
+- Do not rewrite completed story history.
+- If rules already exist, refine instead of duplicating.
+- Keep wording actionable and short.
+
+Verification:
+- Search for duplicate/conflicting rules around MySQL MCP, GitHub issues, visual QA, and frontend commands.
+- Confirm `AGENTS.md` remains within a compact guardrail size.
+
+Acceptance criteria:
+- Agents have a clear preflight rule for UI/browser work.
+- Agents have a clear grouping rule for large UI finding lists.
+- AGENTS.md points to detailed docs instead of embedding long procedures.
+```
+
+## Stage 3 - Issue-Shaper Skill Or Checklist
+
+Goal: convert raw findings into public-safe, implementation-owned GitHub issues and PR groups.
+
+Recommended artifacts:
+
+- Skill: local skill directory if skill creation is desired.
+- Fallback: `docs/operations/issue-shaper-checklist.md`
+
+### Prompt
+
+```text
+You are implementing Stage 3 - issue-shaper skill/checklist.
+
+Objective:
+Create a reusable workflow that turns raw audits, screenshot mismatch lists, or code review findings into scoped GitHub issues and PR grouping.
+
+Read first:
+- `docs/operations/github-issue-guidelines.md`
+- `AGENTS.md`
+- Existing UI audit docs under `docs/ui-audit` for examples
+
+Create one of these, based on project preference:
+- Preferred: a Codex skill named `inex-issue-shaper`
+- Minimum: `docs/operations/issue-shaper-checklist.md`
+
+Workflow requirements:
+1. Intake:
+   - Accept raw findings, screenshots, issue lists, or audit docs.
+   - Identify source route/page/domain.
+2. Classification:
+   - `Confirmed`
+   - `Partial`
+   - `Not current`
+   - `Product decision`
+   - `Fixture/data/locale`
+   - `Blocked`
+3. Grouping:
+   - Group by implementation ownership, not visual symptom.
+   - Separate shared shell/navigation from page-local changes.
+   - Separate fixture/data decisions from structural UI bugs.
+   - Avoid one ticket per pixel difference.
+4. Issue template:
+   - Action-verb title.
+   - One type label.
+   - One priority label.
+   - Problem.
+   - Expected behavior.
+   - Current behavior.
+   - Evidence with repo-relative paths only.
+   - Scope.
+   - Acceptance criteria.
+   - Blockers/decisions.
+5. PR grouping:
+   - Recommend branch names.
+   - Identify dependencies.
+   - Identify what can run in parallel.
+   - Identify shared-file conflict risks.
+6. Safety:
+   - No local absolute paths.
+   - No localhost URLs.
+   - No credentials or test account secrets.
+   - For screenshots, use: `Screenshot captured during local visual QA; local filesystem path intentionally omitted.`
+
+Implementation details for a skill:
+- Create `SKILL.md` with trigger examples:
+  - "verify these issues"
+  - "convert findings into GitHub issues"
+  - "suggest PR grouping"
+  - "audit screenshot mismatch list"
+- Include a compact output format.
+- Link to `docs/operations/github-issue-guidelines.md`.
+
+Verification:
+- Run the checklist manually against an existing audit such as `docs/ui-audit/accounts.md`.
+- Confirm output creates fewer grouped issues than raw findings.
+
+Acceptance criteria:
+- A future agent can take a 25-30 item UI list and produce 3-7 scoped issue drafts.
+- Output follows the project label and public-safe rules.
+- PR grouping includes dependencies and parallelization advice.
+```
+
+## Stage 4 - Visual QA Harness
+
+Goal: make fixture visual QA repeatable and stop relying on ad hoc screenshots.
+
+Recommended artifacts:
+
+- `inex/ClientApp/scripts/visual-qa/`
+- npm scripts such as `qa:visual` and `qa:visual:accounts`
+- Output under `docs/implementation/visual-qa/<story-or-page>/`
+
+### Prompt
+
+```text
+You are implementing Stage 4 - visual QA harness.
+
+Objective:
+Create a repeatable frontend visual QA command that can capture fixture-backed page states and produce screenshots plus `qa-summary.json`.
+
+Read first:
+- `AGENTS.md`
+- `inex/ClientApp/AGENTS.md`
+- `docs/design/docs/design-implementation-guide.md`
+- `docs/implementation/visual-qa/accounts-fixture-baseline.md`
+- Existing `docs/implementation/visual-qa/*/qa-summary.json` files
+
+Initial scope:
+Start with one page, preferably Accounts or Transactions. Do not attempt all pages in the first PR.
+
+Harness requirements:
+1. Use fixture mode as source of truth for mockup parity.
+2. Do not hardcode fixture data into production runtime paths.
+3. Support states:
+   - populated desktop
+   - populated 390px
+   - populated 360px
+   - filter-empty
+   - first-use empty
+   - drawer-open
+   - expanded-row or collapsed-group where applicable
+   - error state where feasible
+4. Support viewport widths:
+   - 1440
+   - 1024
+   - 390
+   - 360
+5. Produce:
+   - screenshots
+   - `qa-summary.json`
+   - overflow checks
+   - bottom nav visibility/occlusion checks on mobile
+   - data mode labels: `fixture` or `live-seed`
+6. Avoid live external provider calls.
+7. Do not require a real user password for fixture mode.
+
+Implementation options to evaluate:
+1. Playwright request interception against Vite dev server.
+2. A test-only mock service worker route.
+3. A dedicated fixture route guarded behind dev/test build flags.
+4. Component-level Playwright/RTL rendering if full app routing is too costly.
+
+Preferred implementation:
+- Use Playwright if package/runtime is available and stable.
+- If Playwright is not installed, propose a dedicated story/PR to add it deliberately.
+- Do not silently rely on the in-app browser if it lacks request interception.
+
+Implementation details:
+- Add a script that starts or expects Vite in test mode.
+- Avoid port `5000` collisions with the real backend by intercepting `/api` or using a test-only proxy target.
+- Keep output deterministic.
+- Include a README section explaining how to run the harness locally.
+
+Verification:
+- Run the new visual QA command for the selected page.
+- Confirm screenshots and `qa-summary.json` are generated.
+- Confirm no horizontal overflow at 390px and 360px.
+- Confirm fixture mode does not call real backend APIs.
+
+Acceptance criteria:
+- One command refreshes visual QA evidence for the selected page.
+- A PR reviewer can inspect screenshots and JSON without rerunning the app manually.
+- The harness failure mode is explicit when dependencies are missing.
+```
+
+## Stage 5 - BMAD Delivery Orchestrator Skill
+
+Goal: stop rewriting long orchestrator prompts for issue-to-production delivery.
+
+Recommended artifact:
+
+- Skill: `inex-bmad-delivery-orchestrator`
+
+### Prompt
+
+```text
+You are implementing Stage 5 - BMAD delivery orchestrator skill.
+
+Objective:
+Create a reusable local skill for issue-driven implementation from GitHub issue intake through branch, code, tests, review, PR, CI, and merge.
+
+Read first:
+- `AGENTS.md`
+- BMAD skills available in `.agents/skills`
+- `docs/implementation/sprint-status.yaml`
+- `docs/operations/github-issue-guidelines.md`
+
+Create:
+- A skill named `inex-bmad-delivery-orchestrator`, or update an existing local skill if the project already has one for this purpose.
+
+Skill trigger examples:
+- "fix issue #215 using BMAD"
+- "run BMAD delivery for these GitHub issues"
+- "implement, review, create PR, and merge"
+- "orchestrate fresh-context subagents"
+
+Skill workflow:
+1. Intake:
+   - Read issue(s), AGENTS, active story/spec if relevant.
+   - Check worktree state.
+   - Identify branch naming and PR grouping.
+2. Planning:
+   - Decide if work is one PR, stacked PRs, or issue-only.
+   - Identify verification matrix.
+   - Identify blocked decisions.
+3. Implementation:
+   - Orchestrator edits files.
+   - Subagents, if available, only analyze/review and return findings.
+   - Preserve unrelated changes.
+4. Verification:
+   - Run focused tests first.
+   - Run broader tests/build/lint as required.
+   - Run visual QA for visual work.
+   - Use MySQL MCP for DB-backed validation.
+5. Review:
+   - Blind Hunter.
+   - Edge Case Hunter.
+   - Acceptance Auditor.
+   - Fix high/medium findings before PR.
+6. GitHub:
+   - Push branch.
+   - Open PR with summary, linked issues, tests, risks.
+   - Wait for checks.
+   - Merge only if checks and review requirements pass.
+7. Final report:
+   - Issues.
+   - Branches.
+   - PR URLs.
+   - Tests run.
+   - Review findings.
+   - Merge result.
+   - Remaining risks.
+
+Implementation details:
+- Include a compact default prompt inside the skill.
+- Include rules for stacked PRs:
+  - base first PR on target branch
+  - stack dependent PRs only when review isolation is valuable
+  - retarget/rebase each PR after dependency merge
+  - wait for fresh CI before merge
+- Include environment-friction behavior:
+  - if app setup fails, run project doctor
+  - do not continue claiming visual verification without visual QA evidence
+
+Verification:
+- Dry-run the skill against a completed issue without editing files.
+- Confirm it produces the expected plan and verification matrix.
+
+Acceptance criteria:
+- Future agents no longer need custom long orchestration prompts.
+- The skill preserves the project branch, review, and CI rules.
+- The skill distinguishes analysis subagents from the editing orchestrator.
+```
+
+## Stage 6 - Prompt Template Library
+
+Goal: make good prompts reusable without requiring the user to recreate them.
+
+Recommended artifact:
+
+- `docs/operations/agent-prompt-templates.md`
+
+### Prompt
+
+```text
+You are implementing Stage 6 - prompt template library.
+
+Objective:
+Create a compact prompt-template document for recurring InEx agent workflows.
+
+Read first:
+- `AGENTS.md`
+- `docs/operations/github-issue-guidelines.md`
+- This document
+
+Create:
+- `docs/operations/agent-prompt-templates.md`
+
+Templates to include:
+1. Starting an implementation task.
+2. Requesting investigation before coding.
+3. Asking for a code review.
+4. Asking for architecture critique.
+5. Asking for frontend visual work.
+6. Asking for GitHub issue creation.
+7. Asking for database-backed validation.
+8. Asking for session retrospective.
+9. Asking for BMAD delivery.
+10. Asking for visual QA evidence refresh.
+
+For each template include:
+- When to use.
+- Prompt text.
+- Required inputs.
+- Expected output.
+- Verification requirements.
+- Stop conditions.
+
+Implementation details:
+- Keep templates concrete and copy-pasteable.
+- Include placeholders such as `<issue-number>`, `<story-file>`, `<route>`, `<page>`.
+- Avoid long explanations.
+- Link to detailed docs instead of duplicating them.
+
+Verification:
+- Confirm templates do not conflict with AGENTS rules.
+- Confirm GitHub issue template is public-safe.
+- Confirm DB validation template says MySQL MCP first.
+
+Acceptance criteria:
+- A user can start common workflows by copying one prompt.
+- The prompts encode the audit improvements.
+- The document stays short enough to scan quickly.
+```
+
+## Stage 7 - Retrospective Loop And Maintenance Automation
+
+Goal: turn repeated friction into durable improvements rather than one-off memory.
+
+Recommended artifacts:
+
+- Skill or checklist: `inex-session-retrospective`
+- Optional doc: `docs/operations/session-retrospective-checklist.md`
+
+### Prompt
+
+```text
+You are implementing Stage 7 - session retrospective loop.
+
+Objective:
+Create a lightweight retrospective workflow that audits completed AI-assisted sessions and proposes durable improvements.
+
+Read first:
+- `AGENTS.md`
+- Existing operations docs
+- Recent examples of completed session artifacts if available
+
+Create one of:
+- Skill: `inex-session-retrospective`
+- Minimum doc: `docs/operations/session-retrospective-checklist.md`
+
+Trigger conditions:
+- Session lasted more than 60 minutes.
+- Two or more environment/tool blockers occurred.
+- A PR needed multiple review-fix rounds.
+- A visual QA task could not produce screenshots.
+- A new rule was discovered during implementation.
+- User explicitly asks for a retrospective.
+
+Checklist:
+1. What caused time loss?
+2. Was the task scoped correctly?
+3. Did the agent use the strongest available tool?
+4. Were docs or AGENTS missing a durable rule?
+5. Was verification sufficient and early enough?
+6. Did visual QA use fixture/live data correctly?
+7. Did DB validation use MySQL MCP first?
+8. Were GitHub issues public-safe and correctly labeled?
+9. What should be automated?
+10. What should not be added because it is too task-specific?
+
+Output format:
+- Findings.
+- Evidence.
+- Durable fix.
+- Recommended artifact: AGENTS/doc/script/skill/MCP/plugin.
+- Priority.
+- Exact follow-up prompt.
+
+Implementation details:
+- Prefer one concrete follow-up per repeated friction pattern.
+- Do not suggest AGENTS bloat for one-off issues.
+- Separate local environment fixes from repo changes.
+
+Verification:
+- Run the checklist against one completed thread summary.
+- Confirm it produces actionable follow-up work, not a generic essay.
+
+Acceptance criteria:
+- A future agent can run a retrospective and produce implementation-ready follow-up prompts.
+- Repeated issues become scripts, skills, or docs.
+- One-off issues remain notes, not permanent rules.
+```
+
+## Recommended Delivery Plan
+
+### PR 1 - `feature/project-doctor-and-agent-rules`
+
+Includes:
+- Stage 1
+- Stage 2
+
+Why first:
+- Prevents immediate environment and tool-use friction.
+- Establishes rules that later agents follow.
+
+Verification:
+- Run project doctor.
+- Docs review only for AGENTS changes.
+
+### PR 2 - `docs/issue-shaper-and-prompt-templates`
+
+Includes:
+- Stage 3 checklist or skill
+- Stage 6 prompt template library
+
+Why second:
+- Improves issue quality before more implementation work starts.
+
+Verification:
+- Dry-run issue shaping against an existing UI audit.
+
+### PR 3 - `feature/frontend-visual-qa-harness`
+
+Includes:
+- Stage 4 for one page only
+
+Why third:
+- Highest-value but most implementation-heavy.
+- Benefits from the doctor and prompt templates.
+
+Verification:
+- Run visual QA command.
+- Confirm screenshots and `qa-summary.json`.
+
+### PR 4 - `feature/bmad-delivery-orchestrator`
+
+Includes:
+- Stage 5
+
+Why fourth:
+- Depends on issue shaping and verification rules.
+
+Verification:
+- Dry-run against a completed issue.
+
+### PR 5 - `docs/session-retrospective-loop`
+
+Includes:
+- Stage 7
+
+Why last:
+- Retrospective workflow should reference the other new artifacts.
+
+Verification:
+- Run against one representative completed session.
+
+## Prompt For A Full Agent Team
+
+Use this only after deciding to implement all stages:
+
+```text
+Run a staged implementation of `docs/operations/ai-session-effectiveness-implementation-prompts.md`.
+
+Rules:
+- Follow the stage order.
+- Keep PRs grouped as recommended in the Delivery Plan.
+- Do not start with the visual QA harness until the project doctor and AGENTS rules are done.
+- Preserve unrelated worktree changes.
+- Use MySQL MCP first for read-only DB checks.
+- Use GitHub connector for issue/PR operations where available.
+- For each stage, report:
+  - files changed
+  - verification run
+  - blockers
+  - whether the next stage can start
+
+Begin with Stage 0 and PR 1 only. Stop after PR 1 unless explicitly told to continue.
+```

--- a/docs/operations/github-issue-guidelines.md
+++ b/docs/operations/github-issue-guidelines.md
@@ -1,0 +1,170 @@
+# GitHub Issue Guidelines
+
+Use these rules when creating, editing, triaging, or consolidating GitHub issues for InEx.
+
+## Public-Safe Content
+
+Issue content must be safe to publish in the repository.
+
+Do not include:
+
+- Local absolute paths such as `C:\Users\artio\...`, `/c/Users/artio/...`, `D:\work\inex\...`, or `AppData\Local\Temp\...`.
+- Local-only evidence URLs such as `http://localhost:3000/...`.
+- Credentials, tokens, connection strings, `.env` values, browser storage, or user-local details.
+
+Prefer repo-relative paths:
+
+```text
+inex/ClientApp/src/pages/Accounts.tsx
+```
+
+For screenshots captured locally, write:
+
+```text
+Screenshot captured during local visual QA; local filesystem path intentionally omitted.
+```
+
+## Titles
+
+Issue titles should start with an action verb.
+
+Good examples:
+
+- Fix transfer ownership enforcement when creating transfers
+- Define Accounts visual QA fixture and default expanded groups
+- Align Transactions toolbar and action layout
+- Tighten Budgets row density and expand affordance
+- Split AccountResponse from account request inheritance
+- Rename frontend report DTO interfaces
+
+Avoid:
+
+- Prefixes like `fix(...)`, `refactor(...)`, or `docs(...)`.
+- Prefixes like `[Feature]`.
+- Vague nouns without an action.
+
+## Labels
+
+Keep issue classification simple: one type label plus one priority label.
+
+Allowed non-priority labels:
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `refactor`
+- `duplicate`
+- `question`
+
+Every open issue should have exactly one priority label:
+
+- `priority:critical`
+- `priority:high`
+- `priority:medium`
+- `priority:low`
+
+Priority meanings:
+
+- `priority:critical`: security, data isolation, data loss, or production outage risk.
+- `priority:high`: user-visible correctness issue, blocking product/API/UX decision, or important shared architecture/API contract problem.
+- `priority:medium`: normal planned implementation, visual parity, contract hardening, or meaningful UX/product quality work.
+- `priority:low`: documentation, naming cleanup, small refactor, or low-risk maintenance.
+
+Do not attach custom taxonomy labels to open issues unless the project explicitly changes the issue taxonomy.
+
+Avoid labels such as:
+
+- `area:*`
+- `domain:*`
+- `kind:*`
+- `source:*`
+- old `priority:p1`, `priority:p2`, or `priority:p3`
+
+## Type Label Selection
+
+Use `question` for issues that primarily require a product, QA, or architecture decision before implementation.
+
+Examples:
+
+- visual QA fixture baseline
+- locale/period/data baseline decision
+- navigation/shell policy
+- API/reporting contract decision
+
+Use `enhancement` for visual alignment and product improvement work unless it is a clear defect.
+
+Examples:
+
+- Align Categories hero spend and distribution with mockup
+- Tighten Accounts table rows and replace row-level share bars
+
+Use `bug` for incorrect behavior, security/correctness risks, broken calculations, wrong currency handling, or regressions.
+
+Examples:
+
+- hardcoded currency
+- missing ownership enforcement
+- incorrect response date mapping
+- broken metadata initialization
+
+Use `refactor` for internal structure, naming, inheritance cleanup, code organization, or non-behavioral technical debt.
+
+Examples:
+
+- DTO/interface renames
+- response/request inheritance split
+- mapping simplification
+- naming collision cleanup
+
+Use `documentation` for docs, client regeneration, or checklist work where implementation behavior does not change.
+
+Use `duplicate` only when closing or marking an issue that is superseded by another canonical issue.
+
+## Duplicate And Intersecting Issues
+
+- Consolidate true duplicates into one canonical issue.
+- Close duplicates with the `duplicate` label if appropriate.
+- Add a short comment explaining which issue supersedes the duplicate.
+- If issues are similar but intentionally separate, clarify scope in each issue instead of closing.
+
+Example: Accounts and Categories request/response inheritance cleanup can remain separate if each issue explicitly says it is domain-specific.
+
+## Shared Shell And Cross-Page UI Findings
+
+- Do not create one duplicate shell issue per page.
+- Create or keep one shared issue for global shell, navigation, header, logo, logout, or app-wide chrome concerns.
+- Page-specific issues should focus only on page content: cards, toolbar, table, rows, charts, forms, and page-local states.
+
+## Visual QA Issues
+
+- Separate structural/layout defects from fixture, data, date, and locale differences.
+- Do not report raw value, name, or date differences as bugs when screenshots use different datasets or periods.
+- Create a `question` issue for fixture or baseline decisions when needed.
+- For local screenshots, omit local filesystem paths and use the approved local visual QA wording.
+
+Visual QA issues should include:
+
+- Expected behavior.
+- Actual behavior.
+- Repo-relative source references.
+- Scope.
+- Acceptance criteria.
+- Blockers or decisions, if applicable.
+
+## Evidence
+
+- Keep useful source references.
+- Use repo-relative paths with line hints where possible.
+- Avoid environment-specific paths.
+- Avoid sensitive or user-local details unless they are essential and safe.
+
+## Open Issue Hygiene
+
+Each issue should be uniquely scoped and have:
+
+- An action-title.
+- One allowed type label.
+- One priority label.
+- Clear expected/actual/follow-up details or acceptance criteria.
+
+Avoid mixing decision work, implementation work, and test-only work in one issue unless intentionally grouped.

--- a/docs/operations/project-doctor.md
+++ b/docs/operations/project-doctor.md
@@ -1,0 +1,39 @@
+# Project Doctor
+
+`scripts/doctor.ps1` is a non-destructive readiness check for local investigation and implementation sessions. It does not start the app, run Docker, call external APIs, read `.env` files, or print secrets.
+
+Run from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/doctor.ps1 -All
+```
+
+Focused checks:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/doctor.ps1 -Ui
+powershell -ExecutionPolicy Bypass -File scripts/doctor.ps1 -Backend
+powershell -ExecutionPolicy Bypass -File scripts/doctor.ps1 -Db
+powershell -ExecutionPolicy Bypass -File scripts/doctor.ps1 -GitHub
+```
+
+No switch defaults to `-All`.
+
+## Result States
+
+- `PASS`: required local prerequisite is present.
+- `FAIL`: selected check is not ready; the script exits non-zero.
+- `WARN`: investigate before proceeding, but the script does not fail on this row.
+- `INFO`: reported state only.
+
+Occupied ports are warnings because an existing dev server may be intentional. Confirm the listener is expected before starting another UI or backend process.
+
+## DB MCP Verification
+
+PowerShell cannot call Codex MCP tools directly. The DB check confirms that the project-local MCP files exist without reading their contents, then reminds Codex agents to verify the server through MCP before DB work:
+
+```sql
+SELECT 1 AS ok
+```
+
+Run that query through `mcp_server_mysql.mysql_query` or `mysql_query` from the Codex MCP environment. Do not use Docker, local `mysql`, migrations, or application startup as the first DB verification path.

--- a/inex/ClientApp/AGENTS.md
+++ b/inex/ClientApp/AGENTS.md
@@ -1,0 +1,52 @@
+# InEx Frontend Agent Instructions
+
+These instructions apply to frontend work under `inex/ClientApp`.
+
+## Stack
+
+- React 18, TypeScript strict, Vite, Redux Toolkit, Ant Design v5, React Router 6, react-i18next, dayjs, Recharts.
+- Check installed package versions before using newer library APIs.
+- Do not add, remove, or upgrade frontend dependencies unless the active story explicitly requires it.
+
+## API And State
+
+- Authenticated API calls must go through `utils/apiClient.ts`; do not create raw authenticated `axios` clients or use `fetch` for app API calls.
+- Preserve auth header injection and refresh-token retry behavior owned by `apiClient`.
+- Parse API errors through existing helpers such as `parseApiError.ts` and `parseAxiosError.ts`.
+- Use `useAppDispatch` and `useAppSelector` from `store/hooks.ts`; avoid raw Redux hooks.
+- Redux slices/thunks and RTK Query APIs may coexist. Follow the existing domain-specific pattern instead of migrating state architecture opportunistically.
+- Keep local form/UI state component-local unless it is reused across views.
+
+## Routing And i18n
+
+- Keep protected UI routes behind `ProtectedRoute`; server-side authorization remains authoritative.
+- Do not add React Router data loaders/actions without an explicit router upgrade.
+- All user-visible strings must go through `useTranslation()` and locale files for every supported language.
+- English is the visual parity baseline; Russian is a long-label responsive stress test.
+- Use `dayjs`; do not reintroduce `moment`.
+
+## Design And Visual QA
+
+- Use `docs/design/docs/design-implementation-guide.md` and `docs/design/*` as visual references only.
+- Do not import from mockup `.jsx` files under `docs/design`; convert needed patterns into typed production React modules.
+- Use shared tokens and primitives before page-local styling.
+- Do not start rebranding by editing individual page cards.
+- Money values must use tabular numerics and explicit income/expense/transfer semantics. Do not rely on color alone.
+- Icon-only controls, drawers, menus, tabs, segmented controls, mobile navigation, and chart summaries must remain keyboard accessible and screen-reader labeled.
+- For converted visual routes, check relevant 1440px, 1024px, 390px, and 360px states.
+- Horizontal overflow, clipped controls, bottom-nav occlusion, overlapping text, and blank charts are acceptance failures.
+- Visual QA may use fixture or live-seed data, but the QA record must identify the data mode. Do not treat raw value/date/name differences as defects when datasets differ.
+
+## Commands
+
+Run from `inex/ClientApp`:
+
+```powershell
+npm run build
+npm run lint
+npm start
+```
+
+- Run `npm run build` and `npm run lint` for frontend changes unless the task or environment makes that infeasible.
+- If a frontend test script or targeted Vitest command is relevant, run it in addition to build/lint.
+- Do not commit generated build output from `build/`.

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -1,0 +1,267 @@
+param(
+    [switch]$Ui,
+    [switch]$Backend,
+    [switch]$Db,
+    [switch]$GitHub,
+    [switch]$All
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Checks = [System.Collections.Generic.List[object]]::new()
+$script:RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+
+function Write-Check {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Area,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('PASS', 'FAIL', 'WARN', 'INFO')]
+        [string]$Status,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Hint
+    )
+
+    $script:Checks.Add([pscustomobject]@{
+        Area = $Area
+        Check = $Name
+        State = $Status
+        Remediation = $Hint
+    })
+}
+
+function Test-CommandExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Test-PortListening {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$Port
+    )
+
+    try {
+        if (Test-CommandExists 'Get-NetTCPConnection') {
+            $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            return $null -ne $connection
+        }
+    }
+    catch {
+        # Fall back below when Get-NetTCPConnection is unavailable or restricted.
+    }
+
+    try {
+        $pattern = "^\s*TCP\s+\S+:$Port\s+\S+\s+LISTENING\s+"
+        $connection = netstat -ano -p tcp 2>$null | Select-String -Pattern $pattern | Select-Object -First 1
+        return $null -ne $connection
+    }
+    catch {
+        Write-Check 'Port' "Port $Port listener check" 'WARN' 'Unable to inspect TCP listeners in this shell.'
+        return $false
+    }
+}
+
+function Write-PortCheck {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Area,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Port
+    )
+
+    if (Test-PortListening $Port) {
+        Write-Check $Area "Port $Port listening" 'WARN' 'Port is occupied; confirm it is the expected local dev process before starting another server.'
+    }
+    else {
+        Write-Check $Area "Port $Port listening" 'INFO' 'Not listening.'
+    }
+}
+
+function Test-Ui {
+    $clientRoot = Join-Path $script:RepoRoot 'inex\ClientApp'
+    $packagePath = Join-Path $clientRoot 'package.json'
+    $viteShimPath = Join-Path $clientRoot 'node_modules\.bin\vite.cmd'
+
+    if (Test-Path -LiteralPath $packagePath -PathType Leaf) {
+        Write-Check 'UI' 'package.json exists' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'UI' 'package.json exists' 'FAIL' 'Restore inex/ClientApp/package.json before frontend work.'
+    }
+
+    if (Test-CommandExists 'npm') {
+        Write-Check 'UI' 'npm command available' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'UI' 'npm command available' 'FAIL' 'Install Node.js/npm and reopen the shell.'
+    }
+
+    if (Test-Path -LiteralPath $viteShimPath -PathType Leaf) {
+        Write-Check 'UI' 'Vite Windows command shim exists' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'UI' 'Vite Windows command shim exists' 'FAIL' 'Run npm install from inex/ClientApp before npm start.'
+    }
+
+    if (Test-Path -LiteralPath $packagePath -PathType Leaf) {
+        try {
+            $package = Get-Content -LiteralPath $packagePath -Raw | ConvertFrom-Json
+            $scriptNames = @()
+
+            if (($package.PSObject.Properties.Name -contains 'scripts') -and $null -ne $package.scripts) {
+                $scriptNames = @($package.scripts.PSObject.Properties.Name)
+            }
+
+            $requiredScripts = @('start', 'build', 'lint')
+            $missingScripts = @($requiredScripts | Where-Object { $scriptNames -notcontains $_ })
+
+            if ($missingScripts.Count -eq 0) {
+                Write-Check 'UI' 'frontend scripts start/build/lint' 'PASS' 'OK.'
+            }
+            else {
+                Write-Check 'UI' 'frontend scripts start/build/lint' 'FAIL' ("Add missing scripts: {0}." -f ($missingScripts -join ', '))
+            }
+        }
+        catch {
+            Write-Check 'UI' 'frontend scripts start/build/lint' 'FAIL' 'package.json could not be parsed as JSON.'
+        }
+    }
+
+    foreach ($port in @(3000, 5173, 5177)) {
+        Write-PortCheck 'UI' $port
+    }
+}
+
+function Test-Backend {
+    if (Test-CommandExists 'dotnet') {
+        Write-Check 'Backend' 'dotnet command available' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'Backend' 'dotnet command available' 'FAIL' 'Install the .NET SDK and reopen the shell.'
+    }
+
+    $solutions = @(Get-ChildItem -LiteralPath $script:RepoRoot -Filter '*.sln' -File -ErrorAction SilentlyContinue)
+    if ($solutions.Count -gt 0) {
+        Write-Check 'Backend' 'solution file exists' 'PASS' ("Found {0}." -f ($solutions[0].Name))
+    }
+    else {
+        Write-Check 'Backend' 'solution file exists' 'FAIL' 'Restore the solution file at the repository root.'
+    }
+
+    Write-PortCheck 'Backend' 5000
+
+    $processes = @(Get-Process -Name 'inex' -ErrorAction SilentlyContinue)
+    if ($processes.Count -gt 0) {
+        $processIds = ($processes | Select-Object -ExpandProperty Id) -join ', '
+        Write-Check 'Backend' 'running inex processes' 'WARN' ("Detected process id(s) {0}; stop manually only if build outputs are locked." -f $processIds)
+    }
+    else {
+        Write-Check 'Backend' 'running inex processes' 'PASS' 'No likely app process locks detected.'
+    }
+}
+
+function Test-Db {
+    $mcpConfigPath = Join-Path $script:RepoRoot '.codex\config.toml'
+    $mysqlMcpEntryPoint = Join-Path $script:RepoRoot '.mcp-local\mysql\node_modules\@benborla29\mcp-server-mysql\dist\index.js'
+
+    if (Test-Path -LiteralPath $mcpConfigPath -PathType Leaf) {
+        Write-Check 'DB' 'project Codex MCP config exists' 'PASS' 'OK. Contents were not read.'
+    }
+    else {
+        Write-Check 'DB' 'project Codex MCP config exists' 'FAIL' 'Create .codex/config.toml from docs/operations/codex-mcp.md; do not commit it.'
+    }
+
+    if (Test-Path -LiteralPath $mysqlMcpEntryPoint -PathType Leaf) {
+        Write-Check 'DB' 'MySQL MCP package entry point exists' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'DB' 'MySQL MCP package entry point exists' 'FAIL' 'Install @benborla29/mcp-server-mysql as described in docs/operations/codex-mcp.md.'
+    }
+
+    Write-Check 'DB' 'MCP query verification' 'WARN' 'PowerShell cannot call Codex MCP tools directly; Codex agents must run SELECT 1 AS ok through mysql_query before DB work.'
+}
+
+function Test-GitHub {
+    if (Test-CommandExists 'gh') {
+        Write-Check 'GitHub' 'gh command available' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'GitHub' 'gh command available' 'FAIL' 'Install GitHub CLI and reopen the shell.'
+        return
+    }
+
+    $authStatusExitCode = 1
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        & gh auth status 1>$null 2>$null
+        $authStatusExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    if ($authStatusExitCode -eq 0) {
+        Write-Check 'GitHub' 'gh auth status succeeds' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'GitHub' 'gh auth status succeeds' 'FAIL' 'Run gh auth login -h github.com, then rerun this check.'
+    }
+}
+
+function Show-Results {
+    $header = "{0,-8} {1,-38} {2,-5} {3}" -f 'Area', 'Check', 'State', 'Remediation'
+    $divider = "{0,-8} {1,-38} {2,-5} {3}" -f '----', '-----', '-----', '-----------'
+
+    Write-Host $header
+    Write-Host $divider
+
+    foreach ($check in $script:Checks) {
+        Write-Host ("{0,-8} {1,-38} {2,-5} {3}" -f $check.Area, $check.Check, $check.State, $check.Remediation)
+    }
+
+    $failed = @($script:Checks | Where-Object { $_.State -eq 'FAIL' })
+    $warnings = @($script:Checks | Where-Object { $_.State -eq 'WARN' })
+
+    Write-Host ''
+    Write-Host ("Summary: {0} failed, {1} warning(s), {2} total check(s)." -f $failed.Count, $warnings.Count, $script:Checks.Count)
+
+    if ($failed.Count -gt 0) {
+        exit 1
+    }
+
+    exit 0
+}
+
+$runEverything = $All -or (-not $Ui -and -not $Backend -and -not $Db -and -not $GitHub)
+
+if ($runEverything -or $Ui) {
+    Test-Ui
+}
+
+if ($runEverything -or $Backend) {
+    Test-Backend
+}
+
+if ($runEverything -or $Db) {
+    Test-Db
+}
+
+if ($runEverything -or $GitHub) {
+    Test-GitHub
+}
+
+Show-Results


### PR DESCRIPTION
## Summary
- Add concise root AGENTS.md session workflow rules for UI/browser preflight, visual QA evidence, large UI finding grouping, and durable friction follow-up.
- Add tool-priority guidance for MySQL MCP-first DB inspection and GitHub connector-first issue/PR operations.
- Add the non-destructive project doctor script and operations doc, with .gitignore allowlisting for scripts/doctor.ps1.

## Validation
- Searched for duplicate/conflicting MySQL MCP, GitHub issue, visual QA, and frontend command rules.
- Confirmed AGENTS.md remains compact at 141 lines after the Stage 2 update.
- Parsed scripts/doctor.ps1 with the PowerShell parser: syntax ok.

## Notes
- Remote branch prod does not exist; this PR targets the repository default branch master.
- Did not run full project doctor because local gh auth is currently invalid in this checkout.