### PR TITLE
Find transactions across the full selected period

### DIFF
--- a/docs/implementation/11-1-find-transactions-across-the-full-selected-period.md
+++ b/docs/implementation/11-1-find-transactions-across-the-full-selected-period.md
@@ -1,0 +1,118 @@
+# Story 11.1: Find Transactions Across the Full Selected Period
+
+Status: review
+
+## Story
+
+As an authenticated manual ledger manager,
+I want Type and Search filters to return every matching transaction in my selected period,
+so that the ledger, counts, and summaries are based on the same complete result set rather than the currently loaded page.
+
+## Acceptance Criteria
+
+1. The authenticated, active-data transaction query applies account, category, tag, reference, date, Type, and Search filters before ordering, counting, aggregation, or pagination. The list metadata and unpaginated summary describe the same scope.
+2. `type` supports `all`, `income`, `expense`, and `transfer`: Income and Expense follow the established signed non-system-category semantics; Transfer selects system-category records.
+3. `search` is trimmed and case-insensitive, remains provider-translated, and matches comment, account name, category name/path, account currency, tags, and references. Whitespace-only Search is ignored; no list, summary, or account-balance path may materialize transactions for filtering.
+4. Both list and summary accept additive `type` and `search` query parameters without changing existing account/category/tag/reference/date parameter semantics, routes, response shapes, or `mode=active` behavior. Do not introduce an Amount API parameter or behavior.
+5. Every filter, relation, aggregate, and returned row remains scoped by `UserId`; cross-user records and relations cannot influence list metadata or summaries. Single-record foreign access remains a not-found response.
+6. MySQL verification demonstrates Search SQL translation, case behavior, and list/summary plans. With one user holding 50,000 transactions, representative list and summary Search complete in at most one second under documented local conditions. Add an ownership/date/filter-aligned index and migration only when that evidence requires it.
+
+## Tasks / Subtasks
+
+- [x] Establish one canonical backend query pipeline (AC: 1, 5)
+  - [x] Start with `UserId` and activity mode, then apply every typed filter; apply deterministic Created/Id ordering last.
+  - [x] Reuse this unpaginated `IQueryable` for list pagination, metadata, summary counts, and currency aggregates.
+- [x] Extend the typed filter contract and semantics (AC: 2-4)
+  - [x] Add camel-case `type` and `search` binding to `TransactionFilterQuery` without changing existing parameter names or array AND semantics.
+  - [x] Implement trim/whitespace handling and database-translated case-insensitive Search across the required transaction and relation fields.
+  - [x] Preserve the existing controller routes, `mode=active`, response contracts, mapper behavior, and provider-free summary calculation.
+- [x] Extend the client API contract only (AC: 3-4)
+  - [x] Extend `TransactionFilterParams` and the shared RTK Query parameter builder so list and summary serialize the same normalized Type/Search values.
+  - [x] Keep existing `apiClient`, invalidation tags, repeated filters, and inclusive date-time serialization unchanged.
+  - [x] Do not move page-local controls, URL state, Amount removal, progressive loading, or UI behavior into this story; they belong to Story 11.2.
+- [x] Add regression and provider verification (AC: 1-6)
+  - [x] Add integration coverage for complete-scope list metadata/summary, Type/Search semantics, whitespace Search, all Search fields, and cross-user exclusion.
+  - [x] Assert generated Search SQL is provider-translated; MySQL MCP confirmed case behavior and a read-only `EXPLAIN` plan.
+  - [ ] Run a documented 50,000-record MySQL list-and-summary timing gate. Blocked: the approved read-only database has no user-scoped 50,000-record fixture, and seeding one requires unapproved writes.
+  - [x] Add focused RTK Query serialization tests, then run frontend test/lint/build and backend focused verification. The full solution suite was attempted twice but did not complete; its documented runner blocker remains.
+
+## Dev Notes
+
+### Implementation Constraints
+
+- Story 11.1a is complete. It established default-date validation and mutation lookup ownership boundaries; do not reopen its transfer/category scope.
+- `TransactionService.GetTransactions(int, ActivityMode, TransactionFilterQuery)` currently orders before applying the activity mode. Refactor it so the base query applies `UserId`, mode, and all filters before ordering. Do not duplicate list and summary predicates.
+- `TransactionSummaryResponse` stays unchanged in this story. Story 11.3 owns its date-and-currency bucket/comparison evolution.
+- Search must be an EF/MySQL-translated predicate. Do not call `AsEnumerable`, `ToList`, or apply `ToLower()` client-side. Case behavior must be verified against MySQL rather than EF InMemory.
+- Existing tag/ref filters search marker text in `Comment`; Search must also cover the current ledger projection fields, including tags/refs. Keep multiple tag/ref filters ANDed as today.
+- An index is conditional. Existing MySQL indexes cover `user_fk`, `account_fk`, and `category_fk`; use the 50,000-record plan/timing evidence to decide whether a migration is justified.
+- No exchange-rate provider call, time-zone model change, full-text-search infrastructure, account-balance work, schema change by default, or dependency upgrade is authorized.
+
+### Frontend Boundary
+
+- `transactions-api.ts` is the only intended frontend implementation surface. Its query args are part of RTK Query cache keys, so normalized Type/Search values must be passed to both list and summary builders.
+- Existing `Transactions.tsx` and `TransactionList.tsx` still apply page-local Type/Search/Amount logic. Replacing that state, URL serialization, chips, filter-drawer controls, and Amount behavior is explicitly Story 11.2 work; do not mix it into this PR.
+- This contract-only frontend change adds no user-visible strings or visual change, so visual QA is not required for this story.
+
+### Testing Requirements
+
+- Backend: extend `inex.Tests/Transactions/TransactionsControllerTests.cs` using its authenticated, isolated fixture helpers. Cover multi-page scope before count/summary, all four Type modes, trimmed/whitespace Search, every required Search field, and cross-user exclusion.
+- SQL translation: update the existing MySQL-provider `ToQueryString()` regression to assert Search uses SQL expressions/joins and does not throw translation errors. This test proves generation, not MySQL execution or performance.
+- Frontend: extend `inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts` to prove list and summary serialize normalized Type/Search identically and omit blank Search.
+- Run `dotnet test inex.Services.Tests/`, focused integration tests, `dotnet build inex.sln`, and `dotnet test inex.sln`; run the closest reliable subset and record a blocker if full verification is infeasible. Run frontend targeted Vitest, `npm run lint`, and `npm run build` from `inex/ClientApp`.
+- MySQL: only read-only inspection is authorized. Never seed, modify, or remove shared records. A 50,000-transaction performance check requiring writes is blocked unless the dataset already exists or explicit approval is granted.
+
+### Project Structure Notes
+
+- Query contract: `inex.Services/Models/Records/Transaction/TransactionFilterQuery.cs`.
+- Query composition and summary reuse: `inex.Services/Services/TransactionService.cs`; service interface remains under `inex.Services/Services/Base/`.
+- HTTP binding: `inex/Controllers/TransactionsController.cs`.
+- Client serialization/cache: `inex/ClientApp/src/store/transactions/transactions-api.ts`.
+- Keep backend contracts as records and all authenticated client calls on the existing shared API client.
+
+### References
+
+- [Source: docs/planning/epics.md - Story 11.1]
+- [Source: docs/planning/transactions-architecture.md - Data Architecture, API & Communication Patterns, and Verification]
+- [Source: docs/planning/prds/prd-inex-2026-08-03/prd.md - Transactions requirements]
+- [Source: docs/implementation/11-1a-harden-transaction-mutation-boundaries.md - prerequisite learnings]
+- [Source: docs/project-context.md - critical implementation and MySQL verification rules]
+- [Source: inex.Services/Services/TransactionService.cs - current query and summary pipeline]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-08-03: Created from the approved Epic 11 specification after examining the prior mutation-boundary story, transaction architecture, current query pipeline, RTK Query API contract, tests, and MySQL indexes.
+- 2026-08-03: MySQL read-only inspection found only single-column transaction indexes (`user_fk`, `account_fk`, `category_fk`). No migration is warranted until the required query-plan and timing evidence demonstrates need.
+
+### Completion Notes List
+
+- Ultimate context engine analysis completed - comprehensive developer guide created.
+- Implemented the ownership- and activity-scoped typed query pipeline; Type/Search now apply before ordering, pagination, list metadata, and summary aggregation.
+- Added Type/Search query binding, database-translated case-insensitive relation search, normalized RTK Query serialization/cache keys, and integration/frontend regression coverage.
+- MySQL read-only inspection verified case matching and the Search-shaped `EXPLAIN` plan. The 50,000-record timing gate remains blocked by the read-only database policy and absent fixture.
+- Three review passes found and resolved cache-key normalization, tag/reference test-independence, and test-helper ownership concerns. The single-level category parent path follows the existing category-creation UI constraint.
+- Focused transaction integration tests, services tests, solution build, frontend Vitest, lint, and production build pass. The full `dotnet test inex.sln --no-build` run hung without output and was stopped; an immediate focused retry required `--disable-build-servers` and passed.
+
+### File List
+
+- docs/implementation/11-1-find-transactions-across-the-full-selected-period.md
+- docs/implementation/11-1a-harden-transaction-mutation-boundaries.md
+- docs/implementation/sprint-status.yaml
+- inex.Services/Models/Records/Transaction/TransactionFilterQuery.cs
+- inex.Services/Services/TransactionService.cs
+- inex/Controllers/TransactionsController.cs
+- inex.Tests/Transactions/TransactionsControllerTests.cs
+- inex/ClientApp/src/store/transactions/transactions-api.ts
+- inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
+
+## Change Log
+
+- 2026-08-03: Created comprehensive implementation context; status set to ready-for-dev.
+- 2026-08-03: Delivery started on the Story 11.1 branch.
+- 2026-08-03: Implemented, verified, and reviewed; status set to review pending the documented MySQL 50,000-record gate and full-suite runner blocker.

