### PR TITLE
Fix Transactions month summary KPIs

### DIFF
--- a/docs/implementation/gh-264-transactions-month-summary-kpis.md
+++ b/docs/implementation/gh-264-transactions-month-summary-kpis.md
@@ -1,0 +1,111 @@
+# Story GH-264: Transactions Month Summary KPIs
+
+Status: review
+
+GitHub Issue: https://github.com/temaby/inex/issues/264
+
+## Story
+
+As an invited account holder,
+I want the Transactions KPI cards to use the full selected month and server-filter scope,
+so that income, expenses, net flow, and type counts do not change when I paginate ledger rows.
+
+## Acceptance Criteria
+
+1. Given a selected month has more transactions than the current page size, when the user switches between ledger pages, then KPI card totals and segmented type counts remain unchanged.
+2. Given account, category, tag, ref, or date filters are active, when the Transactions page renders, then KPI card totals and type counts use the full filtered server scope before pagination.
+3. Given local search, type, min amount, or max amount filters are applied, when the user narrows visible rows, then the paginated ledger row set changes but the monthly KPI cards remain scoped to the selected month and server filters.
+4. Given transactions are created, updated, or deleted, when RTK Query invalidates transaction data, then both the paginated ledger rows and summary cards refresh.
+5. Given backend summary data is queried, when the service loads transactions, then all data remains scoped by authenticated `CurrentUserId`.
+
+## Tasks / Subtasks
+
+- [x] Add a backend transaction summary response. (AC: 1, 2, 5)
+  - [x] Add `TransactionSummaryResponse` and supporting nested record types under `inex.Services/Models/Records/Transaction/`.
+  - [x] Add `ITransactionService.GetSummary(...)` using the existing typed `TransactionFilterQuery` and `ActivityMode`.
+  - [x] Reuse `GetTransactions(userId, mode, filter)` so the summary query preserves `UserId`, activity mode, account/category/tag/ref/date filters, and active account/category behavior.
+  - [x] Aggregate by transaction/account currency and kind; treat system-category transfers as transfer counts, not income or expense totals.
+- [x] Expose `GET /api/transactions/summary`. (AC: 1, 2, 5)
+  - [x] Accept `mode`, `accountId`, `categoryId`, `tag`, `ref`, `startDate`, and `endDate` query params.
+  - [x] Return the summary response without changing the existing paginated `GET /api/transactions` route or response shape.
+- [x] Add frontend RTK Query support. (AC: 1, 2, 4)
+  - [x] Add `getTransactionsSummary` to `inex/ClientApp/src/store/transactions/transactions-api.ts`.
+  - [x] Reuse the same filter serialization as `getTransactions`, without page or page size.
+  - [x] Invalidate summary data from create, transfer, update, and delete mutations with the existing transaction list invalidation.
+- [x] Update the Transactions page data flow. (AC: 1, 2, 3)
+  - [x] Fetch summary data in `Transactions.tsx` for the active server filter.
+  - [x] Convert native currency summary totals to the current base currency using existing `transaction-ledger-utils` conversion behavior.
+  - [x] Render KPI cards and segmented type counts from summary metrics.
+  - [x] Keep `TransactionList` responsible for paginated rows, local search/type/amount filtering, grouped rows, visible-row counts, and pagination summary.
+- [x] Add regression coverage. (AC: 1, 2, 4, 5)
+  - [x] Add or update backend integration tests in `inex.Tests/Transactions/TransactionsControllerTests.cs` proving summary totals ignore pagination and respect filters.
+  - [x] Add or update frontend tests for summary URL serialization, cache invalidation, and summary-to-ledger metric conversion.
+
+## Dev Notes
+
+### Current State
+
+- `inex/ClientApp/src/pages/Transactions.tsx` renders KPI cards from `ledgerMetrics`.
+- `inex/ClientApp/src/pages/Transactions/TransactionList.tsx` computes `ledgerMetrics` from `data.data`, which is only the current paginated page from `useGetTransactionsQuery`.
+- `inex/ClientApp/src/store/transactions/transactions-api.ts` only exposes `getTransactions({ pageSize, page, filter })`.
+- `inex/Controllers/TransactionsController.cs` only exposes paginated list data for typed transaction filters.
+- `inex.Services/Services/TransactionService.cs` already has `GetTransactions(userId, mode, filter)` that applies `UserId`, activity mode, and typed filters before pagination.
+
+### Implementation Guidance
+
+- Keep pagination. Do not load the entire month into the ledger list just to fix cards.
+- Do not call live exchange-rate providers. Frontend summary conversion must reuse existing `state.rates.items` behavior.
+- Backend should return native per-currency aggregate totals plus counts; frontend converts each currency aggregate to base currency using existing `toBaseCurrencyAmount`.
+- If a currency cannot be converted, preserve the current 10.2a safety behavior: do not silently mix unconvertible native values into base-currency KPI totals.
+- Preserve existing routes, JSON shapes, status codes, and query parameter names for `GET /api/transactions`.
+- Do not store parsed tags or refs separately for this work; existing comment/tag behavior remains unchanged.
+
+### Likely Files
+
+- `inex.Services/Models/Records/Transaction/TransactionSummaryResponse.cs`
+- `inex.Services/Services/Base/ITransactionService.cs`
+- `inex.Services/Services/TransactionService.cs`
+- `inex/Controllers/TransactionsController.cs`
+- `inex.Tests/Transactions/TransactionsControllerTests.cs`
+- `inex/ClientApp/src/store/transactions/transactions-api.ts`
+- `inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts`
+- `inex/ClientApp/src/pages/Transactions.tsx`
+- `inex/ClientApp/src/pages/Transactions/TransactionList.tsx`
+- `inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.ts`
+- `inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.test.ts`
+
+## Verification Checklist
+
+- [x] `dotnet test inex.Tests/ --filter FullyQualifiedName~TransactionsControllerTests`
+- [x] `dotnet test inex.Services.Tests/`
+- [x] `npm test -- src/store/transactions/__tests__/transactions-api.test.ts src/pages/Transactions/transaction-ledger-utils.test.ts`
+- [x] `npm run build`
+- [x] `npm run lint`
+- [x] `dotnet build`
+
+## Dev Agent Record
+
+### Completion Notes
+
+- Created GitHub issue #264 as the delivery tracker.
+- Added `GET /api/transactions/summary` with the same typed server filters and activity mode as the paginated list.
+- Added a native per-currency summary contract so frontend base-currency conversion continues to use existing loaded rates without live provider calls.
+- Updated Transactions KPI cards and segmented counts to use full server-scope summary data while the ledger list remains paginated.
+- Kept client-only search/type/amount filters local to visible rows.
+
+### Verification
+
+- `dotnet test inex.Tests/ --filter FullyQualifiedName~TransactionsControllerTests` passed: 23 tests.
+- `dotnet test inex.Services.Tests/` passed: 88 tests.
+- `npm test -- src/store/transactions/__tests__/transactions-api.test.ts src/pages/Transactions/transaction-ledger-utils.test.ts` passed: 14 tests.
+- `npm run build` passed; Vite reported the existing large AntD chunk warning.
+- `npm run lint` passed.
+- `dotnet build` passed.
+
+## BMad Checklist Validation
+
+- [x] Story is single-goal and tied to GitHub issue #264.
+- [x] Acceptance criteria are testable and use Given/When/Then.
+- [x] File paths and implementation constraints are concrete.
+- [x] User data isolation is explicit.
+- [x] External provider calls are explicitly out of scope.

