### PR TITLE
Enhance UI visual QA doctor and verifier

### DIFF
--- a/.agents/skills/inex-bmad-delivery-orchestrator/SKILL.md
+++ b/.agents/skills/inex-bmad-delivery-orchestrator/SKILL.md
@@ -72,6 +72,7 @@ Run InEx BMAD delivery for the referenced GitHub issue(s). Intake issues and rel
 - Frontend changes: run relevant tests, `npm run lint`, and `npm run build` from `inex/ClientApp/` as applicable.
 - DB/schema/provider/concurrency changes: use MySQL MCP for read-only validation before Docker, local MySQL, migrations, or connection-string fallbacks.
 - Visual work: run project doctor before UI/browser work if available, capture visual QA evidence, and do not claim visual verification without evidence.
+- After `npm run visual-qa:all`, run `npm run visual-qa:verify` from `inex/ClientApp/` and include its concise PASS/FAIL result in the verification report. If only a page-specific harness ran, state that the full-suite verifier was not applicable.
 - Do not start the application or call live external/paid providers unless explicitly approved.
 - If app setup fails, run the project doctor and report setup blockers before continuing.
 

--- a/docs/implementation/visual-qa/README.md
+++ b/docs/implementation/visual-qa/README.md
@@ -16,6 +16,7 @@ npm run visual-qa:hero-consistency
 npm run visual-qa:profile
 npm run visual-qa:reports
 npm run visual-qa:transactions
+npm run visual-qa:verify
 ```
 
 Output is refreshed under:
@@ -36,6 +37,19 @@ Each output folder contains:
 - `qa-summary.json` with viewport metrics, overflow checks, mobile bottom-nav checks, request logs, and `dataMode: fixture`
 
 The command does not require a real user password and does not call the real backend. Any unhandled `/api` request is failed by the harness with HTTP 502 and recorded in `qa-summary.json`.
+
+After refreshing the full suite, run:
+
+```powershell
+npm run visual-qa:all
+npm run visual-qa:verify
+```
+
+`visual-qa:verify` reads only the canonical summary folders listed above. It checks required route coverage, `dataMode: fixture`, `checks.hasFailures: false`, `harness.realBackendCalled: false`, `unhandledApiRequests: []`, required screenshot entries/files, and `generatedAt` freshness. The default freshness window is 24 hours; for local diagnostics against older captured evidence, pass an explicit window:
+
+```powershell
+npm run visual-qa:verify -- --max-age-hours=72
+```
 
 Playwright is not currently installed in `inex/ClientApp/package.json`. This first harness uses Chrome DevTools Protocol with a local headless Chrome or Edge executable. If no browser is detected, set `CHROME_PATH` or `EDGE_PATH`; adding Playwright should be handled in a dedicated dependency PR.
 

--- a/docs/operations/agent-prompt-templates.md
+++ b/docs/operations/agent-prompt-templates.md
@@ -338,15 +338,16 @@ Required steps:
 4. Capture required desktop and mobile states.
 5. Check for horizontal overflow and mobile nav occlusion.
 6. Produce or update screenshots and `qa-summary.json`.
-7. Do not claim parity if tooling, fixtures, or browser verification are blocked.
+7. After `npm run visual-qa:all`, run `npm run visual-qa:verify` and include its concise PASS/FAIL result.
+8. Do not claim parity if tooling, fixtures, browser verification, or summary verification are blocked.
 
 Return evidence location, states captured, failures, and gaps.
 ```
 
 **Required inputs:** `<page>`, `<route>`, fixture/baseline doc, output location.
 
-**Expected output:** Refreshed screenshots, `qa-summary.json`, capture summary, blockers or gaps.
+**Expected output:** Refreshed screenshots, `qa-summary.json`, verifier result, capture summary, blockers or gaps.
 
-**Verification requirements:** Doctor run; fixture mode for parity; desktop/mobile captures; overflow and occlusion checks.
+**Verification requirements:** Doctor run; fixture mode for parity; desktop/mobile captures; overflow and occlusion checks; `npm run visual-qa:verify` after full-suite refresh.
 
