### PR TITLE
Validate transaction mutation dates

### DIFF
--- a/docs/implementation/11-1a-harden-transaction-mutation-boundaries.md
+++ b/docs/implementation/11-1a-harden-transaction-mutation-boundaries.md
@@ -1,0 +1,99 @@
+# Story 11.1a: Harden Transaction Mutation Boundaries
+
+Status: in-progress
+
+## Story
+
+As an authenticated manual ledger manager,
+I want transaction mutations and related resource lookups to reject invalid dates and foreign resources consistently,
+so that selected-period work cannot weaken financial data integrity or user isolation.
+
+## Acceptance Criteria
+
+1. A create, update, or transfer request that omits `created` or supplies `default(DateTime)` returns the established validation Problem Details response with the stable error key `created.required`. A valid user-entered local calendar date is preserved without time-zone conversion.
+2. Every transaction mutation lookup of a transaction, account, category, transfer source account, or transfer destination account is scoped by the current authenticated user. Foreign resources follow the existing not-found path.
+3. Service and integration coverage proves the date rules and all cross-user mutation boundaries. Tests do not call an external exchange-rate provider.
+
+## Tasks / Subtasks
+
+- [x] Add date validation to transaction mutations (AC: 1)
+  - [x] Add `Created != default(DateTime)` to `TransactionCreateValidator` with `created.required`; preserve `TransactionUpdateValidator` inheritance.
+  - [x] Add the same `Created` rule and error key to `TransferCreateValidator`.
+  - [x] Do not convert the request date in validators, mappers, or services.
+- [x] Add regression coverage (AC: 1, 3)
+  - [x] Assert omitted and explicit default dates are rejected for create, update, and transfer with 422 `application/problem+json`, `/errors/validation-failed`, and `created.required`.
+  - [x] Add a successful date-only round trip at a DST-boundary calendar date and assert the exact returned `DateTime` is unchanged.
+- [x] Verify current mutation ownership boundaries (AC: 2, 3)
+  - [x] Retain the existing `Id && UserId` service predicates and existing integration coverage for foreign transactions, accounts, categories, and transfer source/destination accounts.
+  - [x] Do not alter generic repository ID-only helpers or widen the story into transfer-category provisioning.
+- [ ] Run verification and document results (AC: 1-3)
+  - [ ] Run focused integration and service tests, then solution build and full tests when feasible.
+  - [ ] Use a MySQL-backed read-only validation path before claiming calendar-date storage behavior is provider-verified; record a setup blocker if unavailable.
+
+## Dev Notes
+
+### Current State and Required Change
+
+- `TransactionService` already scopes target reads/updates/deletes with `Id && UserId`, validates create/update account and category ownership, and resolves both transfer accounts with `Id && UserId`.
+- `TransactionsControllerTests` already covers every foreign-resource path required by the story. Do not duplicate or weaken those tests.
+- `TransactionCreateValidator` and `TransferCreateValidator` currently lack a `Created` rule. `TransactionUpdateValidator` includes `TransactionCreateValidator`, so it inherits the create rule.
+- `TransactionMapper` copies `Created` directly into ordinary and transfer entities. Preserve that behavior; this story introduces no UTC/local conversion, schema change, or API-contract rename.
+- The MySQL entity mapping uses a timestamp-like column. EF InMemory integration tests cannot prove time-zone storage behavior; use MySQL inspection where available and report a blocker otherwise.
+
+### Test Contract
+
+- Follow existing `ValidationTests` Problem Details assertions and extend them to require `application/problem+json` for this validation path.
+- Use valid owned fixture IDs so date validation is the decisive failure.
+- Use a no-offset date-only value such as `2026-03-29` for the successful calendar-date check.
+- Do not start the app, Docker, or an external rate provider for verification.
+
+### Project Structure Notes
+
+- Validators: `inex.Services/Validators/Transaction/`.
+- HTTP regression coverage: `inex.Tests/Validation/ValidationTests.cs` and/or `inex.Tests/Transactions/TransactionsControllerTests.cs`.
+- Retain user ownership enforcement in the service layer; do not change generic repositories.
+
+### References
+
+- [Source: docs/planning/epics.md - Story 11.1a]
+- [Source: docs/planning/transactions-architecture.md - First Implementation Priority]
+- [Source: docs/project-context.md - Security, Testing, and Database Verification]
+- [Source: inex.Services/Services/TransactionService.cs - mutation ownership predicates]
+- [Source: inex.Services/Validators/Transaction/TransactionCreateValidator.cs]
+- [Source: inex.Services/Validators/Transaction/TransactionUpdateValidator.cs]
+- [Source: inex.Services/Validators/Transaction/TransferCreateValidator.cs]
+- [Source: inex.Tests/Transactions/TransactionsControllerTests.cs - ownership regressions]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-08-03: Created from Epic 11 after reviewing transaction service, validators, integration coverage, project context, and recent transaction RTK Query work.
+- 2026-08-03: MySQL MCP read-only inspection confirmed MySQL 8.0.45, `SYSTEM` session/global time zones, and `transaction.created` as `timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP`.
+- 2026-08-03: Provider-backed write/read date round-trip remains blocked: database access is restricted to read-only SQL and this story must not mutate shared data without explicit approval. EF InMemory coverage proves the API/mapping path only; do not claim MySQL calendar-date persistence is verified.
+
+### Completion Notes List
+
+- Added `created.required` validation for create, update (through the included create validator), and transfer requests; default-bound `DateTime` values can no longer reach persistence.
+- Added validator unit tests plus API regression coverage for omitted/default dates, RFC 7807 validation media type and error codes, and an owned-fixture DST-boundary date round trip.
+- Confirmed the existing service-level user predicates and cross-user integration tests already cover transaction, account, category, and both transfer-account boundaries.
+- Review passes fixed fixture ownership and strengthened the calendar-date assertion. MySQL calendar-date round-trip verification remains blocked by read-only database access, so the story stays in progress.
+
+### File List
+
+- docs/implementation/11-1a-harden-transaction-mutation-boundaries.md
+- docs/implementation/sprint-status.yaml
+- inex.Services/Validators/Transaction/TransactionCreateValidator.cs
+- inex.Services/Validators/Transaction/TransferCreateValidator.cs
+- inex.Services.Tests/Validators/TransactionDateValidationTests.cs
+- inex.Tests/Transactions/TransactionsControllerTests.cs
+- inex.Tests/Validation/ValidationTests.cs
+
+## Change Log
+
+- 2026-08-03: Created implementation context from Epic 11; status set to ready-for-dev.
+- 2026-08-03: Added date validation and regression coverage; status remains in-progress pending MySQL write/read calendar-date verification.

