### PR TITLE
Add issue shaper skill

### DIFF
--- a/.agents/skills/inex-issue-shaper/SKILL.md
+++ b/.agents/skills/inex-issue-shaper/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: inex-issue-shaper
+description: Turn raw InEx audits, screenshot mismatch lists, code review findings, or issue lists into public-safe scoped GitHub issue drafts and PR grouping advice. Use when the user says "verify these issues", "convert findings into GitHub issues", "suggest PR grouping", or "audit screenshot mismatch list".
+---
+
+# InEx Issue Shaper
+
+## Required Context
+
+Read [GitHub issue guidelines](../../../docs/operations/github-issue-guidelines.md) before drafting issues. For UI audit work, also inspect the relevant source under `docs/ui-audit/` and identify the route, page, or domain each finding came from.
+
+## Intake
+
+Accept raw findings, screenshots, mismatch lists, review comments, or audit docs. Normalize each finding into:
+
+- Source: route, page, feature domain, or component.
+- Evidence: repo-relative source paths, safe screenshot wording, or audit doc reference.
+- Owner: shared shell/navigation, page-local UI, data/fixture/locale, backend/API, tests, docs, or product decision.
+- Status: one of the classification values below.
+
+Never include local absolute paths, localhost URLs, credentials, tokens, `.env` values, browser storage, or test account secrets. For screenshots, write exactly: `Screenshot captured during local visual QA; local filesystem path intentionally omitted.`
+
+## Classification
+
+Use exactly one classification per finding:
+
+- `Confirmed`: current behavior is verified and implementation-owned.
+- `Partial`: some evidence is current, but scope or reproduction is incomplete.
+- `Not current`: the finding no longer reproduces or has already been addressed.
+- `Product decision`: the right behavior requires product, UX, QA, or architecture direction.
+- `Fixture/data/locale`: difference is driven by seed data, visual QA baseline, period, currency, or language.
+- `Blocked`: cannot classify or scope without missing evidence, environment access, or an external decision.
+
+## Grouping Rules
+
+Group by implementation ownership, not by visual symptom. Separate shared shell/navigation from page-local work. Keep fixture, data, period, currency, and locale decisions out of structural UI bugs. Do not create one issue per pixel difference or per repeated occurrence of the same shared component defect.
+
+Target 3-7 issue drafts for a 25-30 item UI list. Fewer is acceptable when findings collapse into shared ownership; more needs a clear ownership or dependency reason.
+
+## Issue Draft Template
+
+```md
+### <Action-verb title>
+
+Labels: `<type label>`, `<priority label>`
+Classification: `Confirmed|Partial|Not current|Product decision|Fixture/data/locale|Blocked`
+
+Problem:
+Expected behavior:
+Current behavior:
+Evidence:
+- <repo-relative path, audit doc section, or approved screenshot wording>
+Scope:
+Acceptance criteria:
+- <observable outcome>
+Blockers/decisions:
+- <none, or explicit decision needed>
+```
+
+Use exactly one type label from `bug`, `enhancement`, `documentation`, `refactor`, `duplicate`, or `question`, and exactly one priority label from `priority:critical`, `priority:high`, `priority:medium`, or `priority:low`. Titles must start with an action verb and must not use prefixes such as `fix(...)`, `refactor(...)`, `docs(...)`, or `[Feature]`.
+
+## PR Grouping Output
+
+After issue drafts, include compact PR grouping:
+
+```md
+PR grouping:
+- `<branch-name>`: <issue titles>; dependencies: <none or issue/decision>; parallel: <yes/no>; conflict risks: <shared files>
+```
+
+Branch names must use `feature/`, `fix/`, `refactor/`, or `docs/`; never use `codex/`. Identify dependencies, work that can run in parallel, and likely shared-file conflicts such as `AppShell`, locale files, shared primitives, CSS modules, API clients, or fixtures.
+
+## Compact Output Format
+
+When the user asks for a concise pass, output only:
+
+1. `Classification summary`: counts by classification.
+2. `Issue drafts`: grouped drafts using the template.
+3. `Not filed`: findings marked `Not current`, duplicate, or intentionally absorbed into another draft.
+4. `PR grouping`: branch names, dependencies, parallelization, and conflict risks.
+5. `Safety check`: confirm no local absolute paths, localhost URLs, credentials, or screenshot paths are present.
+
+## Final Checks
+
+Before returning issue drafts, confirm:
+
+- The number of issue drafts is lower than the raw finding count unless every finding is uniquely owned.
+- Shared shell/navigation appears in one shared issue, not repeated page tickets.
+- Product, fixture, data, and locale decisions are `question` issues unless implementation is already decided.
+- Evidence uses repo-relative paths or approved screenshot wording only.
+- Each open issue has one allowed type label and one priority label.