--- a/inex.Services/Models/Records/Transaction/TransactionSummaryResponse.cs
+++ b/inex.Services/Models/Records/Transaction/TransactionSummaryResponse.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace inex.Services.Models.Records.Transaction;
+
+public record TransactionTypeCounts
+{
+    public int All { get; init; }
+    public int Income { get; init; }
+    public int Expense { get; init; }
+    public int Transfer { get; init; }
+}
+
+public record TransactionCurrencySummary
+{
+    public string Currency { get; init; } = string.Empty;
+    public decimal Income { get; init; }
+    public decimal Expense { get; init; }
+    public decimal Net { get; init; }
+}
+
+public record TransactionSummaryResponse
+{
+    public int TotalCount { get; init; }
+    public TransactionTypeCounts TypeCounts { get; init; } = new();
+    public IEnumerable<TransactionCurrencySummary> CurrencySummaries { get; init; } = new List<TransactionCurrencySummary>();
+}

--- a/inex.Services/Services/Base/ITransactionService.cs
+++ b/inex.Services/Services/Base/ITransactionService.cs
@@ -13,6 +13,7 @@ public interface ITransactionService : IInExService
     ListResponse<TransactionResponse> Get(int userId, ActivityMode mode, IDictionary<string, string> filters);
     PagedResponse<TransactionResponse, PaginationMetadata> Get(int userId, ActivityMode mode, int pageSize, int pageNumber, IDictionary<string, string> filters);
     PagedResponse<TransactionResponse, PaginationMetadata> Get(int userId, ActivityMode mode, int pageSize, int page, TransactionFilterQuery filter);