--- a/docs/implementation/sprint-status.yaml
+++ b/docs/implementation/sprint-status.yaml
@@ -126,8 +126,8 @@ development_status:
   10-5b-frontend-ux-login-and-registration-redesign: done
   10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist: review
   epic-10-retrospective: optional
-  epic-11: backlog
-  11-1a-harden-transaction-mutation-boundaries: backlog
+  epic-11: in-progress
+  11-1a-harden-transaction-mutation-boundaries: in-progress
   11-1-find-transactions-across-the-full-selected-period: backlog
   11-2-restore-and-control-selected-period-filters: backlog
   11-3-understand-trustworthy-period-summaries: backlog

--- a/inex.Services.Tests/Validators/TransactionDateValidationTests.cs
+++ b/inex.Services.Tests/Validators/TransactionDateValidationTests.cs
@@ -1,0 +1,48 @@
+using inex.Services.Models.Records.Transaction;
+using inex.Services.Validators.Transaction;
+
+namespace inex.Services.Tests.Validators;
+
+public class TransactionDateValidationTests
+{
+    [Fact]
+    public void Create_DefaultCreated_IsInvalidWithStableErrorCode()
+    {
+        var result = new TransactionCreateValidator().Validate(new CreateTransactionRequest
+        {
+            AccountId = 1,
+            CategoryId = 1,
+            Amount = 1m
+        });
+
+        Assert.Contains(result.Errors, error => error.ErrorMessage == "created.required");
+    }
+
+    [Fact]
+    public void Update_DefaultCreated_IsInvalidWithStableErrorCode()
+    {
+        var result = new TransactionUpdateValidator().Validate(new UpdateTransactionRequest
+        {
+            Id = 1,
+            AccountId = 1,
+            CategoryId = 1,
+            Amount = 1m
+        });
+
+        Assert.Contains(result.Errors, error => error.ErrorMessage == "created.required");
+    }
+
+    [Fact]
+    public void Transfer_DefaultCreated_IsInvalidWithStableErrorCode()
+    {
+        var result = new TransferCreateValidator().Validate(new CreateTransferRequest
+        {
+            AccountFromId = 1,
+            AccountToId = 2,
+            AmountFrom = 1m,
+            AmountTo = 1m
+        });
+
+        Assert.Contains(result.Errors, error => error.ErrorMessage == "created.required");
+    }
+}

