### PR TITLE
Add shell keyboard traversal regression

### DIFF
--- a/inex/ClientApp/src/layouts/AppShell.test.tsx
+++ b/inex/ClientApp/src/layouts/AppShell.test.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+
+import { InExButton } from "../components/primitives";
+import authSlice from "../store/auth/auth-slice";
+import AppShell from "./AppShell";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+    ...await importOriginal<typeof import("react-i18next")>(),
+    useTranslation: () => ({
+        t: (key: string) => ({
+            "nav.accounts": "Accounts",
+            "nav.budgets": "Budgets",
+            "nav.categories": "Categories",
+            "nav.dashboard": "Dashboard",
+            "nav.mainNav": "Main navigation",
+            "nav.profile": "Profile",
+            "nav.reports": "Reports",
+            "nav.signOut": "Sign out",
+            "nav.transactions": "Transactions",
+        }[key] ?? key),
+    }),
+}));
+
+const renderShell = () => {
+    const store = configureStore({
+        reducer: {
+            auth: authSlice.reducer,
+        },
+        preloadedState: {
+            auth: {
+                accessToken: "token",
+                expiresAt: Date.now() + 3_600_000,
+                user: { id: 1, username: "qa", email: "qa@example.com", currencyId: 1, languageCode: "en" },
+                isInitializing: false,
+                error: null,
+            },
+        },
+    });
+
+    return render(
+        <Provider store={store}>
+            <MemoryRouter initialEntries={["/dashboard"]}>
+                <AppShell
+                    extra={<InExButton kind="primary">Primary action</InExButton>}
+                    subtitle="Overview"
+                    title="Dashboard"
+                >
+                    <button type="button">Content control</button>
+                </AppShell>
+            </MemoryRouter>
+        </Provider>,
+    );
+};
+
+describe("AppShell keyboard navigation", () => {
+    it("tabs through shell navigation, profile, page controls, content controls, and bottom navigation", async () => {
+        const user = userEvent.setup();
+        renderShell();
+
+        const topDashboard = screen.getAllByRole("button", { name: "Dashboard" })[0];
+        const topTransactions = screen.getAllByRole("button", { name: "Transactions" })[0];
+        const topReports = screen.getAllByRole("button", { name: "Reports" })[0];
+        const profile = screen.getByRole("button", { name: "Profile" });
+        const primaryAction = screen.getByRole("button", { name: "Primary action" });
+        const contentControl = screen.getByRole("button", { name: "Content control" });
+        const bottomDashboard = screen.getAllByRole("button", { name: "Dashboard" })[1];
+        const bottomReports = screen.getAllByRole("button", { name: "Reports" })[1];
+
+        await user.tab();
+        expect(document.activeElement).toBe(topDashboard);
+
+        await user.tab();
+        expect(document.activeElement).toBe(topTransactions);
+
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        expect(document.activeElement).toBe(topReports);
+
+        await user.tab();
+        expect(document.activeElement).toBe(profile);
+
+        await user.tab();
+        expect(document.activeElement).toBe(primaryAction);
+
+        await user.tab();
+        expect(document.activeElement).toBe(contentControl);
+
+        await user.tab();
+        expect(document.activeElement).toBe(bottomDashboard);
+
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        expect(document.activeElement).toBe(bottomReports);
+    });
+});


### PR DESCRIPTION
## Summary
- Add a focused AppShell keyboard regression test for Tab traversal through top navigation, profile, page action, content control, and bottom navigation.
- Preserve the existing native button shell implementation and focus-visible styling; no broad shell rewrite was needed after automated reproduction confirmed controls are tabbable.

Closes #253

## Verification
- `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1 -Ui`
- `npm run test -- src/layouts/AppShell.test.tsx`
- `npm run lint`
- `npm run build`

## Review Notes
- Blind Hunter: no implementation regression found; the shell controls are native buttons in DOM tab order.
- Edge Case Hunter: regression covers top nav, profile control, page-level primary control, content control, and bottom nav traversal.
- Acceptance Auditor: the issue's requested focused regression check is added; no visual QA screenshots were refreshed because this is test-only and does not alter rendered UI.

## Risks
- The original Browser-based mobile observation could not be reproduced as a source defect; this PR locks the expected shell tab order in automated coverage.