--- a/docs/implementation/11-1a-harden-transaction-mutation-boundaries.md
+++ b/docs/implementation/11-1a-harden-transaction-mutation-boundaries.md
@@ -1,6 +1,6 @@
 # Story 11.1a: Harden Transaction Mutation Boundaries
 
-Status: in-progress
+Status: done
 
 ## Story
 
@@ -26,9 +26,9 @@ so that selected-period work cannot weaken financial data integrity or user isol
 - [x] Verify current mutation ownership boundaries (AC: 2, 3)
   - [x] Retain the existing `Id && UserId` service predicates and existing integration coverage for foreign transactions, accounts, categories, and transfer source/destination accounts.
   - [x] Do not alter generic repository ID-only helpers or widen the story into transfer-category provisioning.
-- [ ] Run verification and document results (AC: 1-3)
-  - [ ] Run focused integration and service tests, then solution build and full tests when feasible.
-  - [ ] Use a MySQL-backed read-only validation path before claiming calendar-date storage behavior is provider-verified; record a setup blocker if unavailable.
+- [x] Run verification and document results (AC: 1-3)
+  - [x] Run focused integration and service tests, then solution build and full tests when feasible.
+  - [x] Use a MySQL-backed read-only validation path before claiming calendar-date storage behavior is provider-verified; record a setup blocker if unavailable.
 
 ## Dev Notes
 