--- a/inex.Services/Validators/Transaction/TransactionCreateValidator.cs
+++ b/inex.Services/Validators/Transaction/TransactionCreateValidator.cs
@@ -15,5 +15,8 @@ public class TransactionCreateValidator : AbstractValidator<CreateTransactionReq
 
         RuleFor(x => x.CategoryId)
             .GreaterThan(0).WithMessage("category_id.invalid");
+
+        RuleFor(x => x.Created)
+            .NotEqual(default(DateTime)).WithMessage("created.required");
     }
 }

--- a/inex.Services/Validators/Transaction/TransferCreateValidator.cs
+++ b/inex.Services/Validators/Transaction/TransferCreateValidator.cs
@@ -20,5 +20,8 @@ public class TransferCreateValidator : AbstractValidator<CreateTransferRequest>
             .GreaterThan(0).WithMessage("account_to_id.invalid")
             .Must((dto, toId) => toId != dto.AccountFromId)
             .WithMessage("account_to_id.same_as_source");
+
+        RuleFor(x => x.Created)
+            .NotEqual(default(DateTime)).WithMessage("created.required");
     }
 }

--- a/inex.Tests/Transactions/TransactionsControllerTests.cs
+++ b/inex.Tests/Transactions/TransactionsControllerTests.cs
@@ -59,6 +59,35 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
     }
 
     [Fact]
+    public async Task Create_DateOnlyCreated_RoundTripsWithoutCalendarDateConversion()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(client, "date-only-account");
+        int categoryId = await CreateCategoryAsync(client, "date-only-category");
+        var localCalendarDate = new DateTime(2026, 3, 29);
+        const string localCalendarDateInput = "2026-03-29";
+
+        var createResponse = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId,
+            categoryId,
+            created = localCalendarDateInput,
+            amount = 25m,
+            comment = "date-only",
+        });
+        createResponse.EnsureSuccessStatusCode();
+
+        var createBody = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        int transactionId = createBody.GetProperty("id").GetInt32();
+
+        var getResponse = await client.GetAsync($"/api/transactions/{transactionId}");
+        getResponse.EnsureSuccessStatusCode();
+
+        var transaction = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(localCalendarDate, transaction.GetProperty("created").GetDateTime());
+    }
+
+    [Fact]
     public async Task Update_OtherUsersTransaction_Returns404Problem()
     {
         var userA = await CreateAuthenticatedClientAsync();

--- a/inex.Tests/Validation/ValidationTests.cs
+++ b/inex.Tests/Validation/ValidationTests.cs
@@ -29,6 +29,7 @@ public class ValidationTests : IClassFixture<InExWebApplicationFactory>
     private static async Task AssertValidationError(HttpResponseMessage response, string? expectedCode = null)
     {
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("/errors/validation-failed", body.GetProperty("type").GetString());
         Assert.Equal(422, body.GetProperty("status").GetInt32());
@@ -87,6 +88,70 @@ public class ValidationTests : IClassFixture<InExWebApplicationFactory>
         await AssertValidationError(response, "category_id.invalid");
     }
 
+    [Fact]
+    public async Task Transaction_OmittedCreated_Returns422WithCode()
+    {
+        var client = await AuthenticatedClient();
+        var fixture = await CreateTransactionFixtureAsync(client);
+        var response = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            fixture.AccountId,
+            fixture.CategoryId,
+            amount = 100,
+        });
+
+        await AssertValidationError(response, "created.required");
+    }
+
+    [Fact]
+    public async Task Transaction_DefaultCreated_Returns422WithCode()
+    {
+        var client = await AuthenticatedClient();
+        var fixture = await CreateTransactionFixtureAsync(client);
+        var response = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            fixture.AccountId,
+            fixture.CategoryId,
+            created = DateTime.MinValue,
+            amount = 100,
+        });
+
+        await AssertValidationError(response, "created.required");
+    }
+
+    [Fact]
+    public async Task TransactionUpdate_OmittedCreated_Returns422WithCode()
+    {
+        var client = await AuthenticatedClient();
+        var fixture = await CreateTransactionFixtureAsync(client, createTransaction: true);
+        var response = await client.PutAsJsonAsync($"/api/transactions/{fixture.TransactionId}", new
+        {
+            id = fixture.TransactionId,
+            fixture.AccountId,
+            fixture.CategoryId,
+            amount = 100,
+        });
+
+        await AssertValidationError(response, "created.required");
+    }
+
+    [Fact]
+    public async Task TransactionUpdate_DefaultCreated_Returns422WithCode()
+    {
+        var client = await AuthenticatedClient();
+        var fixture = await CreateTransactionFixtureAsync(client, createTransaction: true);
+        var response = await client.PutAsJsonAsync($"/api/transactions/{fixture.TransactionId}", new
+        {
+            id = fixture.TransactionId,
+            fixture.AccountId,
+            fixture.CategoryId,
+            created = DateTime.MinValue,
+            amount = 100,
+        });
+
+        await AssertValidationError(response, "created.required");
+    }
+
     // ── Transfers ──────────────────────────────────────────────────────────────
 
     [Fact]