--- a/docs/operations/github-issue-guidelines.md
+++ b/docs/operations/github-issue-guidelines.md
@@ -1,0 +1,170 @@
+# GitHub Issue Guidelines
+
+Use these rules when creating, editing, triaging, or consolidating GitHub issues for InEx.
+
+## Public-Safe Content
+
+Issue content must be safe to publish in the repository.
+
+Do not include:
+
+- Local absolute paths such as `C:\Users\artio\...`, `/c/Users/artio/...`, `D:\work\inex\...`, or `AppData\Local\Temp\...`.
+- Local-only evidence URLs such as `http://localhost:3000/...`.
+- Credentials, tokens, connection strings, `.env` values, browser storage, or user-local details.
+
+Prefer repo-relative paths:
+
+```text
+inex/ClientApp/src/pages/Accounts.tsx
+```
+
+For screenshots captured locally, write:
+
+```text
+Screenshot captured during local visual QA; local filesystem path intentionally omitted.
+```
+
+## Titles
+
+Issue titles should start with an action verb.
+
+Good examples:
+
+- Fix transfer ownership enforcement when creating transfers
+- Define Accounts visual QA fixture and default expanded groups
+- Align Transactions toolbar and action layout
+- Tighten Budgets row density and expand affordance
+- Split AccountResponse from account request inheritance
+- Rename frontend report DTO interfaces
+
+Avoid:
+
+- Prefixes like `fix(...)`, `refactor(...)`, or `docs(...)`.
+- Prefixes like `[Feature]`.
+- Vague nouns without an action.
+
+## Labels
+
+Keep issue classification simple: one type label plus one priority label.
+
+Allowed non-priority labels:
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `refactor`
+- `duplicate`
+- `question`
+
+Every open issue should have exactly one priority label:
+
+- `priority:critical`
+- `priority:high`
+- `priority:medium`
+- `priority:low`
+
+Priority meanings:
+
+- `priority:critical`: security, data isolation, data loss, or production outage risk.
+- `priority:high`: user-visible correctness issue, blocking product/API/UX decision, or important shared architecture/API contract problem.
+- `priority:medium`: normal planned implementation, visual parity, contract hardening, or meaningful UX/product quality work.
+- `priority:low`: documentation, naming cleanup, small refactor, or low-risk maintenance.
+
+Do not attach custom taxonomy labels to open issues unless the project explicitly changes the issue taxonomy.
+
+Avoid labels such as:
+
+- `area:*`
+- `domain:*`
+- `kind:*`
+- `source:*`
+- old `priority:p1`, `priority:p2`, or `priority:p3`
+
+## Type Label Selection
+
+Use `question` for issues that primarily require a product, QA, or architecture decision before implementation.
+
+Examples:
+
+- visual QA fixture baseline
+- locale/period/data baseline decision
+- navigation/shell policy
+- API/reporting contract decision
+
+Use `enhancement` for visual alignment and product improvement work unless it is a clear defect.
+
+Examples:
+
+- Align Categories hero spend and distribution with mockup
+- Tighten Accounts table rows and replace row-level share bars
+
+Use `bug` for incorrect behavior, security/correctness risks, broken calculations, wrong currency handling, or regressions.
+
+Examples:
+
+- hardcoded currency
+- missing ownership enforcement
+- incorrect response date mapping
+- broken metadata initialization
+
+Use `refactor` for internal structure, naming, inheritance cleanup, code organization, or non-behavioral technical debt.
+
+Examples:
+
+- DTO/interface renames
+- response/request inheritance split
+- mapping simplification
+- naming collision cleanup
+
+Use `documentation` for docs, client regeneration, or checklist work where implementation behavior does not change.
+
+Use `duplicate` only when closing or marking an issue that is superseded by another canonical issue.
+
+## Duplicate And Intersecting Issues
+
+- Consolidate true duplicates into one canonical issue.
+- Close duplicates with the `duplicate` label if appropriate.
+- Add a short comment explaining which issue supersedes the duplicate.
+- If issues are similar but intentionally separate, clarify scope in each issue instead of closing.
+
+Example: Accounts and Categories request/response inheritance cleanup can remain separate if each issue explicitly says it is domain-specific.
+
+## Shared Shell And Cross-Page UI Findings
+
+- Do not create one duplicate shell issue per page.
+- Create or keep one shared issue for global shell, navigation, header, logo, logout, or app-wide chrome concerns.
+- Page-specific issues should focus only on page content: cards, toolbar, table, rows, charts, forms, and page-local states.
+
+## Visual QA Issues
+
+- Separate structural/layout defects from fixture, data, date, and locale differences.
+- Do not report raw value, name, or date differences as bugs when screenshots use different datasets or periods.
+- Create a `question` issue for fixture or baseline decisions when needed.
+- For local screenshots, omit local filesystem paths and use the approved local visual QA wording.
+
+Visual QA issues should include:
+
+- Expected behavior.
+- Actual behavior.
+- Repo-relative source references.
+- Scope.
+- Acceptance criteria.
+- Blockers or decisions, if applicable.
+
+## Evidence
+
+- Keep useful source references.
+- Use repo-relative paths with line hints where possible.
+- Avoid environment-specific paths.
+- Avoid sensitive or user-local details unless they are essential and safe.
+
+## Open Issue Hygiene
+
+Each issue should be uniquely scoped and have:
+
+- An action-title.
+- One allowed type label.
+- One priority label.
+- Clear expected/actual/follow-up details or acceptance criteria.
+
+Avoid mixing decision work, implementation work, and test-only work in one issue unless intentionally grouped.


### PR DESCRIPTION
## Summary

- Add the reusable `inex-issue-shaper` Codex skill for converting raw audits, screenshot mismatch lists, code review findings, and issue lists into scoped GitHub issue drafts.
- Add the GitHub issue guidelines document required by the skill so public-safe issue drafting rules are available on `master`.

## Validation

- Ran `git diff --check origin/master...HEAD`.
- Verified the skill link to `docs/operations/github-issue-guidelines.md` resolves on the PR branch.
- Manually dry-ran the workflow against `docs/ui-audit/accounts.md`; 18 raw findings collapse into 6 grouped issue drafts.