@@ -81,7 +81,8 @@ GPT-5 Codex
 - Added `created.required` validation for create, update (through the included create validator), and transfer requests; default-bound `DateTime` values can no longer reach persistence.
 - Added validator unit tests plus API regression coverage for omitted/default dates, RFC 7807 validation media type and error codes, and an owned-fixture DST-boundary date round trip.
 - Confirmed the existing service-level user predicates and cross-user integration tests already cover transaction, account, category, and both transfer-account boundaries.
-- Review passes fixed fixture ownership and strengthened the calendar-date assertion. MySQL calendar-date round-trip verification remains blocked by read-only database access, so the story stays in progress.
+- Review passes fixed fixture ownership and strengthened the calendar-date assertion. MySQL calendar-date round-trip verification remains blocked by read-only database access.
+- User accepted the remaining MySQL write/read verification risk and marked the story done on 2026-08-03.
 
 ### File List
 
@@ -96,4 +97,5 @@ GPT-5 Codex
 ## Change Log
 
 - 2026-08-03: Created implementation context from Epic 11; status set to ready-for-dev.
-- 2026-08-03: Added date validation and regression coverage; status remains in-progress pending MySQL write/read calendar-date verification.
+- 2026-08-03: Added date validation and regression coverage; status remained in-progress pending MySQL write/read calendar-date verification.
+- 2026-08-03: Marked done with the remaining MySQL provider round-trip verification accepted as a documented risk.

--- a/docs/implementation/sprint-status.yaml
+++ b/docs/implementation/sprint-status.yaml
@@ -36,7 +36,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-05-26T16:11:20.6477763+02:00
-last_updated: 2026-08-03T00:00:00+02:00
+last_updated: 2026-08-03T22:00:00+02:00
 project: inex
 project_key: NOKEY
 tracking_system: file-system
@@ -127,8 +127,8 @@ development_status:
   10-6-frontend-ux-visual-qa-baseline-and-responsive-regression-checklist: review
   epic-10-retrospective: optional
   epic-11: in-progress