@@ -117,6 +182,41 @@ public class ValidationTests : IClassFixture<InExWebApplicationFactory>
             created       = "2026-01-01",
         });
         await AssertValidationError(response, "amount_from.must_be_positive");
+    }
+
+    [Fact]
+    public async Task Transfer_OmittedCreated_Returns422WithCode()
+    {
+        var client = await AuthenticatedClient();
+        int sourceAccountId = await CreateAccountAsync(client);
+        int destinationAccountId = await CreateAccountAsync(client);
+        var response = await client.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = sourceAccountId,
+            accountToId = destinationAccountId,
+            amountFrom = 100,
+            amountTo = 100,
+        });
+
+        await AssertValidationError(response, "created.required");
+    }
+
+    [Fact]
+    public async Task Transfer_DefaultCreated_Returns422WithCode()
+    {
+        var client = await AuthenticatedClient();
+        int sourceAccountId = await CreateAccountAsync(client);
+        int destinationAccountId = await CreateAccountAsync(client);
+        var response = await client.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = sourceAccountId,
+            accountToId = destinationAccountId,
+            amountFrom = 100,
+            amountTo = 100,
+            created = DateTime.MinValue,
+        });
+
+        await AssertValidationError(response, "created.required");
     }
 
     // ── Accounts ──────────────────────────────────────────────────────────────
@@ -222,4 +322,62 @@ public class ValidationTests : IClassFixture<InExWebApplicationFactory>
         });
         await AssertValidationError(response, "name.required");
     }
+
+    private static async Task<TransactionFixture> CreateTransactionFixtureAsync(HttpClient client, bool createTransaction = false)
+    {
+        int accountId = await CreateAccountAsync(client);
+        int categoryId = await CreateCategoryAsync(client);
+        int? transactionId = null;
+
+        if (createTransaction)
+        {
+            var response = await client.PostAsJsonAsync("/api/transactions", new
+            {
+                accountId,
+                categoryId,
+                created = "2026-03-29",
+                amount = 100,
+            });
+            response.EnsureSuccessStatusCode();
+
+            var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+            transactionId = body.GetProperty("id").GetInt32();
+        }
+
+        return new TransactionFixture(accountId, categoryId, transactionId);
+    }
+
+    private static async Task<int> CreateAccountAsync(HttpClient client)
+    {
+        string key = $"acc-{Guid.NewGuid():N}";
+        var response = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            key,
+            name = key,
+            currencyId = 1,
+            isEnabled = true,
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private static async Task<int> CreateCategoryAsync(HttpClient client)
+    {
+        string key = $"cat-{Guid.NewGuid():N}";
+        var response = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key,
+            name = key,
+            isEnabled = true,
+            isSystem = false,
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private sealed record TransactionFixture(int AccountId, int CategoryId, int? TransactionId);
 }


### PR DESCRIPTION
## Summary
- reject omitted and default transaction dates for create, update, and transfer requests with `created.required`
- add validator and API regression coverage for the RFC 7807 validation contract
- retain verified ownership-scoped mutation lookups and cross-user regression coverage

## Verification
- `dotnet build inex.sln`
- `dotnet test inex.Services.Tests/` — 91 passed
- `dotnet test inex.Tests/` — 111 passed
- MySQL MCP read-only inspection confirmed the transaction date column is `TIMESTAMP` and the session time zone is `SYSTEM`.

## Review
- Blind Hunter, Edge Case Hunter, and Acceptance Auditor review passes completed.
- Fixed review findings for owned test fixtures and exact date-time round-trip assertion.

## Remaining blocker
A MySQL write/read calendar-date round trip is not included because database access is restricted to read-only SQL. This draft PR must remain unmerged until that provider-level verification is completed.