-**Stop conditions:** Visual QA tooling missing, fixture baseline undecided, app/browser setup blocked, live data would make parity evidence non-deterministic.
+**Stop conditions:** Visual QA tooling missing, fixture baseline undecided, app/browser setup blocked, failing summary verifier, live data would make parity evidence non-deterministic.

--- a/docs/operations/project-doctor.md
+++ b/docs/operations/project-doctor.md
@@ -28,6 +28,19 @@ No switch defaults to `-All`.
 
 Occupied ports are warnings because an existing dev server may be intentional. Confirm the listener is expected before starting another UI or backend process.
 
+## UI Visual QA Runtime Check
+
+The `-Ui` check includes a focused visual QA readiness probe:
+
+- resolves Chrome or Edge from `CHROME_PATH`, `EDGE_PATH`, or standard Windows install paths without printing local browser paths
+- runs the detected browser with `--version` to confirm the shell can spawn it without opening a tab
+- runs local `vite --version` through the project shim to confirm Node can spawn the Vite child process without starting the dev server
+- writes and deletes a doctor-owned temp file under `docs/implementation/visual-qa/` to verify screenshot/summary output access
+- checks the Vite dev port and default visual QA harness ports for existing listeners
+- reports when Codex sandbox escalation is likely needed for Node/Vite/browser process startup
+
+If no browser is detected, install Chrome or Edge, or set `CHROME_PATH` / `EDGE_PATH` to the executable before running visual QA. If Chrome or Edge is installed but visual QA still cannot launch it inside Codex, rerun the visual QA command with sandbox escalation approved.
+
 ## DB MCP Verification
 
 PowerShell cannot call Codex MCP tools directly. The DB check confirms that the project-local MCP files exist without reading their contents, then reminds Codex agents to verify the server through MCP before DB work:

--- a/inex/ClientApp/AGENTS.md
+++ b/inex/ClientApp/AGENTS.md
@@ -45,8 +45,10 @@ Run from `inex/ClientApp`:
 npm run build
 npm run lint
 npm start