+    TransactionSummaryResponse GetSummary(int userId, ActivityMode mode, TransactionFilterQuery filter);
     Task<CreatedResponse> CreateAsync(CreateTransactionRequest itemDTO, int userId, CancellationToken ct = default);
     Task<TransferResponse> CreateAsync(CreateTransferRequest itemDTO, int userId, CancellationToken ct = default);
     Task<TransactionResponse> UpdateAsync(int id, UpdateTransactionRequest itemDTO, int userId, CancellationToken ct = default);

--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -56,6 +56,38 @@ public class TransactionService : InExService, ITransactionService
         return BuildPaginatedDataResponse<Transaction, TransactionResponse>(items, pageSize, page, TransactionMapper.ToResponse);
     }
 
+    public TransactionSummaryResponse GetSummary(int userId, ActivityMode mode, TransactionFilterQuery filter)
+    {
+        IQueryable<Transaction> items = GetTransactions(userId, mode, filter);
+
+        var currencySummaries = items
+            .GroupBy(i => i.Account.Currency.Key)
+            .Select(group => new TransactionCurrencySummary
+            {
+                Currency = group.Key,
+                Income = group.Sum(i => !i.Category.IsSystem && i.Value >= 0 ? i.Value : 0),
+                Expense = group.Sum(i => !i.Category.IsSystem && i.Value < 0 ? i.Value : 0),
+                Net = group.Sum(i => !i.Category.IsSystem ? i.Value : 0),
+            })
+            .OrderBy(summary => summary.Currency)
+            .ToList();
+
+        int totalCount = items.Count();
+
+        return new TransactionSummaryResponse
+        {
+            TotalCount = totalCount,
+            TypeCounts = new TransactionTypeCounts
+            {
+                All = totalCount,
+                Income = items.Count(i => !i.Category.IsSystem && i.Value >= 0),
+                Expense = items.Count(i => !i.Category.IsSystem && i.Value < 0),
+                Transfer = items.Count(i => i.Category.IsSystem)
+            },
+            CurrencySummaries = currencySummaries
+        };
+    }
+
     public async Task<CreatedResponse> CreateAsync(CreateTransactionRequest itemDTO, int userId, CancellationToken ct = default)
     {
         await EnsureTransactionRelationsBelongToUserAsync(itemDTO.AccountId, itemDTO.CategoryId, userId, ct);

--- a/inex.Tests/Transactions/TransactionsControllerTests.cs
+++ b/inex.Tests/Transactions/TransactionsControllerTests.cs
@@ -377,6 +377,55 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
     }
 
     [Fact]
+    public async Task Summary_WithPaginationQuery_AggregatesFullFilteredScope()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(client, "summary-pagination-account");
+        int categoryId = await CreateCategoryAsync(client, "summary-pagination-category");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 100m, "paycheck #month");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, -30m, "groceries #month");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, -20m, "transport #month");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 999m, "different #other");
+
+        var response = await client.GetAsync("/api/transactions/summary?tag=month&pageSize=1&page=1");
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(3, body.GetProperty("totalCount").GetInt32());
+        Assert.Equal(3, body.GetProperty("typeCounts").GetProperty("all").GetInt32());
+        Assert.Equal(1, body.GetProperty("typeCounts").GetProperty("income").GetInt32());
+        Assert.Equal(2, body.GetProperty("typeCounts").GetProperty("expense").GetInt32());
+        Assert.Equal(0, body.GetProperty("typeCounts").GetProperty("transfer").GetInt32());
+
+        var currencySummary = Assert.Single(body.GetProperty("currencySummaries").EnumerateArray());
+        Assert.Equal("USD", currencySummary.GetProperty("currency").GetString());
+        Assert.Equal(100m, currencySummary.GetProperty("income").GetDecimal());
+        Assert.Equal(-50m, currencySummary.GetProperty("expense").GetDecimal());
+        Assert.Equal(50m, currencySummary.GetProperty("net").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Summary_ExcludesOtherUsersTransactions()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int accountA = await CreateAccountAsync(userA, "summary-own-account");
+        int categoryA = await CreateCategoryAsync(userA, "summary-own-category");
+        int accountB = await CreateAccountAsync(userB, "summary-other-account");
+        int categoryB = await CreateCategoryAsync(userB, "summary-other-category");
+        await CreateTransactionWithAmountAndCommentAsync(userA, accountA, categoryA, 25m, "own #scope");
+        await CreateTransactionWithAmountAndCommentAsync(userB, accountB, categoryB, 100m, "other #scope");
+
+        var response = await userA.GetAsync("/api/transactions/summary?tag=scope");
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(1, body.GetProperty("totalCount").GetInt32());
+        var currencySummary = Assert.Single(body.GetProperty("currencySummaries").EnumerateArray());
+        Assert.Equal(25m, currencySummary.GetProperty("income").GetDecimal());
+    }
+
+    [Fact]
     public void ApplyFilters_ByTagAndRef_ProducesDatabaseSideSql()
     {
         var options = new DbContextOptionsBuilder<InExDbContext>()
@@ -458,14 +507,17 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
         return body.GetProperty("id").GetInt32();
     }
 