-  11-1a-harden-transaction-mutation-boundaries: in-progress
-  11-1-find-transactions-across-the-full-selected-period: backlog
+  11-1a-harden-transaction-mutation-boundaries: done
+  11-1-find-transactions-across-the-full-selected-period: review
   11-2-restore-and-control-selected-period-filters: backlog
   11-3-understand-trustworthy-period-summaries: backlog
   11-4-recognize-ledger-state-and-recover-without-losing-context: backlog

--- a/inex.Services/Models/Records/Transaction/TransactionFilterQuery.cs
+++ b/inex.Services/Models/Records/Transaction/TransactionFilterQuery.cs
@@ -22,4 +22,10 @@ public record TransactionFilterQuery
 
     [FromQuery(Name = "endDate")]
     public DateTime? EndDate { get; init; }
+
+    [FromQuery(Name = "type")]
+    public string? Type { get; init; }
+
+    [FromQuery(Name = "search")]
+    public string? Search { get; init; }
 }

--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -270,6 +270,34 @@ public class TransactionService : InExService, ITransactionService
             items = items.Where(i => i.Created <= endDate);
         }
 
+        switch (filter.Type?.Trim().ToLowerInvariant())
+        {
+            case "income":
+                items = items.Where(i => !i.Category.IsSystem && i.Value >= 0);
+                break;
+            case "expense":
+                items = items.Where(i => !i.Category.IsSystem && i.Value < 0);
+                break;
+            case "transfer":
+                items = items.Where(i => i.Category.IsSystem);
+                break;
+        }
+
+        string? search = filter.Search?.Trim().ToLowerInvariant();
+        if (!string.IsNullOrEmpty(search))
+        {
+            items = items.Where(i =>
+                (i.Comment != null && i.Comment.ToLower().Contains(search)) ||
+                i.Account.Name.ToLower().Contains(search) ||
+                i.Category.Name.ToLower().Contains(search) ||
+                (i.Category.ParentCategory != null &&
+                    i.Category.ParentCategory.UserId == i.UserId &&
+                    i.Category.ParentCategory.Name.ToLower().Contains(search)) ||
+                i.Account.Currency.Key.ToLower().Contains(search) ||
+                i.TransactionTagDetails.Any(detail =>
+                    detail.Tag.UserId == i.UserId && detail.Tag.Key.ToLower().Contains(search)));
+        }
+
         return items;
     }
 
@@ -296,20 +324,26 @@ public class TransactionService : InExService, ITransactionService
 
     internal IQueryable<Transaction> GetTransactions(int userId, ActivityMode mode, TransactionFilterQuery filter)
     {
-        IQueryable<Transaction> items = ApplyFilters(DbInEx.TransactionRepository
+        IQueryable<Transaction> items = DbInEx.TransactionRepository
             .GetWithIncludePaths(true, null, "Account.Currency", "Category")
-            .Where(i => i.UserId == userId)
-            .OrderByDescending(i => i.Created)
-            .ThenByDescending(i => i.Id), filter);
+            .Where(i => i.UserId == userId && i.Account.UserId == userId && i.Category.UserId == userId);
 
-        return mode switch
+        items = ApplyActivityMode(items, mode);
+        items = ApplyFilters(items, filter);
+
+        return items
+            .OrderByDescending(i => i.Created)
+            .ThenByDescending(i => i.Id);
+    }
+
+    private static IQueryable<Transaction> ApplyActivityMode(IQueryable<Transaction> items, ActivityMode mode) =>
+        mode switch
         {
             ActivityMode.ACTIVE => items.Where(i => i.Account.IsEnabled && i.Category.IsEnabled),
             ActivityMode.INACTIVE => items.Where(i => !i.Account.IsEnabled || !i.Category.IsEnabled),
             ActivityMode.ALL => items,
             _ => throw new ArgumentException($"Unknown ActivityMode: {mode}")
         };
-    }
 
     private Transaction ProcessTagsRefs(Transaction transaction, int userId)
     {

--- a/inex.Tests/Transactions/TransactionsControllerTests.cs
+++ b/inex.Tests/Transactions/TransactionsControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using inex.Data;
+using inex.Services.Models.Records.Transaction;
 using inex.Services.Services;
 using inex.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -455,6 +456,115 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
     }
 
     [Fact]