+npm run visual-qa:verify
 ```
 
 - Run `npm run build` and `npm run lint` for frontend changes unless the task or environment makes that infeasible.
 - If a frontend test script or targeted Vitest command is relevant, run it in addition to build/lint.
+- After `npm run visual-qa:all`, run `npm run visual-qa:verify` and report its PASS/FAIL summary.
 - Do not commit generated build output from `build/`.

--- a/inex/ClientApp/package.json
+++ b/inex/ClientApp/package.json
@@ -56,6 +56,7 @@
     "visual-qa:profile": "node visual-qa/profile.mjs",
     "visual-qa:reports": "node visual-qa/reports.mjs",
     "visual-qa:transactions": "node visual-qa/transactions.mjs",
+    "visual-qa:verify": "node visual-qa/verify-summaries.mjs",
     "test:watch": "vitest"
   }
 }

--- a/inex/ClientApp/visual-qa/harness.mjs
+++ b/inex/ClientApp/visual-qa/harness.mjs
@@ -587,6 +587,7 @@ export async function runBrowserState({
 
     return {
       ...metrics,
+      routePath,
       pngDimensions,
       requestLog: stateRequestLog,
       consoleMessages: consoleMessages.filter(Boolean),

--- a/inex/ClientApp/visual-qa/verify-summaries.mjs
+++ b/inex/ClientApp/visual-qa/verify-summaries.mjs
@@ -1,0 +1,397 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const clientRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(clientRoot, "../..");
+const visualQaRoot = path.join(repoRoot, "docs/implementation/visual-qa");
+
+const defaultMaxAgeHours = 24;
+
+const canonicalSummaries = [
+  {
+    folder: "accounts",
+    page: "accounts",
+    routes: ["/accounts"],
+    screenshots: [
+      "populated-1440.png",
+      "populated-flat-1024.png",
+      "populated-390.png",
+      "populated-360.png",
+      "filter-empty-390.png",
+      "first-use-empty-390.png",
+      "drawer-open-390.png",
+      "drawer-open-360.png",
+      "expanded-row-1440.png",
+      "expanded-row-390.png",
+      "collapsed-group-1440.png",
+      "collapsed-group-390.png",
+      "load-error-390.png",
+    ],
+  },
+  {
+    folder: "auth",
+    page: "auth",
+    routes: ["/login", "/register"],
+    screenshots: [
+      "login-1440.png",
+      "login-1024.png",
+      "login-390.png",
+      "login-360.png",
+      "login-error-390.png",
+      "register-1440.png",
+      "register-1024.png",
+      "register-390.png",
+      "register-360.png",
+      "register-form-filled-390.png",
+      "register-error-390.png",
+      "register-currency-error-390.png",
+    ],
+  },
+  {
+    folder: "budgets",
+    page: "budgets",
+    routes: ["/budgets?year=2026&month=4"],
+    screenshots: [
+      "populated-1440.png",
+      "populated-amount-1024.png",
+      "populated-390.png",
+      "populated-360.png",
+      "filter-empty-390.png",
+      "first-use-empty-390.png",
+      "drawer-open-390.png",
+      "drawer-open-360.png",
+      "expanded-row-1440.png",
+      "expanded-row-390.png",
+      "load-error-390.png",
+    ],
+  },
+  {
+    folder: "categories",
+    page: "categories",
+    routes: ["/categories"],
+    screenshots: [
+      "populated-1440.png",
+      "populated-spend-1024.png",
+      "populated-390.png",
+      "populated-360.png",
+      "filter-empty-390.png",
+      "first-use-empty-390.png",
+      "drawer-open-390.png",
+      "drawer-open-360.png",
+      "expanded-row-1440.png",
+      "expanded-row-390.png",
+      "load-error-390.png",
+    ],
+  },
+  {
+    folder: "dashboard",
+    page: "dashboard",
+    routes: ["/dashboard"],
+    screenshots: [
+      "populated-1440.png",
+      "populated-1024.png",
+      "populated-390.png",
+      "populated-360.png",
+      "first-use-empty-390.png",
+      "summary-error-390.png",
+      "net-worth-error-390.png",
+      "heatmap-error-390.png",
+    ],
+  },
+  {
+    folder: "hero-consistency",
+    page: "hero-consistency",
+    routes: ["/transactions", "/accounts", "/categories", "/budgets?year=2026&month=4", "/dashboard"],
+    screenshots: [
+      "transactions-hero-1440.png",
+      "accounts-hero-1440.png",
+      "categories-hero-1440.png",
+      "budgets-hero-1440.png",
+      "dashboard-hero-1440.png",
+      "transactions-hero-390.png",
+      "accounts-hero-390.png",
+      "categories-hero-390.png",
+      "budgets-hero-390.png",
+      "dashboard-hero-390.png",
+    ],
+  },
+  {
+    folder: "profile",
+    page: "profile",
+    routes: ["/profile"],
+    screenshots: [
+      "populated-1440.png",
+      "populated-1024.png",
+      "populated-390.png",
+      "populated-360.png",
+      "profile-form-edit-390.png",
+      "security-form-filled-390.png",
+      "currency-error-390.png",
+      "profile-update-error-390.png",
+    ],
+  },
+  {
+    folder: "reports",
+    page: "reports",
+    routes: [
+      "/reports",
+      "/reports/category?interval=2026-04",
+      "/reports/budget?interval=2026-04",
+      "/reports/history?year=2026",
+      "/reports/heatmap?interval=2026-04",
+    ],
+    screenshots: [
+      "hub-populated-1440.png",
+      "hub-populated-1024.png",
+      "hub-populated-390.png",
+      "hub-populated-360.png",
+      "category-report-1440.png",
+      "category-empty-390.png",
+      "budget-report-390.png",
+      "budget-error-390.png",
+      "history-report-1440.png",
+      "heatmap-report-390.png",
+      "heatmap-error-390.png",
+    ],
+  },
+  {
+    folder: "transactions",
+    page: "transactions",
+    routes: ["/transactions"],
+    screenshots: [
+      "populated-1440.png",
+      "populated-1024.png",
+      "populated-390.png",
+      "populated-360.png",
+      "filter-empty-390.png",
+      "first-use-empty-390.png",
+      "drawer-open-390.png",
+      "drawer-open-360.png",
+      "expanded-row-1440.png",
+      "expanded-row-390.png",
+      "load-error-390.png",
+    ],
+  },
+];
+
+function parseArgs(argv) {
+  const options = {
+    maxAgeHours: defaultMaxAgeHours,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    const maxAgeMatch = arg.match(/^--max-age-hours=(\d+(?:\.\d+)?)$/);
+    if (maxAgeMatch) {
+      options.maxAgeHours = Number(maxAgeMatch[1]);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isFinite(options.maxAgeHours) || options.maxAgeHours <= 0) {
+    throw new Error("--max-age-hours must be a positive number.");
+  }
+
+  return options;
+}
+
+function relativeFromRepo(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function readSummary(summaryPath) {
+  try {
+    return JSON.parse(readFileSync(summaryPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Cannot read JSON: ${error.message}`);
+  }
+}
+
+function routeMatches(actualRoute, expectedRoute) {
+  return actualRoute === expectedRoute;
+}
+
+function inferRouteCoverage(summary, expectedRoute) {
+  if (summary.page === "hero-consistency") {
+    const routePage = expectedRoute.split(/[/?]/).filter(Boolean)[0];
+    return Array.isArray(summary.states) && summary.states.some((state) => state.page === routePage);
+  }
+
+  if (summary.page === "budgets" && expectedRoute.startsWith("/budgets")) {
+    return true;
+  }
+
+  return expectedRoute === `/${summary.page}`;
+}
+
+function collectStateRoutes(summary) {
+  if (!Array.isArray(summary.states)) {
+    return [];
+  }
+
+  return summary.states
+    .map((state) => state.routePath)
+    .filter((routePath) => typeof routePath === "string" && routePath.length > 0);
+}
+
+function validateSummary(config, options, now) {
+  const folderPath = path.join(visualQaRoot, config.folder);
+  const summaryPath = path.join(folderPath, "qa-summary.json");
+  const issues = [];
+
+  if (!existsSync(summaryPath)) {
+    return {
+      folder: config.folder,
+      generatedAt: null,
+      screenshotCount: 0,
+      issues: [`missing ${relativeFromRepo(summaryPath)}`],
+    };
+  }
+
+  let summary;
+  try {
+    summary = readSummary(summaryPath);
+  } catch (error) {
+    return {
+      folder: config.folder,
+      generatedAt: null,
+      screenshotCount: 0,
+      issues: [`${relativeFromRepo(summaryPath)}: ${error.message}`],
+    };
+  }
+
+  if (summary.page !== config.page) {
+    issues.push(`page expected ${config.page}, got ${summary.page ?? "missing"}`);
+  }
+
+  if (summary.dataMode !== "fixture") {
+    issues.push(`dataMode expected fixture, got ${summary.dataMode ?? "missing"}`);
+  }
+
+  if (summary.harness?.realBackendCalled !== false) {
+    issues.push("harness.realBackendCalled must be false");
+  }
+
+  if (summary.checks?.hasFailures !== false) {
+    issues.push("checks.hasFailures must be false");
+  }
+
+  if (!Array.isArray(summary.unhandledApiRequests) || summary.unhandledApiRequests.length !== 0) {
+    issues.push("unhandledApiRequests must be []");
+  }
+
+  if (!Array.isArray(summary.states) || summary.states.length === 0) {
+    issues.push("states must be a non-empty array");
+  } else {
+    const nonFixtureState = summary.states.find((state) => state.dataMode !== "fixture");
+    if (nonFixtureState) {
+      issues.push(`state ${nonFixtureState.name ?? "unknown"} dataMode must be fixture`);
+    }
+  }
+
+  const generatedAt = typeof summary.generatedAt === "string" ? new Date(summary.generatedAt) : null;
+  if (!generatedAt || Number.isNaN(generatedAt.valueOf())) {
+    issues.push("generatedAt must be a valid ISO timestamp");
+  } else {
+    const ageHours = (now.valueOf() - generatedAt.valueOf()) / 3_600_000;
+    if (ageHours < -0.05) {
+      issues.push(`generatedAt is in the future: ${summary.generatedAt}`);
+    } else if (ageHours > options.maxAgeHours) {
+      issues.push(`summary is stale: ${ageHours.toFixed(1)}h old, max ${options.maxAgeHours}h`);
+    }
+  }
+
+  const summaryScreenshots = Array.isArray(summary.screenshots) ? new Set(summary.screenshots) : new Set();
+  if (!Array.isArray(summary.screenshots)) {
+    issues.push("screenshots must be an array");
+  }
+
+  for (const screenshot of config.screenshots) {
+    if (!summaryScreenshots.has(screenshot)) {
+      issues.push(`summary missing screenshot entry ${screenshot}`);
+    }
+
+    const screenshotPath = path.join(folderPath, screenshot);
+    if (!existsSync(screenshotPath)) {
+      issues.push(`missing screenshot file ${relativeFromRepo(screenshotPath)}`);
+      continue;
+    }
+
+    const stats = statSync(screenshotPath);
+    if (!stats.isFile() || stats.size === 0) {
+      issues.push(`screenshot file is empty ${relativeFromRepo(screenshotPath)}`);
+    }
+  }
+
+  const stateScreenshots = Array.isArray(summary.states)
+    ? new Set(summary.states.map((state) => state.screenshot).filter(Boolean))
+    : new Set();
+  for (const screenshot of config.screenshots) {
+    if (!stateScreenshots.has(screenshot)) {
+      issues.push(`states missing screenshot reference ${screenshot}`);
+    }
+  }
+
+  const explicitRoutes = collectStateRoutes(summary);
+  for (const expectedRoute of config.routes) {
+    const hasExplicitMatch = explicitRoutes.some((route) => routeMatches(route, expectedRoute));
+    if (!hasExplicitMatch && !inferRouteCoverage(summary, expectedRoute)) {
+      issues.push(`missing required route ${expectedRoute}`);
+    }
+  }
+
+  return {
+    folder: config.folder,
+    generatedAt: summary.generatedAt ?? null,
+    screenshotCount: config.screenshots.length,
+    issues,
+  };
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node visual-qa/verify-summaries.mjs [--max-age-hours=24]\n`);
+}
+
+function printResults(results, options) {
+  const failed = results.filter((result) => result.issues.length > 0);
+  const screenshotCount = results.reduce((total, result) => total + result.screenshotCount, 0);
+
+  if (failed.length === 0) {
+    process.stdout.write("PASS visual QA summaries\n");
+    process.stdout.write(`folders: ${results.length} canonical, screenshots: ${screenshotCount}, freshness: <= ${options.maxAgeHours}h\n`);
+    process.stdout.write(`summaries: ${results.map((result) => result.folder).join(", ")}\n`);
+    return;
+  }
+
+  process.stdout.write("FAIL visual QA summaries\n");
+  process.stdout.write(`folders: ${results.length} canonical, failed: ${failed.length}, freshness: <= ${options.maxAgeHours}h\n`);
+  for (const result of failed) {
+    process.stdout.write(`- ${result.folder}: ${result.issues.join("; ")}\n`);
+  }
+  process.stdout.write("Run npm run visual-qa:all, then npm run visual-qa:verify.\n");
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const results = canonicalSummaries.map((config) => validateSummary(config, options, new Date()));
+  printResults(results, options);
+
+  if (results.some((result) => result.issues.length > 0)) {
+    process.exit(1);
+  }
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -11,6 +11,7 @@ $ErrorActionPreference = 'Stop'
 
 $script:Checks = [System.Collections.Generic.List[object]]::new()
 $script:RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$script:LastPortInspectionError = $null
 
 function Write-Check {
     param(
@@ -51,6 +52,8 @@ function Test-PortListening {
         [int]$Port
     )
 
+    $script:LastPortInspectionError = $null
+
     try {
         if (Test-CommandExists 'Get-NetTCPConnection') {
             $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
@@ -68,8 +71,8 @@ function Test-PortListening {
         return $null -ne $connection
     }
     catch {
-        Write-Check 'Port' "Port $Port listener check" 'WARN' 'Unable to inspect TCP listeners in this shell.'
-        return $false
+        $script:LastPortInspectionError = 'Unable to inspect TCP listeners in this shell.'
+        return $null
     }
 }
 
@@ -82,12 +85,226 @@ function Write-PortCheck {
         [int]$Port
     )
 
-    if (Test-PortListening $Port) {
+    $isListening = Test-PortListening $Port
+
+    if ($null -eq $isListening) {
+        Write-Check $Area "Port $Port listener check" 'WARN' $script:LastPortInspectionError
+    }
+    elseif ($isListening) {
         Write-Check $Area "Port $Port listening" 'WARN' 'Port is occupied; confirm it is the expected local dev process before starting another server.'
     }
     else {
         Write-Check $Area "Port $Port listening" 'INFO' 'Not listening.'
     }
+}
+
+function Write-PortAvailabilityCheck {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Area,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Port,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Purpose
+    )
+
+    $isListening = Test-PortListening $Port
+
+    if ($null -eq $isListening) {
+        Write-Check $Area "Port $Port available" 'WARN' $script:LastPortInspectionError
+    }
+    elseif ($isListening) {
+        Write-Check $Area "Port $Port available" 'WARN' ("Port is occupied; confirm it is the expected {0} process or choose another port before starting visual QA." -f $Purpose)
+    }
+    else {
+        Write-Check $Area "Port $Port available" 'PASS' ("Available for {0}." -f $Purpose)
+    }
+}
+
+function Test-ViteChildProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ClientRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ViteShimPath
+    )
+
+    if (-not (Test-Path -LiteralPath $ViteShimPath -PathType Leaf)) {
+        return
+    }
+
+    $previousLocation = Get-Location
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        Set-Location -LiteralPath $ClientRoot
+        $ErrorActionPreference = 'SilentlyContinue'
+        & $ViteShimPath --version 1>$null 2>$null
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        $message = $_.Exception.Message
+        if ($message -match 'EPERM|access.*denied|operation.*permitted|sandbox') {
+            Write-Check 'UI' 'Vite child-process startup viable' 'FAIL' 'Vite could not be spawned from this shell. In Codex, approve sandbox escalation for npm/Node/Vite startup, then rerun the doctor; outside Codex, check endpoint protection or AppLocker rules.'
+        }
+        else {
+            Write-Check 'UI' 'Vite child-process startup viable' 'FAIL' 'Vite could not be spawned from node_modules/.bin; run npm install from inex/ClientApp and verify Node.js can start local package binaries.'
+        }
+        return
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+        Set-Location -LiteralPath $previousLocation
+    }
+
+    if ($exitCode -eq 0) {
+        Write-Check 'UI' 'Vite child-process startup viable' 'PASS' 'Local vite --version process starts successfully.'
+    }
+    else {
+        Write-Check 'UI' 'Vite child-process startup viable' 'FAIL' 'Local vite --version exited non-zero; run npm install from inex/ClientApp and verify the Vite package is usable.'
+    }
+}
+
+function Test-VisualQaBrowser {
+    $envCandidates = @(
+        @{ Name = 'CHROME_PATH'; Path = $env:CHROME_PATH },
+        @{ Name = 'EDGE_PATH'; Path = $env:EDGE_PATH }
+    )
+
+    $validEnvCandidate = $false
+    $detectedBrowserPath = $null
+    $invalidEnvNames = @()
+    foreach ($candidate in $envCandidates) {
+        $pathValue = [string]$candidate.Path
+        if ([string]::IsNullOrWhiteSpace($pathValue)) {
+            continue
+        }
+
+        if (Test-Path -LiteralPath $pathValue -PathType Leaf) {
+            $validEnvCandidate = $true
+            if ($null -eq $detectedBrowserPath) {
+                $detectedBrowserPath = $pathValue
+            }
+        }
+        else {
+            $invalidEnvNames += $candidate.Name
+        }
+    }
+
+    if ($validEnvCandidate) {
+        Write-Check 'UI' 'CHROME_PATH/EDGE_PATH override' 'PASS' 'A configured browser override points to an existing file.'
+    }
+    elseif ($invalidEnvNames.Count -gt 0) {
+        Write-Check 'UI' 'CHROME_PATH/EDGE_PATH override' 'WARN' ("Configured {0} value does not point to an existing file; update it or unset it." -f ($invalidEnvNames -join '/'))
+    }
+    else {
+        Write-Check 'UI' 'CHROME_PATH/EDGE_PATH override' 'INFO' 'No override configured; default Chrome/Edge install paths will be checked.'
+    }
+
+    $defaultCandidates = @(
+        'C:\Program Files\Microsoft\Edge\Application\msedge.exe',
+        'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe',
+        'C:\Program Files\Google\Chrome\Application\chrome.exe',
+        'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+    )
+
+    $hasDefaultBrowser = $false
+    foreach ($pathValue in $defaultCandidates) {
+        if (Test-Path -LiteralPath $pathValue -PathType Leaf) {
+            $hasDefaultBrowser = $true
+            if ($null -eq $detectedBrowserPath) {
+                $detectedBrowserPath = $pathValue
+            }
+            break
+        }
+    }
+
+    if ($validEnvCandidate -or $hasDefaultBrowser) {
+        Write-Check 'UI' 'Chrome/Edge executable detected' 'PASS' 'Visual QA can resolve a local Chromium browser. If launch still fails under Codex, rerun visual QA with sandbox escalation.'
+        Test-VisualQaBrowserProcess -BrowserPath $detectedBrowserPath
+    }
+    else {
+        Write-Check 'UI' 'Chrome/Edge executable detected' 'FAIL' 'Install Chrome or Edge, or set CHROME_PATH/EDGE_PATH to the browser executable. In Codex, approve sandbox escalation if the browser exists but process launch is blocked.'
+    }
+}
+
+function Test-VisualQaBrowserProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BrowserPath
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        & $BrowserPath --version 1>$null 2>$null
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        $message = $_.Exception.Message
+        if ($message -match 'EPERM|access.*denied|operation.*permitted|sandbox') {
+            Write-Check 'UI' 'Chrome/Edge process startup viable' 'FAIL' 'The detected browser could not be spawned from this shell. In Codex, approve sandbox escalation for browser startup, then rerun visual QA.'
+        }
+        else {
+            Write-Check 'UI' 'Chrome/Edge process startup viable' 'FAIL' 'The detected browser could not be spawned. Set CHROME_PATH/EDGE_PATH to a working Chrome or Edge executable.'
+        }
+        return
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    if ($exitCode -eq 0) {
+        Write-Check 'UI' 'Chrome/Edge process startup viable' 'PASS' 'Detected browser starts for a version probe.'
+    }
+    else {
+        Write-Check 'UI' 'Chrome/Edge process startup viable' 'FAIL' 'Detected browser version probe exited non-zero. Set CHROME_PATH/EDGE_PATH to a working Chrome or Edge executable, or approve sandbox escalation if process launch is blocked.'
+    }
+}
+
+function Test-VisualQaOutputWriteAccess {
+    $visualQaRoot = Join-Path $script:RepoRoot 'docs\implementation\visual-qa'
+
+    if (-not (Test-Path -LiteralPath $visualQaRoot -PathType Container)) {
+        Write-Check 'UI' 'visual QA output directory writable' 'FAIL' 'Create docs/implementation/visual-qa before running visual QA.'
+        return
+    }
+
+    $testFile = Join-Path $visualQaRoot ('.doctor-write-test-{0}.tmp' -f [guid]::NewGuid().ToString('N'))
+    try {
+        Set-Content -LiteralPath $testFile -Value 'doctor write test' -NoNewline
+        Remove-Item -LiteralPath $testFile -Force
+        Write-Check 'UI' 'visual QA output directory writable' 'PASS' 'Doctor-owned temp file write/delete succeeded.'
+    }
+    catch {
+        Write-Check 'UI' 'visual QA output directory writable' 'FAIL' 'Cannot write visual QA output. Fix filesystem permissions for docs/implementation/visual-qa or run with an approved workspace that can write there.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $testFile -PathType Leaf) {
+            Remove-Item -LiteralPath $testFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Get-VisualQaPorts {
+    $visualQaScriptRoot = Join-Path $script:RepoRoot 'inex\ClientApp\visual-qa'
+    if (-not (Test-Path -LiteralPath $visualQaScriptRoot -PathType Container)) {
+        return @()
+    }
+
+    $ports = [System.Collections.Generic.List[int]]::new()
+    $scripts = @(Get-ChildItem -LiteralPath $visualQaScriptRoot -Filter '*.mjs' -File -ErrorAction SilentlyContinue)
+    foreach ($script in $scripts) {
+        $content = Get-Content -LiteralPath $script.FullName -Raw
+        $matches = [regex]::Matches($content, 'defaultPort:\s*(\d+)')
+        foreach ($match in $matches) {
+            [void]$ports.Add([int]$match.Groups[1].Value)
+        }
+    }
+
+    return @($ports | Sort-Object -Unique)
 }
 
 function Test-Ui {
@@ -109,12 +326,23 @@ function Test-Ui {
         Write-Check 'UI' 'npm command available' 'FAIL' 'Install Node.js/npm and reopen the shell.'
     }
 
+    if (Test-CommandExists 'node') {
+        Write-Check 'UI' 'node command available' 'PASS' 'OK.'
+    }
+    else {
+        Write-Check 'UI' 'node command available' 'FAIL' 'Install Node.js and reopen the shell.'
+    }
+
     if (Test-Path -LiteralPath $viteShimPath -PathType Leaf) {
         Write-Check 'UI' 'Vite Windows command shim exists' 'PASS' 'OK.'
     }
     else {
         Write-Check 'UI' 'Vite Windows command shim exists' 'FAIL' 'Run npm install from inex/ClientApp before npm start.'
     }
+
+    Test-ViteChildProcess -ClientRoot $clientRoot -ViteShimPath $viteShimPath
+    Test-VisualQaBrowser
+    Test-VisualQaOutputWriteAccess
 
     if (Test-Path -LiteralPath $packagePath -PathType Leaf) {
         try {
@@ -140,8 +368,10 @@ function Test-Ui {
         }
     }
 
-    foreach ($port in @(3000, 5173, 5177)) {
-        Write-PortCheck 'UI' $port
+    Write-PortAvailabilityCheck 'UI' 3000 'Vite dev server'
+
+    foreach ($port in (Get-VisualQaPorts)) {
+        Write-PortAvailabilityCheck 'UI' $port 'visual QA harness'
     }
 }
 


### PR DESCRIPTION
## Summary
- Enhance the project doctor UI checks for Chrome/Edge detection, Vite child-process startup, visual QA output write access, and visual QA port availability.
- Add a canonical visual QA summary verifier and npm command.
- Document the `visual-qa:all` -> `visual-qa:verify` flow and integrate it into InEx agent guidance.

## Verification
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/doctor.ps1 -Ui` passed.
- `npm run visual-qa:verify -- --max-age-hours=72` passed against existing canonical summaries.
- `npm run visual-qa:verify` correctly failed because some existing summaries were older than the default 24-hour freshness gate.
- `npm run lint` passed.
- `npm run build` passed after sandbox escalation; the first sandboxed attempt failed with Vite/esbuild `spawn EPERM`.

## Notes
- Did not run `npm run visual-qa:all`; this PR does not refresh screenshot artifacts.