-    private static async Task<int> CreateTransactionWithCommentAsync(HttpClient client, int accountId, int categoryId, string comment)
+    private static Task<int> CreateTransactionWithCommentAsync(HttpClient client, int accountId, int categoryId, string comment)
+        => CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 10m, comment);
+
+    private static async Task<int> CreateTransactionWithAmountAndCommentAsync(HttpClient client, int accountId, int categoryId, decimal amount, string comment)
     {
         var response = await client.PostAsJsonAsync("/api/transactions", new
         {
             accountId,
             categoryId,
             created = DateTime.UtcNow,
-            amount  = 10m,
+            amount,
             comment,
         });
         response.EnsureSuccessStatusCode();

--- a/inex/ClientApp/public/locales/en/translation.json
+++ b/inex/ClientApp/public/locales/en/translation.json
@@ -306,8 +306,8 @@
       "netFlow": "Net Flow",
       "filteredPage": "Current ledger page",
       "updatesWithLedger": "Updates with the visible ledger",
-      "visibleRows": "{{count}} visible rows for {{period}}",
-      "baseCurrencyContext": "Visible page shown in {{currency}} where rates exist"
+      "visibleRows": "{{count}} transactions in {{period}}",
+      "baseCurrencyContext": "Month summary shown in {{currency}} where rates exist"
     },
     "loading": {
       "initial": "Loading transactions",

--- a/inex/ClientApp/public/locales/ru/translation.json
+++ b/inex/ClientApp/public/locales/ru/translation.json
@@ -308,8 +308,8 @@
       "netFlow": "Чистый поток",
       "filteredPage": "Текущая страница журнала",
       "updatesWithLedger": "Обновляется по видимому журналу",
-      "visibleRows": "{{count}} видимых строк за {{period}}",
-      "baseCurrencyContext": "Видимая страница в {{currency}}, где есть курсы"
+      "visibleRows": "{{count}} транзакций за {{period}}",
+      "baseCurrencyContext": "Сводка месяца в {{currency}}, где есть курсы"
     },
     "loading": {
       "initial": "Загружаем транзакции",

--- a/inex/ClientApp/src/pages/Transactions.tsx
+++ b/inex/ClientApp/src/pages/Transactions.tsx
@@ -9,6 +9,7 @@ import BasicPage from "../layouts/BasicPage";
 import { useAppDispatch, useAppSelector } from "../store/hooks";
 import { AccountResponse, useGetAccountsQuery } from "../store/accounts/accounts-api";
 import { CategoryResponse, useGetCategoriesQuery } from "../store/categories/categories-api";
+import { useGetTransactionsSummaryQuery, type TransactionFilterParams } from "../store/transactions/transactions-api";
 import { transactionsActions, transactionsDefaultFilter, type TransactionFilter } from "../store/transactions/transactions-slice";
 import {
     InExButton,
@@ -30,6 +31,7 @@ import {
     formatTransactionPeriodLabel,
     getBaseCurrencyCode,
     getCurrentTransactionMonthRange,
+    getLedgerMetricsFromSummary,
     isCurrentOrFutureTransactionMonth,
     isWholeTransactionMonthRange,
     shiftTransactionMonthRange,
@@ -99,8 +101,26 @@ const Transactions = () => {
     const filterActive = isTransactionFilterActive(filterState) || isLedgerUiFilterActive(ledgerFilter);
     const filterIndicatorTitle = filterActive ? t("transactions.filtersActive") : undefined;
     const baseCurrency = useMemo(() => getBaseCurrencyCode(exchangeRates), [exchangeRates]);
-    const noMatchActive = filterActive && ledgerMetrics.totalCount > 0 && ledgerMetrics.visibleCount === 0;
     const activeMonthRange = filterState.range.length === 2 ? filterState.range : getCurrentTransactionMonthRange();
+    const summaryFilter = useMemo<TransactionFilterParams>(() => ({
+        accountIds: filterState.accountIds,
+        categoryIds: filterState.categoryIds,
+        tags: filterState.tags,
+        refs: filterState.refs,
+        range: filterState.range,
+    }), [filterState]);
+    const summaryQuery = useGetTransactionsSummaryQuery(summaryFilter, {
+        skip: filterParam === null && filterState.range.length !== 2,
+    });
+    const summaryMetrics = useMemo(
+        () => summaryQuery.data
+            ? getLedgerMetricsFromSummary(summaryQuery.data, exchangeRates)
+            : null,
+        [exchangeRates, summaryQuery.data],
+    );
+    const scopedMetrics = summaryMetrics ?? ledgerMetrics;
+    const scopedTotalCount = scopedMetrics.totalCount;
+    const noMatchActive = filterActive && scopedTotalCount > 0 && ledgerMetrics.visibleCount === 0;
     const periodLabel = useMemo(
         () => isWholeTransactionMonthRange(activeMonthRange)
             ? formatTransactionMonthLabel(activeMonthRange, t("transactions.period.currentMonth"))
@@ -250,22 +270,22 @@ const Transactions = () => {
     const kpiItems = [
         {
             label: t("transactions.kpi.income"),
-            value: Math.abs(ledgerMetrics.income),
+            value: Math.abs(scopedMetrics.income),
             kind: "income" as MoneyKind,
             signage: "color-only" as Signage,
-            sub: t("transactions.kpi.visibleRows", { count: ledgerMetrics.visibleCount, period: periodLabel }),
+            sub: t("transactions.kpi.visibleRows", { count: scopedMetrics.totalCount, period: periodLabel }),
         },
         {
             label: t("transactions.kpi.expenses"),
-            value: Math.abs(ledgerMetrics.expense),
+            value: Math.abs(scopedMetrics.expense),
             kind: "expense" as MoneyKind,
             signage: "color-only" as Signage,
-            sub: t("transactions.kpi.visibleRows", { count: ledgerMetrics.visibleCount, period: periodLabel }),
+            sub: t("transactions.kpi.visibleRows", { count: scopedMetrics.totalCount, period: periodLabel }),
         },
         {
             label: t("transactions.kpi.netFlow"),
-            value: ledgerMetrics.net,
-            kind: ledgerMetrics.net > 0 ? "income" as MoneyKind : ledgerMetrics.net < 0 ? "expense" as MoneyKind : "neutral" as MoneyKind,
+            value: scopedMetrics.net,
+            kind: scopedMetrics.net > 0 ? "income" as MoneyKind : scopedMetrics.net < 0 ? "expense" as MoneyKind : "neutral" as MoneyKind,
             signage: "signed" as Signage,
             sub: t("transactions.kpi.baseCurrencyContext", { currency: baseCurrency }),
             primary: true,
@@ -286,10 +306,10 @@ const Transactions = () => {
                 <section className="transactions-ledger">
                     <div className="transactions-kpi-strip" aria-label={t("transactions.kpi.title")} data-qa="hero-card">
                         {kpiItems.map(item => (
-                            <div className={`transactions-kpi${ledgerInitialLoading ? " transactions-kpi--loading" : ""}`} key={item.label}>
+                            <div className={`transactions-kpi${ledgerInitialLoading || summaryQuery.isLoading ? " transactions-kpi--loading" : ""}`} key={item.label}>
                                 <div className="transactions-kpi__label" data-qa={item.primary ? "hero-primary-label" : undefined}>{item.label}</div>
                                 <div className="transactions-kpi__value" data-qa={item.primary ? "hero-primary-value" : undefined}>
-                                    {ledgerInitialLoading ? (
+                                    {ledgerInitialLoading || summaryQuery.isLoading ? (
                                         <span className="transactions-kpi__skeleton" />
                                     ) : (
                                         <Num
@@ -316,7 +336,7 @@ const Transactions = () => {
                                 <span className="transactions-toolbar-count">
                                     {t("transactions.toolbarCount", {
                                         visible: ledgerMetrics.visibleCount,
-                                        total: ledgerMetrics.totalCount,
+                                        total: scopedTotalCount,
                                         period: periodLabel,
                                     })}
                                 </span>
@@ -342,10 +362,10 @@ const Transactions = () => {
                                 label={t("transactions.view")}
                                 onChange={(value) => setLedgerFilter(prev => ({ ...prev, type: value as LedgerTypeFilter }))}
                                 options={[
-                                    { key: "all", label: `${t("transactions.all")} ${ledgerMetrics.typeCounts.all}` },
-                                    { key: "income", label: `${t("transactions.income")} ${ledgerMetrics.typeCounts.income}` },
-                                    { key: "expense", label: `${t("transactions.expense")} ${ledgerMetrics.typeCounts.expense}` },
-                                    { key: "transfer", label: `${t("transactions.transfer")} ${ledgerMetrics.typeCounts.transfer}` },
+                                    { key: "all", label: `${t("transactions.all")} ${scopedMetrics.typeCounts.all}` },
+                                    { key: "income", label: `${t("transactions.income")} ${scopedMetrics.typeCounts.income}` },
+                                    { key: "expense", label: `${t("transactions.expense")} ${scopedMetrics.typeCounts.expense}` },
+                                    { key: "transfer", label: `${t("transactions.transfer")} ${scopedMetrics.typeCounts.transfer}` },
                                 ]}
                                 size="compact"
                                 value={ledgerFilter.type}

--- a/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.test.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.test.ts
@@ -8,6 +8,7 @@ import {
   getCategoryPathLabel,
   getCurrentTransactionMonthRange,
   getFriendlyTransactionDayLabel,
+  getLedgerMetricsFromSummary,
   getLedgerTypeCounts,
   isCurrentOrFutureTransactionMonth,
   isWholeTransactionMonthRange,
@@ -101,6 +102,39 @@ describe("transaction ledger helpers", () => {
       income: 1,
       expense: 1,
       transfer: 1,
+    });
+  });
+
+  it("builds base-currency ledger metrics from full summary aggregates", () => {
+    const rates = [
+      { id: 1, currencyFrom: "USD", currencyTo: "PLN", date: "2026-06-05", rate: 4, isTemporary: false },
+    ];
+
+    expect(getLedgerMetricsFromSummary({
+      totalCount: 4,
+      typeCounts: {
+        all: 4,
+        income: 1,
+        expense: 2,
+        transfer: 1,
+      },
+      currencySummaries: [
+        { currency: "USD", income: 100, expense: -40, net: 60 },
+        { currency: "PLN", income: 400, expense: -80, net: 320 },
+        { currency: "EUR", income: 999, expense: -999, net: 0 },
+      ],
+    }, rates)).toEqual({
+      income: 200,
+      expense: -60,
+      net: 140,
+      visibleCount: 4,
+      totalCount: 4,
+      typeCounts: {
+        all: 4,
+        income: 1,
+        expense: 2,
+        transfer: 1,
+      },
     });
   });
 

--- a/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.ts
@@ -32,6 +32,19 @@ export interface LedgerMetrics extends LedgerSummary {
   typeCounts: LedgerTypeCounts;
 }
 
+export interface LedgerCurrencySummary {
+  currency: string;
+  income: number;
+  expense: number;
+  net: number;
+}
+
+export interface LedgerSummarySource {
+  totalCount: number;
+  typeCounts: LedgerTypeCounts;
+  currencySummaries: LedgerCurrencySummary[];
+}
+
 export interface ExchangeRateLike {
   currencyFrom: string;
   currencyTo: string;
@@ -100,6 +113,31 @@ export const toBaseCurrencyAmount = (
   if (sameCurrency(accountCurrency, baseCurrency)) return amount;
 
   return getBaseCurrencyEquivalent(amount, accountCurrency, exchangeRates)?.value ?? null;
+};
+
+export const getLedgerMetricsFromSummary = (
+  summary: LedgerSummarySource,
+  exchangeRates: ExchangeRateLike[],
+): LedgerMetrics => {
+  let income = 0;
+  let expense = 0;
+
+  for (const currencySummary of summary.currencySummaries) {
+    const convertedIncome = toBaseCurrencyAmount(currencySummary.income, currencySummary.currency, exchangeRates);
+    const convertedExpense = toBaseCurrencyAmount(currencySummary.expense, currencySummary.currency, exchangeRates);
+
+    if (convertedIncome !== null) income += convertedIncome;
+    if (convertedExpense !== null) expense += convertedExpense;
+  }
+
+  return {
+    income,
+    expense,
+    net: income + expense,
+    visibleCount: summary.totalCount,
+    totalCount: summary.totalCount,
+    typeCounts: summary.typeCounts,
+  };
 };
 
 export const getTransactionKind = (

--- a/inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
+++ b/inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
@@ -5,7 +5,12 @@ import dayjs from "dayjs";
 import { vi } from "vitest";
 
 import apiClient from "../../../utils/apiClient";
-import { transactionsApi, type GetTransactionsArgs, type TransactionsPagedResult } from "../transactions-api";
+import {
+  transactionsApi,
+  type GetTransactionsArgs,
+  type TransactionSummaryResult,
+  type TransactionsPagedResult,
+} from "../transactions-api";
 
 vi.mock("../../../utils/apiClient", () => ({
   default: vi.fn(),
@@ -60,6 +65,24 @@ const updatedFixture: TransactionsPagedResult = {
     },
   ],
   metadata: { totalItems: 2 },
+};
+
+const summaryFixture: TransactionSummaryResult = {
+  totalCount: 2,
+  typeCounts: {
+    all: 2,
+    income: 1,
+    expense: 1,
+    transfer: 0,
+  },
+  currencySummaries: [
+    {
+      currency: "USD",
+      income: 100,
+      expense: -42,
+      net: 58,
+    },
+  ],
 };
 
 function createTestStore() {
@@ -125,6 +148,31 @@ describe("transactionsApi", () => {
     });
   });
 
+  it("getTransactionsSummary: serializes the same filters without pagination", async () => {
+    const store = createTestStore();
+    mockApiClient.mockResolvedValue(axiosResponse(summaryFixture));
+
+    await store.dispatch(
+      transactionsApi.endpoints.getTransactionsSummary.initiate({
+        accountIds: [10],
+        categoryIds: [20],
+        tags: ["food"],
+        refs: ["alice"],
+        range: [
+          dayjs("2026-06-01T00:00:00").unix(),
+          dayjs("2026-06-30T23:59:59").unix(),
+        ],
+      }),
+    );
+
+    expect(mockApiClient).toHaveBeenCalledWith({
+      url: "/transactions/summary?mode=active&accountId=10&categoryId=20&tag=food&ref=alice&startDate=2026-06-01T00%3A00%3A00&endDate=2026-06-30T23%3A59%3A59",
+      method: "get",
+      data: undefined,
+      params: undefined,
+    });
+  });
+
   it("cache invalidation on mutation triggers refetch", async () => {
     const store = createTestStore();
     mockApiClient.mockImplementation(async (config) => {
@@ -156,6 +204,48 @@ describe("transactionsApi", () => {
     await waitFor(() => {
       expect(mockApiClient).toHaveBeenCalledTimes(3);
       expect(transactionsApi.endpoints.getTransactions.select(args)(store.getState()).data).toEqual(updatedFixture);
+    });
+  });
+
+  it("cache invalidation on mutation refreshes subscribed summary data", async () => {
+    const store = createTestStore();
+    const updatedSummary: TransactionSummaryResult = {
+      ...summaryFixture,
+      totalCount: 3,
+      typeCounts: { ...summaryFixture.typeCounts, all: 3, expense: 2 },
+      currencySummaries: [
+        { currency: "USD", income: 100, expense: -54, net: 46 },
+      ],
+    };
+    mockApiClient.mockImplementation(async (config) => {
+      const request = config as AxiosRequestConfig;
+      if (request.method === "post") {
+        return axiosResponse(undefined);
+      }
+
+      const summaryResponse = mockApiClient.mock.calls.length >= 3 ? updatedSummary : summaryFixture;
+      return axiosResponse(summaryResponse);
+    });
+
+    store.dispatch(transactionsApi.endpoints.getTransactionsSummary.initiate(emptyFilter));
+
+    await waitFor(() => {
+      expect(transactionsApi.endpoints.getTransactionsSummary.select(emptyFilter)(store.getState()).data).toEqual(summaryFixture);
+    });
+
+    await store.dispatch(
+      transactionsApi.endpoints.createTransaction.initiate({
+        accountId: 2,
+        categoryId: 3,
+        amount: -12,
+        comment: "Coffee",
+        created: "2026-06-02",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockApiClient).toHaveBeenCalledTimes(3);
+      expect(transactionsApi.endpoints.getTransactionsSummary.select(emptyFilter)(store.getState()).data).toEqual(updatedSummary);
     });
   });
 

--- a/inex/ClientApp/src/store/transactions/transactions-api.ts
+++ b/inex/ClientApp/src/store/transactions/transactions-api.ts
@@ -22,6 +22,26 @@ export interface TransactionsPagedResult {
   metadata: { totalItems: number };
 }
 
+export interface TransactionTypeCounts {
+  all: number;
+  income: number;
+  expense: number;
+  transfer: number;
+}
+
+export interface TransactionCurrencySummary {
+  currency: string;
+  income: number;
+  expense: number;
+  net: number;
+}
+
+export interface TransactionSummaryResult {
+  totalCount: number;
+  typeCounts: TransactionTypeCounts;
+  currencySummaries: TransactionCurrencySummary[];
+}
+
 export const formatTransactionFilterDateTime = (timestamp: number): string =>
   dayjs.unix(timestamp).format("YYYY-MM-DDTHH:mm:ss");
 
@@ -51,15 +71,10 @@ export interface UpdateTransactionArgs {
   created: string;
 }
 
-function buildTransactionParams(
-  pageSize: number,
-  page: number,
+function appendTransactionFilters(
+  params: URLSearchParams,
   filter: TransactionFilterParams,
-): URLSearchParams {
-  const params = new URLSearchParams();
-  params.set("mode", "active");
-  params.set("pageSize", String(pageSize));
-  params.set("page", String(page));
+): void {
   filter.accountIds.forEach((id) => params.append("accountId", String(id)));
   filter.categoryIds.forEach((id) => params.append("categoryId", String(id)));
   filter.tags.forEach((tag) => params.append("tag", tag));
@@ -70,6 +85,27 @@ function buildTransactionParams(
   if (filter.range.length === 2 && filter.range[1] > 0) {
     params.set("endDate", formatTransactionFilterDateTime(filter.range[1]));
   }
+}
+
+function buildTransactionFilterParams(
+  filter: TransactionFilterParams,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("mode", "active");
+  appendTransactionFilters(params, filter);
+  return params;
+}
+
+function buildTransactionParams(
+  pageSize: number,
+  page: number,
+  filter: TransactionFilterParams,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("mode", "active");
+  params.set("pageSize", String(pageSize));
+  params.set("page", String(page));
+  appendTransactionFilters(params, filter);
   return params;
 }
 
@@ -91,6 +127,12 @@ export const transactionsApi = createApi({
     getTransactions: builder.query<TransactionsPagedResult, GetTransactionsArgs>({
       query: ({ pageSize, page, filter }) => ({
         url: `/transactions?${buildTransactionParams(pageSize, page, filter).toString()}`,
+      }),
+      providesTags: [{ type: "Transaction", id: "LIST" }],
+    }),
+    getTransactionsSummary: builder.query<TransactionSummaryResult, TransactionFilterParams>({
+      query: (filter) => ({
+        url: `/transactions/summary?${buildTransactionFilterParams(filter).toString()}`,
       }),
       providesTags: [{ type: "Transaction", id: "LIST" }],
     }),
@@ -135,6 +177,7 @@ export const transactionsApi = createApi({
 
 export const {
   useGetTransactionsQuery,
+  useGetTransactionsSummaryQuery,
   useCreateTransactionMutation,
   useCreateTransferMutation,
   useUpdateTransactionMutation,

--- a/inex/Controllers/TransactionsController.cs
+++ b/inex/Controllers/TransactionsController.cs
@@ -26,6 +26,7 @@ public class TransactionsController : ApiControllerBase
 
     public const string GetSingleRoute = "{id}";
     public const string GetAllRoute = "";
+    public const string GetSummaryRoute = "summary";
 
     public const string PostAddRoute = "";
     public const string PostAddTransferRoute = "transfer";
@@ -72,6 +73,20 @@ public class TransactionsController : ApiControllerBase
         ActivityMode activityMode = mode.ToEnum(ActivityMode.ALL);
         PagedResponse<TransactionResponse, PaginationMetadata> resultsDTO = _transactionService.Get(CurrentUserId, activityMode, pageSize, page, filter);
         return Ok(resultsDTO);
+    }
+
+    /// <summary>Get transaction summary for a user</summary>
+    /// <param name="mode">Activity mode (all, active, inactive)</param>
+    /// <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate.</param>
+    /// <returns>Transaction summary for the filtered scope</returns>
+    [HttpGet]
+    [Route(GetSummaryRoute)]
+    [ProducesResponseType(typeof(TransactionSummaryResponse), StatusCodes.Status200OK)]
+    public ActionResult Summary(string? mode, [FromQuery] TransactionFilterQuery filter)
+    {
+        ActivityMode activityMode = mode.ToEnum(ActivityMode.ALL);
+        TransactionSummaryResponse resultDTO = _transactionService.GetSummary(CurrentUserId, activityMode, filter);
+        return Ok(resultDTO);
     }
 
     /// <summary>Add a new transaction</summary>

--- a/inex/inex.xml
+++ b/inex/inex.xml
@@ -176,6 +176,12 @@
             <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate.</param>
             <returns>List of transactions with pagination metadata</returns>
         </member>
+        <member name="M:inex.Controllers.TransactionsController.Summary(System.String,inex.Services.Models.Records.Transaction.TransactionFilterQuery)">
+            <summary>Get transaction summary for a user</summary>
+            <param name="mode">Activity mode (all, active, inactive)</param>
+            <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate.</param>
+            <returns>Transaction summary for the filtered scope</returns>
+        </member>
         <member name="M:inex.Controllers.TransactionsController.Add(inex.Services.Models.Records.Transaction.CreateTransactionRequest,System.Threading.CancellationToken)">
             <summary>Add a new transaction</summary>
             <param name="itemDTO">Transaction details</param>


### PR DESCRIPTION
Closes #264. Delivers the Transactions month summary KPI fix directly to master. Adds a filtered transaction summary endpoint and uses it for Transactions KPI cards and type counts while keeping ledger rows paginated. Verification: dotnet test inex.Tests/ --filter FullyQualifiedName~TransactionsControllerTests; dotnet test inex.Services.Tests/; npm test -- src/store/transactions/__tests__/transactions-api.test.ts src/pages/Transactions/transaction-ledger-utils.test.ts; npm run build; npm run lint; dotnet build. Note: npm build reports the existing large AntD chunk warning.