+    public async Task ListAndSummary_SearchUseTheCompleteFilteredScopeBeforePagination()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(client, "full-scope-account");
+        int categoryId = await CreateCategoryAsync(client, "full-scope-category");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 100m, "Selected ledger item one");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, -40m, "Selected ledger item two");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 15m, "Selected ledger item three");
+        await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 999m, "different scope");
+
+        var listResponse = await client.GetAsync("/api/transactions?search=SELECTED%20LEDGER&pageSize=2&page=1");
+        var summaryResponse = await client.GetAsync("/api/transactions/summary?search=SELECTED%20LEDGER");
+
+        listResponse.EnsureSuccessStatusCode();
+        summaryResponse.EnsureSuccessStatusCode();
+
+        var list = await listResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var summary = await summaryResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(2, list.GetProperty("data").GetArrayLength());
+        Assert.Equal(3, list.GetProperty("metadata").GetProperty("totalItems").GetInt32());
+        Assert.Equal(3, summary.GetProperty("totalCount").GetInt32());
+        Assert.Equal(2, summary.GetProperty("typeCounts").GetProperty("income").GetInt32());
+        Assert.Equal(1, summary.GetProperty("typeCounts").GetProperty("expense").GetInt32());
+    }
+
+    [Fact]
+    public async Task Search_IsTrimmedCaseInsensitiveAndMatchesLedgerRelations()
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(client, "needle-account");
+        int parentCategoryId = await CreateCategoryAsync(client, "needle-parent");
+        int categoryId = await CreateCategoryAsync(client, "needle-category", parentCategoryId);
+        int commentId = await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 10m, "needle-comment");
+        int tagId = await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 10m, "tagged #needle-tag");
+        int refId = await CreateTransactionWithAmountAndCommentAsync(client, accountId, categoryId, 10m, "referenced @needle-ref");
+        await UpdateTransactionCommentAsync(client, tagId, accountId, categoryId, "tag relation only");
+        await UpdateTransactionCommentAsync(client, refId, accountId, categoryId, "reference relation only");
+
+        await AssertSearchContainsAsync(client, "  NEEDLE-COMMENT  ", commentId);
+        await AssertSearchContainsAsync(client, "NEEDLE-TAG", tagId);
+        await AssertSearchContainsAsync(client, "NEEDLE-REF", refId);
+        await AssertSearchContainsAsync(client, "NEEDLE-ACCOUNT", commentId, tagId, refId);
+        await AssertSearchContainsAsync(client, "NEEDLE-CATEGORY", commentId, tagId, refId);
+        await AssertSearchContainsAsync(client, "NEEDLE-PARENT", commentId, tagId, refId);
+        await AssertSearchContainsAsync(client, "USD", commentId, tagId, refId);
+
+        var whitespaceResponse = await client.GetAsync("/api/transactions?search=%20%20%20&pageSize=20&page=1");
+        whitespaceResponse.EnsureSuccessStatusCode();
+        var whitespaceList = await whitespaceResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(3, whitespaceList.GetProperty("metadata").GetProperty("totalItems").GetInt32());
+    }
+
+    [Theory]
+    [InlineData("all", 4, 1, 1, 2)]
+    [InlineData("income", 1, 1, 0, 0)]
+    [InlineData("expense", 1, 0, 1, 0)]
+    [InlineData("transfer", 2, 0, 0, 2)]
+    public async Task TypeFilter_UsesIncomeExpenseAndTransferSemantics(string type, int total, int income, int expense, int transfer)
+    {
+        var client = await CreateAuthenticatedClientAsync();
+        int sourceAccountId = await CreateAccountAsync(client, "type-source");
+        int destinationAccountId = await CreateAccountAsync(client, "type-destination");
+        int categoryId = await CreateCategoryAsync(client, "type-category");
+        await CreateTransactionWithAmountAndCommentAsync(client, sourceAccountId, categoryId, 10m, "income");
+        await CreateTransactionWithAmountAndCommentAsync(client, sourceAccountId, categoryId, -5m, "expense");
+
+        var transferResponse = await client.PostAsJsonAsync("/api/transactions/transfer", new
+        {
+            accountFromId = sourceAccountId,
+            accountToId = destinationAccountId,
+            created = DateTime.UtcNow,
+            amountFrom = 7m,
+            amountTo = 7m,
+            comment = "transfer",
+        });
+        transferResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync($"/api/transactions/summary?type={type}");
+        response.EnsureSuccessStatusCode();
+        var summary = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var counts = summary.GetProperty("typeCounts");
+        Assert.Equal(total, summary.GetProperty("totalCount").GetInt32());
+        Assert.Equal(total, counts.GetProperty("all").GetInt32());
+        Assert.Equal(income, counts.GetProperty("income").GetInt32());
+        Assert.Equal(expense, counts.GetProperty("expense").GetInt32());
+        Assert.Equal(transfer, counts.GetProperty("transfer").GetInt32());
+    }
+
+    [Fact]
+    public async Task Search_ExcludesOtherUsersMatchingTransactions()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int ownAccountId = await CreateAccountAsync(userA, "own-search-account");
+        int ownCategoryId = await CreateCategoryAsync(userA, "own-search-category");
+        int otherAccountId = await CreateAccountAsync(userB, "other-search-account");
+        int otherCategoryId = await CreateCategoryAsync(userB, "other-search-category");
+        await CreateTransactionWithAmountAndCommentAsync(userA, ownAccountId, ownCategoryId, 10m, "shared-search-term");
+        await CreateTransactionWithAmountAndCommentAsync(userB, otherAccountId, otherCategoryId, 100m, "shared-search-term");
+
+        var response = await userA.GetAsync("/api/transactions/summary?search=shared-search-term");
+
+        response.EnsureSuccessStatusCode();
+        var summary = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(1, summary.GetProperty("totalCount").GetInt32());
+        Assert.Equal(10m, Assert.Single(summary.GetProperty("currencySummaries").EnumerateArray()).GetProperty("income").GetDecimal());
+    }
+
+    [Fact]
     public void ApplyFilters_ByTagAndRef_ProducesDatabaseSideSql()
     {
         var options = new DbContextOptionsBuilder<InExDbContext>()
@@ -474,6 +584,27 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
         Assert.Contains("transaction_tag_map", sql, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("`key`", sql, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("tag_type", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ApplyFilters_WithTypeAndSearch_ProducesDatabaseSideSql()
+    {
+        var options = new DbContextOptionsBuilder<InExDbContext>()
+            .UseMySql("Server=localhost;Database=inex;User=root;Password=password;", new MySqlServerVersion(new Version(8, 0, 0)))
+            .Options;
+
+        using var db = new InExDbContext(options);
+        var query = TransactionService.ApplyFilters(db.Transactions, new TransactionFilterQuery
+        {
+            Type = "expense",
+            Search = "Ledger",
+        });
+
+        string sql = query.ToQueryString();
+
+        Assert.Contains("LOWER", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("transaction_tag_map", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("category", sql, StringComparison.OrdinalIgnoreCase);
     }
 
     private Task<HttpClient> CreateAuthenticatedClientAsync() =>
@@ -505,12 +636,13 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
         return body.GetProperty("id").GetInt32();
     }
 
-    private static async Task<int> CreateCategoryAsync(HttpClient client, string key)
+    private static async Task<int> CreateCategoryAsync(HttpClient client, string key, int? parentId = null)
     {
         var response = await client.PostAsJsonAsync("/api/categories", new
         {
             key,
             name      = key,
+            parentId,
             isEnabled = true,
             isSystem  = false,
         });
@@ -553,6 +685,30 @@ public class TransactionsControllerTests : IClassFixture<InExWebApplicationFacto
 
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         return body.GetProperty("id").GetInt32();
+    }
+
+    private static async Task AssertSearchContainsAsync(HttpClient client, string search, params int[] expectedIds)
+    {
+        var response = await client.GetAsync($"/api/transactions?search={Uri.EscapeDataString(search)}&pageSize=20&page=1");
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var ids = body.GetProperty("data").EnumerateArray().Select(transaction => transaction.GetProperty("id").GetInt32());
+        Assert.Equal(expectedIds.OrderBy(id => id), ids.OrderBy(id => id));
+    }
+
+    private static async Task UpdateTransactionCommentAsync(HttpClient client, int transactionId, int accountId, int categoryId, string comment)
+    {
+        var response = await client.PutAsJsonAsync($"/api/transactions/{transactionId}", new
+        {
+            id = transactionId,
+            accountId,
+            categoryId,
+            created = DateTime.UtcNow,
+            amount = 10m,
+            comment,
+        });
+        response.EnsureSuccessStatusCode();
     }
 
     private sealed record TransactionFixtureIds(int AccountId, int CategoryId, int TransactionId);

--- a/inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
+++ b/inex/ClientApp/src/store/transactions/__tests__/transactions-api.test.ts
@@ -176,6 +176,58 @@ describe("transactionsApi", () => {
     });
   });
 
+  it("serializes normalized Type and Search for both list and summary", async () => {
+    const store = createTestStore();
+    mockApiClient.mockResolvedValue(axiosResponse(fixture));
+    const filter = { ...emptyFilter, type: "expense" as const, search: "  groceries  " };
+
+    await store.dispatch(transactionsApi.endpoints.getTransactions.initiate({ pageSize: 25, page: 1, filter }));
+    await store.dispatch(transactionsApi.endpoints.getTransactionsSummary.initiate(filter));
+
+    expect(mockApiClient).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      url: "/transactions?mode=active&pageSize=25&page=1&type=expense&search=groceries",
+    }));
+    expect(mockApiClient).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      url: "/transactions/summary?mode=active&type=expense&search=groceries",
+    }));
+  });
+
+  it("omits blank Search and the all Type from transaction query parameters", async () => {
+    const store = createTestStore();
+    mockApiClient.mockResolvedValue(axiosResponse(fixture));
+
+    await store.dispatch(transactionsApi.endpoints.getTransactions.initiate({
+      pageSize: 25,
+      page: 1,
+      filter: { ...emptyFilter, type: "all", search: "   " },
+    }));
+
+    expect(mockApiClient).toHaveBeenCalledWith(expect.objectContaining({
+      url: "/transactions?mode=active&pageSize=25&page=1",
+    }));
+  });
+
+  it("shares a cache entry for equivalent normalized Type and Search filters", async () => {
+    const store = createTestStore();
+    mockApiClient.mockResolvedValue(axiosResponse(fixture));
+    const firstArgs = {
+      pageSize: 25,
+      page: 1,
+      filter: { ...emptyFilter, type: "expense" as const, search: "  groceries  " },
+    };
+    const equivalentArgs = {
+      pageSize: 25,
+      page: 1,
+      filter: { ...emptyFilter, type: "expense" as const, search: "groceries" },
+    };
+
+    await store.dispatch(transactionsApi.endpoints.getTransactions.initiate(firstArgs));
+    await store.dispatch(transactionsApi.endpoints.getTransactions.initiate(equivalentArgs));
+
+    expect(mockApiClient).toHaveBeenCalledTimes(1);
+    expect(transactionsApi.endpoints.getTransactions.select(equivalentArgs)(store.getState()).data).toEqual(fixture);
+  });
+
   it("cache invalidation on mutation triggers refetch", async () => {
     const store = createTestStore();
     mockApiClient.mockImplementation(async (config) => {

--- a/inex/ClientApp/src/store/transactions/transactions-api.ts
+++ b/inex/ClientApp/src/store/transactions/transactions-api.ts
@@ -9,7 +9,12 @@ import { budgetReportApi } from "../budgetReport/budgetReport-api";
 import { reportApi } from "../report/report-api";
 import type { TransactionFilter } from "./transactions-slice";
 
-export type TransactionFilterParams = TransactionFilter;
+export type TransactionFilterType = "all" | "income" | "expense" | "transfer";
+
+export type TransactionFilterParams = TransactionFilter & {
+  type?: TransactionFilterType;
+  search?: string;
+};
 
 export interface GetTransactionsArgs {
   pageSize: number;
@@ -41,6 +46,20 @@ export interface TransactionSummaryResult {
   typeCounts: TransactionTypeCounts;
   currencySummaries: TransactionCurrencySummary[];
 }
+
+const normalizeTransactionFilterParams = (
+  filter: TransactionFilterParams,
+): TransactionFilterParams => {
+  const normalizedType = filter.type?.trim().toLowerCase();
+  const type: TransactionFilterType | undefined = normalizedType === "income" ||
+    normalizedType === "expense" ||
+    normalizedType === "transfer"
+    ? normalizedType
+    : undefined;
+  const search = filter.search?.trim() || undefined;
+
+  return { ...filter, type, search };
+};
 
 export const formatTransactionFilterDateTime = (timestamp: number): string =>
   dayjs.unix(timestamp).format("YYYY-MM-DDTHH:mm:ss");
@@ -75,15 +94,25 @@ function appendTransactionFilters(
   params: URLSearchParams,
   filter: TransactionFilterParams,
 ): void {
-  filter.accountIds.forEach((id) => params.append("accountId", String(id)));
-  filter.categoryIds.forEach((id) => params.append("categoryId", String(id)));
-  filter.tags.forEach((tag) => params.append("tag", tag));
-  filter.refs.forEach((ref) => params.append("ref", ref));
-  if (filter.range.length === 2 && filter.range[0] > 0) {
-    params.set("startDate", formatTransactionFilterDateTime(filter.range[0]));
+  const normalizedFilter = normalizeTransactionFilterParams(filter);
+
+  normalizedFilter.accountIds.forEach((id) => params.append("accountId", String(id)));
+  normalizedFilter.categoryIds.forEach((id) => params.append("categoryId", String(id)));
+  normalizedFilter.tags.forEach((tag) => params.append("tag", tag));
+  normalizedFilter.refs.forEach((ref) => params.append("ref", ref));
+  if (normalizedFilter.range.length === 2 && normalizedFilter.range[0] > 0) {
+    params.set("startDate", formatTransactionFilterDateTime(normalizedFilter.range[0]));
   }
-  if (filter.range.length === 2 && filter.range[1] > 0) {
-    params.set("endDate", formatTransactionFilterDateTime(filter.range[1]));
+  if (normalizedFilter.range.length === 2 && normalizedFilter.range[1] > 0) {
+    params.set("endDate", formatTransactionFilterDateTime(normalizedFilter.range[1]));
+  }
+
+  if (normalizedFilter.type) {
+    params.set("type", normalizedFilter.type);
+  }
+
+  if (normalizedFilter.search) {
+    params.set("search", normalizedFilter.search);
   }
 }
 
@@ -129,12 +158,22 @@ export const transactionsApi = createApi({
         url: `/transactions?${buildTransactionParams(pageSize, page, filter).toString()}`,
       }),
       providesTags: [{ type: "Transaction", id: "LIST" }],
+      serializeQueryArgs: ({ endpointName, queryArgs }) => ({
+        endpointName,
+        pageSize: queryArgs.pageSize,
+        page: queryArgs.page,
+        filter: normalizeTransactionFilterParams(queryArgs.filter),
+      }),
     }),
     getTransactionsSummary: builder.query<TransactionSummaryResult, TransactionFilterParams>({
       query: (filter) => ({
         url: `/transactions/summary?${buildTransactionFilterParams(filter).toString()}`,
       }),
       providesTags: [{ type: "Transaction", id: "LIST" }],
+      serializeQueryArgs: ({ endpointName, queryArgs }) => ({
+        endpointName,
+        filter: normalizeTransactionFilterParams(queryArgs),
+      }),
     }),
     createTransaction: builder.mutation<void, CreateTransactionArgs>({
       query: (body) => ({ url: "/transactions", method: "post", data: body }),

--- a/inex/Controllers/TransactionsController.cs
+++ b/inex/Controllers/TransactionsController.cs
@@ -63,7 +63,7 @@ public class TransactionsController : ApiControllerBase
     /// <param name="mode">Activity mode (all, active, inactive)</param>
     /// <param name="pageSize">Amount of items per page</param>
     /// <param name="page">Current page number</param>
-    /// <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate.</param>
+    /// <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate, type, search.</param>
     /// <returns>List of transactions with pagination metadata</returns>
     [HttpGet]
     [Route(GetAllRoute)]
@@ -77,7 +77,7 @@ public class TransactionsController : ApiControllerBase
 
     /// <summary>Get transaction summary for a user</summary>
     /// <param name="mode">Activity mode (all, active, inactive)</param>
-    /// <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate.</param>
+    /// <param name="filter">Typed query filters. Supported query parameters: accountId, categoryId, tag, ref, startDate, endDate, type, search.</param>
     /// <returns>Transaction summary for the filtered scope</returns>
     [HttpGet]
     [Route(GetSummaryRoute)]


### PR DESCRIPTION
Closes #288

## Summary

- Apply ownership, activity mode, Type, and Search predicates before ordering, pagination, list metadata, and summary aggregation.
- Add `type` and `search` transaction query parameters and database-translated case-insensitive Search across ledger fields and relations.
- Normalize Type/Search for shared RTK Query request serialization and cache keys; add API and integration regressions.

## Verification

- `dotnet test inex.Tests/ --filter FullyQualifiedName~TransactionsControllerTests` — 32 passed.
- `dotnet test inex.Services.Tests/` — 91 passed.
- `dotnet build inex.sln` — passed.
- Focused transactions RTK Query Vitest, frontend lint, and frontend production build — passed.
- MySQL read-only inspection confirmed case behavior and a Search-shaped `EXPLAIN` plan.

## Review

Blind Hunter, Edge Case Hunter, and Acceptance Auditor reviews completed. Cache-key normalization, relation-search test independence, and test-helper ownership concerns were fixed.

## Blockers / risks

- The 50,000-transactions-per-user list/summary Search timing gate cannot run: the approved MySQL connection is read-only and has no qualifying fixture. No index is proposed without that evidence.
- `dotnet test inex.sln --no-build` was attempted twice but hung without output; the focused suites above pass.

Draft status is intentional until the MySQL performance gate and full-suite runner issue are resolved.