### PR TITLE
Restore legacy transaction visibility

### DIFF
--- a/inex.Services/Services/TransactionService.cs
+++ b/inex.Services/Services/TransactionService.cs
@@ -326,7 +326,7 @@ public class TransactionService : InExService, ITransactionService
     {
         IQueryable<Transaction> items = DbInEx.TransactionRepository
             .GetWithIncludePaths(true, null, "Account.Currency", "Category")
-            .Where(i => i.UserId == userId && i.Account.UserId == userId && i.Category.UserId == userId);
+            .Where(i => i.UserId == userId);
 
         items = ApplyActivityMode(items, mode);
         items = ApplyFilters(items, filter);


### PR DESCRIPTION
## Summary
- restore transaction list visibility using the transaction's existing `UserId` ownership predicate
- remove newly introduced account/category ownership gates that exclude legacy transaction relationships

## Regression
The filter work merged in #289 added relation-owner equality checks to the shared transaction query. Legacy transactions can be owned by the signed-in user while their related account or category ownership metadata no longer matches, causing the page to appear empty.

## Validation
- `git diff --check`
- Project UI doctor: all 20 checks passed
- Focused transaction controller tests could not complete because the local .NET test runner left orphaned workers with no output. The environment declined the requested cleanup because it could affect unrelated local processes.

## Security
The query remains scoped to the authenticated user's `Transaction.UserId`.