### PR TITLE
Synchronize selected-period transaction filters

### DIFF
--- a/inex/ClientApp/public/locales/en/translation.json
+++ b/inex/ClientApp/public/locales/en/translation.json
@@ -298,6 +298,7 @@
     "itemCount_other": "{{count}} items",
     "toolbarCount": "{{visible}} of {{total}} transactions in {{period}}",
     "paginationSummary": "Showing {{visible}} of {{total}} transactions for {{period}}",
+    "loadMore": "Load more",
     "period": {
       "currentMonth": "Current month",
       "allActiveDates": "All active dates"

--- a/inex/ClientApp/public/locales/ru/translation.json
+++ b/inex/ClientApp/public/locales/ru/translation.json
@@ -300,6 +300,7 @@
     "itemCount_other": "{{count}} записи",
     "toolbarCount": "{{visible}} из {{total}} транзакций за {{period}}",
     "paginationSummary": "Показано {{visible}} из {{total}} транзакций за {{period}}",
+    "loadMore": "Загрузить ещё",
     "period": {
       "currentMonth": "Текущий месяц",
       "allActiveDates": "Все активные даты"

--- a/inex/ClientApp/src/pages/Transactions.tsx
+++ b/inex/ClientApp/src/pages/Transactions.tsx
@@ -11,8 +11,8 @@ import { TransactionType } from "../model/Transaction/TransactionType";
 import { useAppDispatch, useAppSelector } from "../store/hooks";
 import { AccountResponse, useGetAccountsQuery } from "../store/accounts/accounts-api";
 import { CategoryResponse, useGetCategoriesQuery } from "../store/categories/categories-api";
-import { useGetTransactionsSummaryQuery, type TransactionFilterParams } from "../store/transactions/transactions-api";
-import { transactionsActions, transactionsDefaultFilter, type TransactionFilter } from "../store/transactions/transactions-slice";
+import { useGetTransactionsSummaryQuery } from "../store/transactions/transactions-api";
+import { normalizeTransactionFilter, transactionsActions, transactionsDefaultFilter, type TransactionFilter } from "../store/transactions/transactions-slice";
 import {
     InExButton,
     InExDrawer,
@@ -25,9 +25,8 @@ import type { Signage } from "../components/primitives";
 import TransactionCreate from "./Transactions/TransactionCreate";
 import TransactionFilterForm from "./Transactions/TransactionFilterForm";
 import TransactionList from "./Transactions/TransactionList";
-import { buildTransactionFilterSearch } from "./Transactions/transaction-filter-url";
+import { buildTransactionFilterSearch, parseTransactionFilterParam } from "./Transactions/transaction-filter-url";
 import {
-    emptyLedgerFilter,
     emptyLedgerMetrics,
     formatTransactionMonthLabel,
     formatTransactionPeriodLabel,
@@ -37,9 +36,6 @@ import {
     isCurrentOrFutureTransactionMonth,
     isWholeTransactionMonthRange,
     shiftTransactionMonthRange,
-    type LedgerMetrics,
-    type LedgerTypeFilter,
-    type LedgerUiFilter,
 } from "./Transactions/transaction-ledger-utils";
 import "./Transactions/transactions-ledger.css";
 
@@ -56,12 +52,6 @@ const isTransactionFilterActive = (filter: TransactionFilter): boolean =>
     filter.categoryIds.length > 0 ||
     filter.tags.length > 0 ||
     filter.refs.length > 0;
-
-const isLedgerUiFilterActive = (filter: LedgerUiFilter): boolean =>
-    filter.type !== "all" ||
-    filter.search.trim() !== "" ||
-    filter.minAmount.trim() !== "" ||
-    filter.maxAmount.trim() !== "";
 
 const formatDateRange = (range: number[]): string => {
     if (range.length !== 2) return "";
@@ -86,15 +76,13 @@ const Transactions = () => {
 
     const { data: allAccounts = [] } = useGetAccountsQuery("ALL");
     const { data: allCategories = [] } = useGetCategoriesQuery("ALL");
-    const filterState = useAppSelector(state => state.transactions.filter);
     const formError = useAppSelector(state => state.transactions.error);
     const exchangeRates = useAppSelector(state => state.rates.items);
 
     const [addDrawerOpen, setAddDrawerOpen] = useState(false);
     const [filterDrawerOpen, setFilterDrawerOpen] = useState(filterParam !== null);
     const [createMode, setCreateMode] = useState<TransactionType>(TransactionType.EXPENSE);
-    const [ledgerFilter, setLedgerFilter] = useState<LedgerUiFilter>(emptyLedgerFilter);
-    const [ledgerMetrics, setLedgerMetrics] = useState<LedgerMetrics>(emptyLedgerMetrics);
+    const [ledgerVisibleCount, setLedgerVisibleCount] = useState(0);
     const [ledgerInitialLoading, setLedgerInitialLoading] = useState(false);
 
     const activeAccounts = useMemo(
@@ -106,23 +94,20 @@ const Transactions = () => {
         [allCategories],
     );
 
-    const filterActive = isTransactionFilterActive(filterState) || isLedgerUiFilterActive(ledgerFilter);
+    const canonicalFilter = useMemo(() => normalizeTransactionFilter(
+        parseTransactionFilterParam(filterParam) ?? {
+            ...transactionsDefaultFilter,
+            range: getCurrentTransactionMonthRange(),
+        },
+    ), [filterParam]);
+    const filterActive = isTransactionFilterActive(canonicalFilter) || canonicalFilter.type !== "all" || canonicalFilter.search !== "";
     const filterIndicatorTitle = filterActive ? t("transactions.filtersActive") : undefined;
     const baseCurrency = useMemo(() => getBaseCurrencyCode(exchangeRates), [exchangeRates]);
-    const activeMonthRange = filterState.range.length === 2 ? filterState.range : getCurrentTransactionMonthRange();
+    const activeMonthRange = canonicalFilter.range;
     const activeMonthRangeKey = activeMonthRange.join(":");
     const [pendingMonthRange, setPendingMonthRange] = useState<number[]>(activeMonthRange);
     const pendingMonthRangeKey = pendingMonthRange.join(":");
-    const summaryFilter = useMemo<TransactionFilterParams>(() => ({
-        accountIds: filterState.accountIds,
-        categoryIds: filterState.categoryIds,
-        tags: filterState.tags,
-        refs: filterState.refs,
-        range: filterState.range,
-    }), [filterState]);
-    const summaryQuery = useGetTransactionsSummaryQuery(summaryFilter, {
-        skip: filterParam === null && filterState.range.length !== 2,
-    });
+    const summaryQuery = useGetTransactionsSummaryQuery(canonicalFilter);
     const summaryData = summaryQuery.currentData;
     const summaryInitialLoading = summaryQuery.isLoading || (summaryQuery.isFetching && summaryData === undefined);
     const summaryMetrics = useMemo(
@@ -131,9 +116,9 @@ const Transactions = () => {
             : null,
         [exchangeRates, summaryData],
     );
-    const scopedMetrics = summaryMetrics ?? ledgerMetrics;
+    const scopedMetrics = summaryMetrics ?? emptyLedgerMetrics;
     const scopedTotalCount = scopedMetrics.totalCount;
-    const noMatchActive = filterActive && scopedTotalCount > 0 && ledgerMetrics.visibleCount === 0;
+    const noMatchActive = filterActive && summaryData?.totalCount === 0;
     const periodLabel = useMemo(
         () => isWholeTransactionMonthRange(activeMonthRange)
             ? formatTransactionMonthLabel(activeMonthRange, t("transactions.period.currentMonth"))
@@ -152,9 +137,18 @@ const Transactions = () => {
     );
 
     const applyServerFilter = useCallback((nextFilter: TransactionFilter, replace = true) => {
-        dispatch(transactionsActions.setFilter({ filter: nextFilter }));
-        navigate(`${location.pathname}${buildTransactionFilterSearch(nextFilter)}`, { replace });
+        const normalizedFilter = normalizeTransactionFilter(nextFilter);
+        dispatch(transactionsActions.setFilter({ filter: normalizedFilter }));
+        navigate(`${location.pathname}${buildTransactionFilterSearch(normalizedFilter)}`, { replace });
     }, [dispatch, location.pathname, navigate]);
+
+    useEffect(() => {
+        dispatch(transactionsActions.setFilter({ filter: canonicalFilter }));
+        const normalizedSearch = buildTransactionFilterSearch(canonicalFilter);
+        if (location.search !== normalizedSearch) {
+            navigate(`${location.pathname}${normalizedSearch}`, { replace: true });
+        }
+    }, [canonicalFilter, dispatch, location.pathname, location.search, navigate]);
 
     useEffect(() => {
         setPendingMonthRange(activeMonthRange);
@@ -165,22 +159,13 @@ const Transactions = () => {
 
         const timeoutId = window.setTimeout(() => {
             applyServerFilter({
-                ...filterState,
+                ...canonicalFilter,
                 range: pendingMonthRange,
             }, false);
         }, MONTH_FILTER_COMMIT_DELAY_MS);
 
         return () => window.clearTimeout(timeoutId);
-    }, [activeMonthRange, applyServerFilter, filterState, pendingMonthRange, pendingMonthRangeKey]);
-
-    useEffect(() => {
-        if (filterParam !== null) return;
-
-        applyServerFilter({
-            ...transactionsDefaultFilter,
-            range: getCurrentTransactionMonthRange(),
-        }, true);
-    }, [applyServerFilter, filterParam]);
+    }, [activeMonthRange, applyServerFilter, canonicalFilter, pendingMonthRange, pendingMonthRangeKey]);
 
     const changeMonth = useCallback((monthDelta: number) => {
         setPendingMonthRange((currentRange) => {
@@ -208,7 +193,6 @@ const Transactions = () => {
         date.startOf("month").isAfter(dayjs().startOf("month")), []);
 
     const clearAllFilters = useCallback(() => {
-        setLedgerFilter(emptyLedgerFilter);
         applyServerFilter({
             ...transactionsDefaultFilter,
             range: getCurrentTransactionMonthRange(),
@@ -255,72 +239,64 @@ const Transactions = () => {
         const categoryById = new Map(allCategories.map(category => [category.id, category.name]));
         const next: FilterChip[] = [];
 
-        if (ledgerFilter.type !== "all") {
+        if (canonicalFilter.type !== "all") {
             next.push({
                 key: "type",
-                label: `${t("transactions.type")}: ${t(`transactions.${ledgerFilter.type}`)}`,
-                onClear: () => setLedgerFilter(prev => ({ ...prev, type: "all" })),
+                label: `${t("transactions.type")}: ${t(`transactions.${canonicalFilter.type}`)}`,
+                onClear: () => applyServerFilter({ ...canonicalFilter, type: "all" }),
             });
         }
 
-        if (ledgerFilter.search.trim() !== "") {
+        if (canonicalFilter.search !== "") {
             next.push({
                 key: "search",
-                label: `${t("transactions.search")}: ${ledgerFilter.search.trim()}`,
-                onClear: () => setLedgerFilter(prev => ({ ...prev, search: "" })),
+                label: `${t("transactions.search")}: ${canonicalFilter.search}`,
+                onClear: () => applyServerFilter({ ...canonicalFilter, search: "" }),
             });
         }
 
-        if (filterState.accountIds.length > 0) {
+        if (canonicalFilter.accountIds.length > 0) {
             next.push({
                 key: "accounts",
-                label: `${t("transactions.account")}: ${filterState.accountIds.map(id => accountById.get(id) ?? id).join(", ")}`,
-                onClear: () => clearServerFilter({ ...filterState, accountIds: [] }),
+                label: `${t("transactions.account")}: ${canonicalFilter.accountIds.map(id => accountById.get(id) ?? id).join(", ")}`,
+                onClear: () => clearServerFilter({ ...canonicalFilter, accountIds: [] }),
             });
         }
 
-        if (filterState.categoryIds.length > 0) {
+        if (canonicalFilter.categoryIds.length > 0) {
             next.push({
                 key: "categories",
-                label: `${t("transactions.category")}: ${filterState.categoryIds.map(id => categoryById.get(id) ?? id).join(", ")}`,
-                onClear: () => clearServerFilter({ ...filterState, categoryIds: [] }),
+                label: `${t("transactions.category")}: ${canonicalFilter.categoryIds.map(id => categoryById.get(id) ?? id).join(", ")}`,
+                onClear: () => clearServerFilter({ ...canonicalFilter, categoryIds: [] }),
             });
         }
 
-        if (filterState.tags.length > 0) {
+        if (canonicalFilter.tags.length > 0) {
             next.push({
                 key: "tags",
-                label: `${t("transactions.tags")}: ${filterState.tags.map(tag => `#${tag}`).join(" ")}`,
-                onClear: () => clearServerFilter({ ...filterState, tags: [] }),
+                label: `${t("transactions.tags")}: ${canonicalFilter.tags.map(tag => `#${tag}`).join(" ")}`,
+                onClear: () => clearServerFilter({ ...canonicalFilter, tags: [] }),
             });
         }
 
-        if (filterState.refs.length > 0) {
+        if (canonicalFilter.refs.length > 0) {
             next.push({
                 key: "refs",
-                label: `${t("transactions.refs")}: ${filterState.refs.map(ref => `@${ref}`).join(" ")}`,
-                onClear: () => clearServerFilter({ ...filterState, refs: [] }),
+                label: `${t("transactions.refs")}: ${canonicalFilter.refs.map(ref => `@${ref}`).join(" ")}`,
+                onClear: () => clearServerFilter({ ...canonicalFilter, refs: [] }),
             });
         }
 
-        if (filterState.range.length === 2 && !isWholeTransactionMonthRange(filterState.range)) {
+        if (canonicalFilter.range.length === 2 && !isWholeTransactionMonthRange(canonicalFilter.range)) {
             next.push({
                 key: "date",
-                label: `${t("transactions.date")}: ${formatDateRange(filterState.range)}`,
-                onClear: () => clearServerFilter({ ...filterState, range: getCurrentTransactionMonthRange() }),
-            });
-        }
-
-        if (ledgerFilter.minAmount.trim() !== "" || ledgerFilter.maxAmount.trim() !== "") {
-            next.push({
-                key: "amount",
-                label: `${t("transactions.amount")}: ${ledgerFilter.minAmount || "0"} - ${ledgerFilter.maxAmount || t("transactions.anyAmount")}`,
-                onClear: () => setLedgerFilter(prev => ({ ...prev, minAmount: "", maxAmount: "" })),
+                label: `${t("transactions.date")}: ${formatDateRange(canonicalFilter.range)}`,
+                onClear: () => clearServerFilter({ ...canonicalFilter, range: getCurrentTransactionMonthRange() }),
             });
         }
 
         return next;
-    }, [allAccounts, allCategories, clearServerFilter, filterState, ledgerFilter, t]);
+    }, [allAccounts, allCategories, applyServerFilter, canonicalFilter, clearServerFilter, t]);
 
     const kpiItems = [
         {
@@ -404,7 +380,7 @@ const Transactions = () => {
                                 {monthControls}
                                 <span className="transactions-toolbar-count">
                                     {t("transactions.toolbarCount", {
-                                        visible: ledgerMetrics.visibleCount,
+                                        visible: ledgerVisibleCount,
                                         total: scopedTotalCount,
                                         period: periodLabel,
                                     })}
@@ -429,7 +405,7 @@ const Transactions = () => {
                         <div className="transactions-ledger-controls">
                             <SegmentedControl
                                 label={t("transactions.view")}
-                                onChange={(value) => setLedgerFilter(prev => ({ ...prev, type: value as LedgerTypeFilter }))}
+                                onChange={(value) => applyServerFilter({ ...canonicalFilter, type: value as TransactionFilter["type"] })}
                                 options={[
                                     { key: "all", label: `${t("transactions.all")} ${scopedMetrics.typeCounts.all}` },
                                     { key: "income", label: `${t("transactions.income")} ${scopedMetrics.typeCounts.income}` },
@@ -437,14 +413,14 @@ const Transactions = () => {
                                     { key: "transfer", label: `${t("transactions.transfer")} ${scopedMetrics.typeCounts.transfer}` },
                                 ]}
                                 size="compact"
-                                value={ledgerFilter.type}
+                                value={canonicalFilter.type}
                             />
                             <Input
                                 aria-label={t("transactions.search")}
                                 className="transactions-search"
-                                onChange={(event) => setLedgerFilter(prev => ({ ...prev, search: event.target.value }))}
+                                onChange={(event) => applyServerFilter({ ...canonicalFilter, search: event.target.value })}
                                 placeholder={t("transactions.searchPlaceholder")}
-                                value={ledgerFilter.search}
+                                value={canonicalFilter.search}
                                 variant="search"
                             />
                         </div>
@@ -467,11 +443,11 @@ const Transactions = () => {
                             accounts={allAccounts}
                             categories={allCategories}
                             exchangeRates={exchangeRates}
-                            ledgerFilter={ledgerFilter}
+                            filter={canonicalFilter}
                             onAddTransaction={() => setAddDrawerOpen(true)}
                             onClearFilters={clearAllFilters}
                             onInitialLoadingChange={setLedgerInitialLoading}
-                            onMetricsChange={setLedgerMetrics}
+                            onVisibleCountChange={setLedgerVisibleCount}
                             periodLabel={periodLabel}
                         />
                     </section>
@@ -506,9 +482,11 @@ const Transactions = () => {
                 <TransactionFilterForm
                     accounts={activeAccounts}
                     categories={activeCategories}
-                    filter={filterParam}
-                    ledgerFilter={ledgerFilter}
-                    onLedgerFilterChange={setLedgerFilter}
+                    filter={canonicalFilter}
+                    onApply={(nextFilter) => {
+                        applyServerFilter(nextFilter);
+                        setFilterDrawerOpen(false);
+                    }}
                 />
                 {formError && (
                     <Alert

--- a/inex/ClientApp/src/pages/Transactions/TransactionFilterForm.test.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionFilterForm.test.tsx
@@ -1,129 +1,46 @@
 import * as React from "react";
-import { configureStore } from "@reduxjs/toolkit";
-import { render, screen } from "@testing-library/react";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AccountResponse } from "../../store/accounts/accounts-api";
-import transactionsSlice from "../../store/transactions/transactions-slice";
-import type { LedgerUiFilter } from "./transaction-ledger-utils";
+import { transactionsDefaultFilter } from "../../store/transactions/transactions-slice";
 import TransactionFilterForm from "./TransactionFilterForm";
 
 vi.mock("react-i18next", () => ({
-    useTranslation: () => ({
-        t: (key: string) => ({
-            "categories.systemGroup": "System",
-            "transactions.account": "Account",
-            "transactions.advancedFilters": "Advanced filters",
-            "transactions.allAccounts": "All accounts",
-            "transactions.allCategories": "All categories",
-            "transactions.amountEquivalent": "Amount equivalent",
-            "transactions.applyFilters": "Apply filters",
-            "transactions.category": "Category",
-            "transactions.clearAll": "Clear all",
-            "transactions.from": "From",
-            "transactions.keyword": "Keyword",
-            "transactions.keywordPlaceholder": "Search text, #tag, or @reference",
-            "transactions.max": "Max",
-            "transactions.min": "Min",
-            "transactions.to": "To",
-        }[key] ?? key),
-    }),
+    useTranslation: () => ({ t: (key: string) => ({
+        "categories.systemGroup": "System", "transactions.account": "Account", "transactions.allAccounts": "All accounts",
+        "transactions.allCategories": "All categories", "transactions.applyFilters": "Apply filters", "transactions.category": "Category",
+        "transactions.clearAll": "Clear all", "transactions.from": "From", "transactions.keyword": "Keyword",
+        "transactions.keywordPlaceholder": "Search text, #tag, or @reference", "transactions.to": "To",
+    }[key] ?? key) }),
 }));
 
-const accounts: AccountResponse[] = [
-    {
-        id: 1,
-        key: "wallet",
-        name: "Wallet",
-        description: null,
-        isEnabled: true,
-        currencyId: 1,
-        currency: "PLN",
-    },
-    {
-        id: 2,
-        key: "brokerage",
-        name: "Brokerage",
-        description: null,
-        isEnabled: true,
-        currencyId: 2,
-        currency: "USD",
-    },
-];
-
-const ledgerFilter: LedgerUiFilter = {
-    type: "all",
-    search: "",
-    minAmount: "",
-    maxAmount: "",
-};
-
-const renderFilter = (filter: string | null) => {
-    const store = configureStore({
-        reducer: {
-            transactions: transactionsSlice.reducer,
-        },
-    });
-
-    return render(
-        <Provider store={store}>
-            <MemoryRouter initialEntries={["/transactions"]}>
-                <TransactionFilterForm
-                    accounts={accounts}
-                    categories={[]}
-                    filter={filter}
-                    ledgerFilter={ledgerFilter}
-                    onLedgerFilterChange={vi.fn()}
-                />
-            </MemoryRouter>
-        </Provider>,
-    );
-};
+const accounts: AccountResponse[] = [{ id: 1, key: "wallet", name: "Wallet", description: null, isEnabled: true, currencyId: 1, currency: "PLN" }];
 
 describe("TransactionFilterForm", () => {
     beforeEach(() => {
         Object.defineProperty(window, "matchMedia", {
             writable: true,
             value: vi.fn().mockImplementation((query: string) => ({
-                matches: false,
-                media: query,
-                onchange: null,
-                addListener: vi.fn(),
-                removeListener: vi.fn(),
-                addEventListener: vi.fn(),
-                removeEventListener: vi.fn(),
-                dispatchEvent: vi.fn(),
+                matches: false, media: query, onchange: null,
+                addListener: vi.fn(), removeListener: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
             })),
         });
     });
 
-    it("does not show a default base currency suffix before an account is selected", () => {
-        renderFilter(null);
-
+    it("keeps Amount controls out of the advanced filter drawer", () => {
+        render(<TransactionFilterForm accounts={accounts} categories={[]} filter={{ ...transactionsDefaultFilter, range: [1, 2] }} onApply={vi.fn()} />);
         expect(screen.getByText("All accounts")).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("Min")).toBeDisabled();
-        expect(screen.getByPlaceholderText("Max")).toBeDisabled();
-        expect(screen.queryByText("USD")).not.toBeInTheDocument();
-        expect(screen.queryByText("PLN")).not.toBeInTheDocument();
+        expect(screen.queryByText("Amount equivalent")).not.toBeInTheDocument();
+        expect(screen.queryByPlaceholderText("Min")).not.toBeInTheDocument();
+        expect(screen.queryByPlaceholderText("Max")).not.toBeInTheDocument();
     });
 
-    it("uses the selected account currency for amount filter suffixes", async () => {
-        renderFilter("accountIds:1;");
-
-        expect(await screen.findAllByText("PLN")).toHaveLength(2);
-        expect(screen.getByPlaceholderText("Min")).not.toBeDisabled();
-        expect(screen.getByPlaceholderText("Max")).not.toBeDisabled();
-        expect(screen.queryByText("USD")).not.toBeInTheDocument();
-    });
-
-    it("omits the suffix when selected accounts have mixed currencies", () => {
-        renderFilter("accountIds:1,2;");
-
-        expect(screen.getByPlaceholderText("Min")).toBeDisabled();
-        expect(screen.getByPlaceholderText("Max")).toBeDisabled();
-        expect(screen.queryByText("USD")).not.toBeInTheDocument();
-        expect(screen.queryByText("PLN")).not.toBeInTheDocument();
+    it("applies parsed tag and reference values through the canonical filter", () => {
+        const onApply = vi.fn();
+        render(<TransactionFilterForm accounts={accounts} categories={[]} filter={{ ...transactionsDefaultFilter, range: [1, 2] }} onApply={onApply} />);
+        fireEvent.change(screen.getByPlaceholderText("Search text, #tag, or @reference"), { target: { value: "#food @alex" } });
+        fireEvent.click(screen.getByText("Apply filters"));
+        expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ tags: ["food"], refs: ["alex"] }));
     });
 });

--- a/inex/ClientApp/src/pages/Transactions/TransactionFilterForm.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionFilterForm.tsx
@@ -3,35 +3,24 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Form, Input, Select } from "antd";
 import dayjs from "dayjs";
-import { useLocation, useNavigate } from "react-router-dom";
 
 import { InExButton } from "../../components/primitives";
 import { CategoryDetails, createCategoryDetails, getCategoriesTree } from "../../model/Category/CategoryDetails";
 import type { AccountResponse } from "../../store/accounts/accounts-api";
 import type { CategoryResponse } from "../../store/categories/categories-api";
-import { transactionsDefaultFilter, transactionsActions } from "../../store/transactions/transactions-slice";
-import type { TransactionFilter } from "../../store/transactions/transactions-slice";
-import { useAppDispatch } from "../../store/hooks";
-import { buildTransactionFilterSearch, parseTransactionFilterParam } from "./transaction-filter-url";
-import { getAccountFilterCurrency, getCurrentTransactionMonthRange, type LedgerUiFilter } from "./transaction-ledger-utils";
+import { normalizeTransactionFilter, transactionsDefaultFilter, type NormalizedTransactionFilter } from "../../store/transactions/transactions-slice";
+import { getCurrentTransactionMonthRange } from "./transaction-ledger-utils";
 
 type FlatCategory = Omit<CategoryDetails, "children"> & { depth: number };
 
 interface TransactionFilterFormProps {
     accounts: AccountResponse[];
     categories: CategoryResponse[];
-    filter: string | null;
-    ledgerFilter: LedgerUiFilter;
-    onLedgerFilterChange: React.Dispatch<React.SetStateAction<LedgerUiFilter>>;
+    filter: NormalizedTransactionFilter;
+    onApply: (filter: NormalizedTransactionFilter) => void;
 }
 
-const hasActiveTransactionFilter = (filter: TransactionFilter): boolean =>
-    filter.categoryIds.some((id) => id > 0) ||
-    filter.accountIds.some((id) => id > 0) ||
-    filter.tags.some((tag) => tag !== "") ||
-    filter.refs.some((ref) => ref !== "");
-
-const createCurrentMonthFilter = (): TransactionFilter => ({
+const createCurrentMonthFilter = (): NormalizedTransactionFilter => normalizeTransactionFilter({
     ...transactionsDefaultFilter,
     range: getCurrentTransactionMonthRange(),
 });
@@ -52,286 +41,84 @@ const toCategoryDetails = (category: CategoryResponse): CategoryDetails =>
         children: [],
     });
 
-const TransactionFilterForm: React.FC<TransactionFilterFormProps> = ({
-    accounts,
-    categories,
-    filter,
-    ledgerFilter,
-    onLedgerFilterChange,
-}) => {
+const TransactionFilterForm: React.FC<TransactionFilterFormProps> = ({ accounts, categories, filter, onApply }) => {
     const { t } = useTranslation();
-    const dispatch = useAppDispatch();
-    const location = useLocation();
-    const navigate = useNavigate();
-
-    const [localFilter, setLocalFilter] = useState<TransactionFilter>(transactionsDefaultFilter);
+    const [localFilter, setLocalFilter] = useState(filter);
     const [tagsAndRefsInput, setTagsAndRefsInput] = useState("");
     const [fromDate, setFromDate] = useState("");
     const [toDate, setToDate] = useState("");
 
     useEffect(() => {
-        const queryFilter = parseTransactionFilterParam(filter);
-
-        if (!queryFilter) {
-            const monthFilter = createCurrentMonthFilter();
-            dispatch(transactionsActions.setFilter({ filter: monthFilter }));
-            setLocalFilter(monthFilter);
-            setTagsAndRefsInput("");
-            setFromDate(toDateInputValue(monthFilter.range[0]));
-            setToDate(toDateInputValue(monthFilter.range[1]));
-            return;
-        }
-
-        setLocalFilter(queryFilter);
-        setFromDate(toDateInputValue(queryFilter.range[0]));
-        setToDate(toDateInputValue(queryFilter.range[1]));
+        setLocalFilter(filter);
+        setFromDate(toDateInputValue(filter.range[0]));
+        setToDate(toDateInputValue(filter.range[1]));
         setTagsAndRefsInput([
-            queryFilter.tags.map((tag) => `#${tag}`).join(" "),
-            queryFilter.refs.map((ref) => `@${ref}`).join(" "),
+            filter.tags.map((tag) => `#${tag}`).join(" "),
+            filter.refs.map((ref) => `@${ref}`).join(" "),
         ].filter(Boolean).join(" "));
-
-        dispatch(
-            transactionsActions.setFilter({
-                filter: queryFilter,
-            }),
-        );
-    }, [dispatch, filter]);
+    }, [filter]);
 
     const categoryTree = useMemo(
         () => getCategoriesTree(categories.map(toCategoryDetails), true, t("categories.systemGroup")) as FlatCategory[],
         [categories, t],
     );
-
-    const filterDetails = useMemo(() => {
-        const tags = localFilter.tags.map((tag) => `#${tag}`).join(" ");
-        const refs = localFilter.refs.map((ref) => `@${ref}`).join(" ");
-        const combinedTagsAndRefs = [tags, refs].filter(Boolean).join(" ");
-
-        return {
-            tagsAndRefs: tagsAndRefsInput || combinedTagsAndRefs,
-        };
-    }, [localFilter.refs, localFilter.tags, tagsAndRefsInput]);
-
-    const amountFilterCurrency = useMemo(
-        () => getAccountFilterCurrency(accounts, localFilter.accountIds),
-        [accounts, localFilter.accountIds],
-    );
-    const amountFilterActive = amountFilterCurrency !== null &&
-        (ledgerFilter.minAmount.trim() !== "" || ledgerFilter.maxAmount.trim() !== "");
-    const filterActive = hasActiveTransactionFilter(localFilter) || amountFilterActive;
-    const amountCurrencyAddonProps = amountFilterCurrency ? { addonAfter: amountFilterCurrency } : {};
-
-    const accountOptions = useMemo(
-        () => accounts.map((account) => ({
-            label: account.name,
-            title: account.name,
-            value: account.id,
-        })),
-        [accounts],
-    );
-
-    const categoryOptions = useMemo(
-        () => categoryTree.map((category) => ({
-            disabled: category.id <= 0,
-            label: (
-                <span className="transactions-filter-option" style={{ paddingLeft: category.depth * 12 }}>
-                    {category.name}
-                </span>
-            ),
-            title: category.name,
-            value: category.id,
-        })),
-        [categoryTree],
-    );
+    const accountOptions = useMemo(() => accounts.map((account) => ({ label: account.name, title: account.name, value: account.id })), [accounts]);
+    const categoryOptions = useMemo(() => categoryTree.map((category) => ({
+        disabled: category.id <= 0,
+        label: <span className="transactions-filter-option" style={{ paddingLeft: category.depth * 12 }}>{category.name}</span>,
+        title: category.name,
+        value: category.id,
+    })), [categoryTree]);
 
     const setSelectedIds = (ids: number[], key: "accountIds" | "categoryIds") => {
-        const selectedIds = ids.filter((id) => id > 0);
-
-        setLocalFilter((prevState) => ({
-            ...prevState,
-            [key]: selectedIds,
-        }));
-
-        if (key === "accountIds" && getAccountFilterCurrency(accounts, selectedIds) === null) {
-            onLedgerFilterChange((prevState) => ({
-                ...prevState,
-                minAmount: "",
-                maxAmount: "",
-            }));
-        }
+        setLocalFilter((previous) => normalizeTransactionFilter({ ...previous, [key]: ids }));
     };
 
-    const setTagsAndRefsHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const setTagsAndRefs = (event: React.ChangeEvent<HTMLInputElement>) => {
         const input = event.target.value;
-        const tags: string[] = [];
-        const refs: string[] = [];
-
-        const tagRegex = /#(\S+)/g;
-        const refRegex = /@(\S+)/g;
-
-        let match: RegExpExecArray | null;
-        while ((match = tagRegex.exec(input)) !== null) {
-            tags.push(match[1]);
-        }
-        while ((match = refRegex.exec(input)) !== null) {
-            refs.push(match[1]);
-        }
-
-        setLocalFilter((prevState) => ({
-            ...prevState,
-            tags,
-            refs,
-        }));
+        const tags = Array.from(input.matchAll(/#(\S+)/g), (match) => match[1]);
+        const refs = Array.from(input.matchAll(/@(\S+)/g), (match) => match[1]);
         setTagsAndRefsInput(input);
+        setLocalFilter((previous) => normalizeTransactionFilter({ ...previous, tags, refs }));
     };
 
     const setDateRange = (nextFrom: string, nextTo: string) => {
         const start = nextFrom ? dayjs(nextFrom).startOf("day") : null;
         const end = nextTo ? dayjs(nextTo).endOf("day") : null;
-        setLocalFilter((prevState) => ({
-            ...prevState,
-            range: start?.isValid() && end?.isValid() && start.unix() <= end.unix()
-                ? [start.unix(), end.unix()]
-                : [],
+        setLocalFilter((previous) => normalizeTransactionFilter({
+            ...previous,
+            range: start?.isValid() && end?.isValid() && start.unix() <= end.unix() ? [start.unix(), end.unix()] : [],
         }));
-    };
-
-    const setFromDateHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = event.target.value;
-        setFromDate(value);
-        setDateRange(value, toDate);
-    };
-
-    const setToDateHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = event.target.value;
-        setToDate(value);
-        setDateRange(fromDate, value);
-    };
-
-    const setMinAmountHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-        onLedgerFilterChange((prevState) => ({
-            ...prevState,
-            minAmount: event.target.value,
-        }));
-    };
-
-    const setMaxAmountHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-        onLedgerFilterChange((prevState) => ({
-            ...prevState,
-            maxAmount: event.target.value,
-        }));
-    };
-
-    const resetFilterHandler = () => {
-        const monthFilter = createCurrentMonthFilter();
-        dispatch(transactionsActions.setFilter({ filter: monthFilter }));
-        setLocalFilter(monthFilter);
-        setTagsAndRefsInput("");
-        setFromDate(toDateInputValue(monthFilter.range[0]));
-        setToDate(toDateInputValue(monthFilter.range[1]));
-        onLedgerFilterChange((prevState) => ({
-            ...prevState,
-            minAmount: "",
-            maxAmount: "",
-        }));
-        navigate(`${location.pathname}${buildTransactionFilterSearch(monthFilter)}`, { replace: true });
-    };
-
-    const applyFilterHandler = () => {
-        navigate(`${location.pathname}${buildTransactionFilterSearch(localFilter)}`, { replace: true });
     };
 
     return (
-        <Form className="transactions-filter-form" layout="vertical" hideRequiredMark>
+        <Form className="transactions-filter-form" hideRequiredMark layout="vertical">
             <div className="transactions-filter-form__date-grid">
                 <Form.Item label={t("transactions.from")}>
-                    <input
-                        className="transactions-native-input"
-                        id="filter_from"
-                        onChange={setFromDateHandler}
-                        type="date"
-                        value={fromDate}
-                    />
+                    <input className="transactions-native-input" id="filter_from" onChange={(event) => {
+                        setFromDate(event.target.value);
+                        setDateRange(event.target.value, toDate);
+                    }} type="date" value={fromDate} />
                 </Form.Item>
                 <Form.Item label={t("transactions.to")}>
-                    <input
-                        className="transactions-native-input"
-                        id="filter_to"
-                        onChange={setToDateHandler}
-                        type="date"
-                        value={toDate}
-                    />
+                    <input className="transactions-native-input" id="filter_to" onChange={(event) => {
+                        setToDate(event.target.value);
+                        setDateRange(fromDate, event.target.value);
+                    }} type="date" value={toDate} />
                 </Form.Item>
             </div>
-
             <Form.Item label={t("transactions.account")}>
-                <Select
-                    aria-label={t("transactions.account")}
-                    className="transactions-multi-select"
-                    id="filter_account"
-                    mode="multiple"
-                    onChange={(ids) => setSelectedIds(ids, "accountIds")}
-                    optionFilterProp="title"
-                    options={accountOptions}
-                    placeholder={t("transactions.allAccounts")}
-                    value={localFilter.accountIds}
-                />
+                <Select aria-label={t("transactions.account")} className="transactions-multi-select" id="filter_account" mode="multiple" onChange={(ids) => setSelectedIds(ids, "accountIds")} optionFilterProp="title" options={accountOptions} placeholder={t("transactions.allAccounts")} value={localFilter.accountIds} />
             </Form.Item>
-
             <Form.Item label={t("transactions.category")}>
-                <Select
-                    aria-label={t("transactions.category")}
-                    className="transactions-multi-select"
-                    id="filter_category"
-                    mode="multiple"
-                    onChange={(ids) => setSelectedIds(ids, "categoryIds")}
-                    optionFilterProp="title"
-                    options={categoryOptions}
-                    placeholder={t("transactions.allCategories")}
-                    value={localFilter.categoryIds}
-                />
+                <Select aria-label={t("transactions.category")} className="transactions-multi-select" id="filter_category" mode="multiple" onChange={(ids) => setSelectedIds(ids, "categoryIds")} optionFilterProp="title" options={categoryOptions} placeholder={t("transactions.allCategories")} value={localFilter.categoryIds} />
             </Form.Item>
-
             <Form.Item label={t("transactions.keyword")}>
-                <Input
-                    id="filter_tags_refs"
-                    onChange={setTagsAndRefsHandler}
-                    placeholder={t("transactions.keywordPlaceholder")}
-                    size="large"
-                    value={filterDetails.tagsAndRefs}
-                />
+                <Input id="filter_tags_refs" onChange={setTagsAndRefs} placeholder={t("transactions.keywordPlaceholder")} size="large" value={tagsAndRefsInput} />
             </Form.Item>
-
-            <Form.Item label={t("transactions.amountEquivalent")}>
-                <div className="transactions-filter-form__amount-grid">
-                    <Input
-                        {...amountCurrencyAddonProps}
-                        disabled={amountFilterCurrency === null}
-                        id="transactions-min-amount"
-                        onChange={setMinAmountHandler}
-                        placeholder={t("transactions.min")}
-                        size="large"
-                        value={ledgerFilter.minAmount}
-                    />
-                    <Input
-                        {...amountCurrencyAddonProps}
-                        disabled={amountFilterCurrency === null}
-                        id="transactions-max-amount"
-                        onChange={setMaxAmountHandler}
-                        placeholder={t("transactions.max")}
-                        size="large"
-                        value={ledgerFilter.maxAmount}
-                    />
-                </div>
-            </Form.Item>
-
-            <div className="transactions-drawer-actions" data-filter-active={filterActive}>
-                <InExButton kind="default" onClick={resetFilterHandler}>
-                    {t("transactions.clearAll")}
-                </InExButton>
-                <InExButton kind="primary" onClick={applyFilterHandler}>
-                    {t("transactions.applyFilters")}
-                </InExButton>
+            <div className="transactions-drawer-actions">
+                <InExButton kind="default" onClick={() => onApply(createCurrentMonthFilter())}>{t("transactions.clearAll")}</InExButton>
+                <InExButton kind="primary" onClick={() => onApply(localFilter)}>{t("transactions.applyFilters")}</InExButton>
             </div>
         </Form>
     );

--- a/inex/ClientApp/src/pages/Transactions/TransactionList.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionList.tsx
@@ -1,42 +1,38 @@
 import * as React from "react";
 import dayjs from "dayjs";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Pagination } from "antd";
 import { Inbox, Plus, RotateCw } from "lucide-react";
-import { useNavigate } from "react-router-dom";
 
-import { AccountResponse } from "../../store/accounts/accounts-api";
-import { CategoryResponse } from "../../store/categories/categories-api";
+import type { AccountResponse } from "../../store/accounts/accounts-api";
+import type { CategoryResponse } from "../../store/categories/categories-api";
 import { useAppSelector } from "../../store/hooks";
-import { TransactionResponse } from "../../model/Transaction/TransactionResponse";
-import { useGetTransactionsQuery, type TransactionFilterParams } from "../../store/transactions/transactions-api";
-import { EmptyState, FilterEmpty, InExButton, InExDrawer, ListPanelNoMatchRow, Num, type MoneyKind } from "../../components/primitives";
+import type { TransactionResponse } from "../../model/Transaction/TransactionResponse";
+import { useGetTransactionsQuery } from "../../store/transactions/transactions-api";
+import type { NormalizedTransactionFilter } from "../../store/transactions/transactions-slice";
+import { EmptyState, FilterEmpty, InExButton, InExDrawer, Num, type MoneyKind } from "../../components/primitives";
 import TransactionEditForm from "./TransactionEditForm";
-import { buildSingleTagOrRefFilterSearch } from "./transaction-filter-url";
 import {
-    getAccountFilterCurrency,
+    appendSequentialPage,
+    createProgressivePageAccumulator,
     getBaseCurrencyEquivalent,
     getCategoryPathLabel,
     getFriendlyTransactionDayLabel,
-    getLedgerTypeCounts,
     getTransactionKind,
-    toBaseCurrencyAmount,
-    toCurrencyAmount,
+    getTransactionNavigationMode,
     type ExchangeRateLike,
-    type LedgerMetrics,
-    type LedgerUiFilter,
 } from "./transaction-ledger-utils";
 
 interface TransactionListProps {
     accounts: AccountResponse[];
     categories: CategoryResponse[];
     exchangeRates: ExchangeRateLike[];
-    ledgerFilter: LedgerUiFilter;
+    filter: NormalizedTransactionFilter;
     onAddTransaction: () => void;
     onClearFilters: () => void;
     onInitialLoadingChange: (loading: boolean) => void;
-    onMetricsChange: (metrics: LedgerMetrics) => void;
+    onVisibleCountChange: (count: number) => void;
     periodLabel: string;
 }
 
@@ -48,447 +44,143 @@ interface TransactionDateGroup {
 
 const emptyTransactions: TransactionResponse[] = [];
 
-const matchesAmount = (amount: number, min: string, max: string): boolean => {
-    const absoluteAmount = Math.abs(amount);
-    const minValue = min.trim() === "" ? null : Number(min);
-    const maxValue = max.trim() === "" ? null : Number(max);
-
-    if (minValue !== null && Number.isFinite(minValue) && absoluteAmount < minValue) return false;
-    if (maxValue !== null && Number.isFinite(maxValue) && absoluteAmount > maxValue) return false;
-    return true;
-};
-
-const buildSearchHaystack = (
-    transaction: TransactionResponse,
-    account?: AccountResponse,
-    category?: CategoryResponse,
-    categoryPath?: string,
-): string =>
-    [
-        transaction.comment,
-        account?.name,
-        category?.name,
-        categoryPath,
-        transaction.accountCurrency,
-        ...transaction.tags,
-        ...transaction.refs,
-    ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-
-const groupTransactions = (
-    transactions: TransactionResponse[],
-    dayLabels: { today: string; yesterday: string },
-): TransactionDateGroup[] => {
+const groupTransactions = (transactions: TransactionResponse[], dayLabels: { today: string; yesterday: string }): TransactionDateGroup[] => {
     const groups = new Map<string, TransactionDateGroup>();
-
     for (const transaction of transactions) {
         const dateKey = dayjs(transaction.created).format("YYYY-MM-DD");
-        const existing = groups.get(dateKey) ?? {
+        const group = groups.get(dateKey) ?? {
             dateKey,
             label: getFriendlyTransactionDayLabel(transaction.created, dayLabels),
             items: [],
         };
-        existing.items.push(transaction);
-        groups.set(dateKey, existing);
+        group.items.push(transaction);
+        groups.set(dateKey, group);
     }
-
-    return Array.from(groups.values()).sort((a, b) => b.dateKey.localeCompare(a.dateKey));
+    return Array.from(groups.values()).sort((left, right) => right.dateKey.localeCompare(left.dateKey));
 };
 
-const TransactionList = ({
-    accounts,
-    categories,
-    exchangeRates,
-    ledgerFilter,
-    onAddTransaction,
-    onClearFilters,
-    onInitialLoadingChange,
-    onMetricsChange,
-    periodLabel,
-}: TransactionListProps) => {
+const TransactionList = ({ accounts, categories, exchangeRates, filter, onAddTransaction, onClearFilters, onInitialLoadingChange, onVisibleCountChange, periodLabel }: TransactionListProps) => {
     const { t } = useTranslation();
-    const navigate = useNavigate();
-    const filter = useAppSelector(state => state.transactions.filter);
     const formError = useAppSelector(state => state.transactions.error);
-
-    const [pagination, setPagination] = useState({ current: 1, total: 0, size: 20 });
+    const [pagination, setPagination] = useState({ current: 1, size: 20 });
+    const [requestedProgressivePage, setRequestedProgressivePage] = useState(1);
     const [editRecord, setEditRecord] = useState<TransactionResponse | null>(null);
-    const { size: pageSize, current: currentPage } = pagination;
+    const navigationMode = getTransactionNavigationMode(filter.range);
+    const requestKey = useMemo(() => JSON.stringify({ filter, pageSize: pagination.size, navigationMode }), [filter, pagination.size, navigationMode]);
+    const [progressivePages, setProgressivePages] = useState(() => createProgressivePageAccumulator<TransactionResponse>(requestKey));
+    const loadMoreSentinel = useRef<HTMLDivElement | null>(null);
 
-    const queryFilter = useMemo<TransactionFilterParams>(() => ({
-        accountIds: filter.accountIds,
-        categoryIds: filter.categoryIds,
-        tags: filter.tags,
-        refs: filter.refs,
-        range: filter.range,
-    }), [filter]);
+    useEffect(() => {
+        setPagination(previous => ({ ...previous, current: 1 }));
+        setRequestedProgressivePage(1);
+        setProgressivePages(createProgressivePageAccumulator<TransactionResponse>(requestKey));
+    }, [requestKey]);
 
-    const {
-        currentData,
-        error,
-        isError,
-        isFetching,
-        isLoading,
-        refetch,
-    } = useGetTransactionsQuery(
-        { pageSize, page: currentPage, filter: queryFilter },
+    const requestedPage = navigationMode === "progressive" ? requestedProgressivePage : pagination.current;
+    const query = useGetTransactionsQuery(
+        { pageSize: pagination.size, page: requestedPage, filter },
         { skip: accounts.length === 0 || categories.length === 0 },
     );
+    const currentPageData = query.currentData;
 
-    const transactions = currentData?.data ?? emptyTransactions;
-    const total = currentData?.metadata.totalItems ?? 0;
+    useEffect(() => {
+        if (navigationMode !== "progressive" || !currentPageData) return;
+        setProgressivePages((current) => appendSequentialPage(
+            current,
+            requestKey,
+            requestedPage,
+            currentPageData.metadata.totalItems,
+            currentPageData.data,
+        ));
+    }, [currentPageData, navigationMode, requestKey, requestedPage]);
+
+    const transactions = navigationMode === "progressive"
+        ? progressivePages.items
+        : currentPageData?.data ?? emptyTransactions;
+    const total = navigationMode === "progressive"
+        ? progressivePages.total
+        : currentPageData?.metadata.totalItems ?? 0;
     const hasRows = transactions.length > 0;
-    const isCurrentDataLoading = isLoading || (isFetching && currentData === undefined);
+    const isCurrentDataLoading = query.isLoading || (query.isFetching && currentPageData === undefined);
+    const hasNextPage = navigationMode === "progressive" && progressivePages.items.length < progressivePages.total;
+    const canRequestMore = hasNextPage && !query.isFetching && progressivePages.nextPage === requestedProgressivePage + 1;
+
+    const loadMore = useCallback(() => {
+        if (canRequestMore) setRequestedProgressivePage(progressivePages.nextPage);
+    }, [canRequestMore, progressivePages.nextPage]);
+
+    useEffect(() => {
+        const sentinel = loadMoreSentinel.current;
+        if (!sentinel || !canRequestMore || typeof IntersectionObserver === "undefined") return undefined;
+        const observer = new IntersectionObserver((entries) => {
+            if (entries.some((entry) => entry.isIntersecting)) loadMore();
+        }, { rootMargin: "240px" });
+        observer.observe(sentinel);
+        return () => observer.disconnect();
+    }, [canRequestMore, loadMore]);
 
     const accountsById = useMemo(() => new Map(accounts.map(account => [account.id, account])), [accounts]);
     const categoriesById = useMemo(() => new Map(categories.map(category => [category.id, category])), [categories]);
-    const amountFilterCurrency = useMemo(
-        () => getAccountFilterCurrency(accounts, filter.accountIds),
-        [accounts, filter.accountIds],
-    );
+    const groups = useMemo(() => groupTransactions(transactions, {
+        today: t("transactions.day.today"),
+        yesterday: t("transactions.day.yesterday"),
+    }), [t, transactions]);
 
-    const locallyScopedTransactions = useMemo(() => {
-        const search = ledgerFilter.search.trim().toLowerCase();
-
-        return transactions.filter(transaction => {
-            const account = accountsById.get(transaction.accountId);
-            const category = categoriesById.get(transaction.categoryId);
-            const categoryPath = getCategoryPathLabel(category, categoriesById);
-            const currency = account?.currency ?? transaction.accountCurrency;
-            const amountFilterActive = amountFilterCurrency !== null &&
-                (ledgerFilter.minAmount.trim() !== "" || ledgerFilter.maxAmount.trim() !== "");
-            const filterAmount = amountFilterActive
-                ? toCurrencyAmount(transaction.amount, currency, amountFilterCurrency, exchangeRates)
-                : null;
-
-            if (search && !buildSearchHaystack(transaction, account, category, categoryPath).includes(search)) return false;
-            if (!amountFilterActive) return true;
-            if (filterAmount === null) return false;
-            return matchesAmount(filterAmount, ledgerFilter.minAmount, ledgerFilter.maxAmount);
-        });
-    }, [accountsById, amountFilterCurrency, categoriesById, exchangeRates, ledgerFilter.maxAmount, ledgerFilter.minAmount, ledgerFilter.search, transactions]);
-
-    const visibleTransactions = useMemo(() => (
-        locallyScopedTransactions.filter(transaction => {
-            const category = categoriesById.get(transaction.categoryId);
-            const kind = getTransactionKind(transaction, category);
-
-            return ledgerFilter.type === "all" || kind === ledgerFilter.type;
-        })
-    ), [categoriesById, ledgerFilter.type, locallyScopedTransactions]);
-
-    const groups = useMemo(
-        () => groupTransactions(
-            visibleTransactions,
-            {
-                today: t("transactions.day.today"),
-                yesterday: t("transactions.day.yesterday"),
-            },
-        ),
-        [t, visibleTransactions],
-    );
-    const ledgerMetrics = useMemo<LedgerMetrics>(() => {
-        let income = 0;
-        let expense = 0;
-
-        for (const transaction of visibleTransactions) {
-            const account = accountsById.get(transaction.accountId);
-            const category = categoriesById.get(transaction.categoryId);
-            const kind = getTransactionKind(transaction, category);
-            const currency = account?.currency ?? transaction.accountCurrency;
-            const baseAmount = toBaseCurrencyAmount(transaction.amount, currency, exchangeRates);
-
-            if (baseAmount !== null && kind === "income") income += baseAmount;
-            if (baseAmount !== null && kind === "expense") expense += baseAmount;
-        }
-
-        return {
-            income,
-            expense,
-            net: income + expense,
-            visibleCount: visibleTransactions.length,
-            totalCount: total,
-            typeCounts: getLedgerTypeCounts(locallyScopedTransactions, categoriesById),
-        };
-    }, [accountsById, categoriesById, exchangeRates, locallyScopedTransactions, total, visibleTransactions]);
-
-    useEffect(() => {
-        setPagination(prev => ({ ...prev, total }));
-    }, [total]);
-
-    useEffect(() => {
-        setPagination(prev => ({ ...prev, current: 1 }));
-    }, [queryFilter]);
-
-    useEffect(() => {
-        onMetricsChange(ledgerMetrics);
-    }, [ledgerMetrics, onMetricsChange]);
-
-    useEffect(() => {
-        onInitialLoadingChange(isCurrentDataLoading && !hasRows);
-    }, [hasRows, isCurrentDataLoading, onInitialLoadingChange]);
+    useEffect(() => onVisibleCountChange(transactions.length), [onVisibleCountChange, transactions.length]);
+    useEffect(() => onInitialLoadingChange(isCurrentDataLoading && !hasRows), [hasRows, isCurrentDataLoading, onInitialLoadingChange]);
 
     const paginationChangedHandler = (page: number, size: number) => {
-        setPagination(prev => ({ ...prev, current: prev.size === size ? page : 1, size }));
+        setPagination(previous => ({ current: previous.size === size ? page : 1, size }));
         window.scrollTo({ top: 0, behavior: "smooth" });
     };
 
-    const handleTagClick = (tag: string) => {
-        navigate(`../../transactions${buildSingleTagOrRefFilterSearch("tags", tag)}`, { replace: false });
-    };
-
-    const handleRefClick = (ref: string) => {
-        navigate(`../../transactions${buildSingleTagOrRefFilterSearch("refs", ref)}`, { replace: false });
-    };
+    const serverFilterActive = filter.accountIds.length > 0 || filter.categoryIds.length > 0 || filter.tags.length > 0 || filter.refs.length > 0 || filter.type !== "all" || filter.search !== "";
 
     if (isCurrentDataLoading && !hasRows) {
-        return (
-            <div className="transactions-loading" aria-label={t("transactions.loading.initial")}>
-                {Array.from({ length: 6 }).map((_, index) => (
-                    <div className="transactions-skeleton-row" key={index}>
-                        <span />
-                        <span />
-                        <span />
-                    </div>
-                ))}
-            </div>
-        );
+        return <div className="transactions-loading" aria-label={t("transactions.loading.initial")}>{Array.from({ length: 6 }).map((_, index) => <div className="transactions-skeleton-row" key={index}><span /><span /><span /></div>)}</div>;
     }
 
-    if (isError && !hasRows) {
-        return (
-            <div className="transactions-load-failure">
-                <Alert
-                    action={(
-                        <InExButton icon={<RotateCw size={14} />} kind="ghost" onClick={() => refetch()} size="sm">
-                            {t("transactions.error.retry")}
-                        </InExButton>
-                    )}
-                    message={t("transactions.error.loadFailure")}
-                    showIcon
-                    type="error"
-                />
-                <div className="transactions-error-detail">{String(error ?? "")}</div>
-            </div>
-        );
+    if (query.isError && !hasRows) {
+        return <div className="transactions-load-failure"><Alert action={<InExButton icon={<RotateCw size={14} />} kind="ghost" onClick={() => query.refetch()} size="sm">{t("transactions.error.retry")}</InExButton>} message={t("transactions.error.loadFailure")} showIcon type="error" /><div className="transactions-error-detail">{String(query.error ?? "")}</div></div>;
     }
-
-    const serverFilterActive =
-        queryFilter.accountIds.length > 0 ||
-        queryFilter.categoryIds.length > 0 ||
-        queryFilter.tags.length > 0 ||
-        queryFilter.refs.length > 0;
 
     if (!isCurrentDataLoading && transactions.length === 0 && serverFilterActive) {
-        return (
-            <div className="transactions-empty-wrap">
-                <FilterEmpty
-                    description={t("transactions.emptyDescription")}
-                    onClear={onClearFilters}
-                    title={t("transactions.empty")}
-                />
-            </div>
-        );
+        return <div className="transactions-empty-wrap"><FilterEmpty description={t("transactions.emptyDescription")} onClear={onClearFilters} title={t("transactions.empty")} /></div>;
     }
 
     if (!isCurrentDataLoading && transactions.length === 0) {
-        return (
-            <div className="transactions-empty-wrap">
-                <EmptyState
-                    actions={(
-                        <InExButton icon={<Plus size={15} />} kind="primary" onClick={onAddTransaction} size="md">
-                            {t("transactions.add")}
-                        </InExButton>
-                    )}
-                    iconNode={<Inbox size={28} />}
-                    description={t("transactions.emptyDescription")}
-                    title={t("transactions.empty")}
-                />
-            </div>
-        );
+        return <div className="transactions-empty-wrap"><EmptyState actions={<InExButton icon={<Plus size={15} />} kind="primary" onClick={onAddTransaction} size="md">{t("transactions.add")}</InExButton>} iconNode={<Inbox size={28} />} description={t("transactions.emptyDescription")} title={t("transactions.empty")} /></div>;
     }
 
-    return (
-        <>
-            {isFetching && hasRows && (
-                <div className="transactions-refreshing" role="status">
-                    <RotateCw aria-hidden="true" size={14} />
-                    {t("transactions.loading.refreshing")}
-                </div>
-            )}
-
-            {isError && hasRows && (
-                <Alert
-                    action={(
-                        <InExButton icon={<RotateCw size={14} />} kind="ghost" onClick={() => refetch()} size="sm">
-                            {t("transactions.error.retry")}
-                        </InExButton>
-                    )}
-                    className="transactions-inline-error"
-                    message={t("transactions.error.partialFailure")}
-                    showIcon
-                    type="error"
-                />
-            )}
-
-            <div className="transactions-ledger-head">
-                <div>{t("transactions.description")}</div>
-                <div>{t("transactions.amount")}</div>
-                <div>{t("transactions.account")}</div>
-                <div>{t("transactions.date")}</div>
-            </div>
-
-            {visibleTransactions.length === 0 ? (
-                <ListPanelNoMatchRow message={t("transactions.noMatch")} />
-            ) : (
-                groups.map(group => (
-                    <section className="transactions-day-group" key={group.dateKey}>
-                        <header className="transactions-day-header">
-                            <div className="transactions-day-header__date">
-                                {group.label}
-                                <span>&middot; {t("transactions.itemCount", { count: group.items.length })}</span>
-                            </div>
-                        </header>
-                        {group.items.map(transaction => {
-                            const account = accountsById.get(transaction.accountId);
-                            const category = categoriesById.get(transaction.categoryId);
-                            const kind = getTransactionKind(transaction, category);
-                            const amountKind: MoneyKind = kind === "transfer" ? "transfer" : kind;
-                            const cleanComment = transaction.comment?.replace(/#\S+/g, "").replace(/@\S+/g, "").trim();
-                            const categoryPath = getCategoryPathLabel(category, categoriesById);
-                            const title = cleanComment || (kind === "transfer" ? t("transactions.transfer") : category?.name) || t("transactions.uncategorized");
-                            const currency = account?.currency ?? transaction.accountCurrency;
-                            const baseEquivalent = getBaseCurrencyEquivalent(transaction.amount, currency, exchangeRates);
-
-                            const openEdit = () => setEditRecord(transaction);
-
-                            return (
-                                <div
-                                    className={`transactions-ledger-row transactions-ledger-row--${kind}`}
-                                    key={transaction.id}
-                                    onClick={openEdit}
-                                    onKeyDown={(event) => {
-                                        if (event.key === "Enter" || event.key === " ") {
-                                            event.preventDefault();
-                                            openEdit();
-                                        }
-                                    }}
-                                    role="button"
-                                    tabIndex={0}
-                                >
-                                    <div className="transactions-row-main">
-                                        <div className="transactions-row-title">{title}</div>
-                                        <div className="transactions-row-meta">
-                                            {categoryPath && kind !== "transfer" && <span className="transactions-category-path">{categoryPath}</span>}
-                                            {kind === "transfer" && <span>{t("transactions.transfer")}</span>}
-                                            {transaction.tags.map(tag => (
-                                                <button
-                                                    className="transactions-row-token"
-                                                    key={`tag-${tag}`}
-                                                    onClick={(event) => {
-                                                        event.stopPropagation();
-                                                        handleTagClick(tag);
-                                                    }}
-                                                    type="button"
-                                                >
-                                                    #{tag}
-                                                </button>
-                                            ))}
-                                            {transaction.refs.map(ref => (
-                                                <button
-                                                    className="transactions-row-token"
-                                                    key={`ref-${ref}`}
-                                                    onClick={(event) => {
-                                                        event.stopPropagation();
-                                                        handleRefClick(ref);
-                                                    }}
-                                                    type="button"
-                                                >
-                                                    @{ref}
-                                                </button>
-                                            ))}
-                                        </div>
-                                    </div>
-                                    <div className="transactions-row-amount">
-                                        <Num
-                                            currency={currency}
-                                            kind={amountKind}
-                                            value={transaction.amount}
-                                            size={15}
-                                        />
-                                        {baseEquivalent && (
-                                            <span className="transactions-row-amount-equivalent">
-                                                {"\u2248 "}
-                                                <Num
-                                                    currency={baseEquivalent.currency}
-                                                    kind={amountKind}
-                                                    signage="color-only"
-                                                    value={Math.abs(baseEquivalent.value)}
-                                                    size={12}
-                                                />
-                                            </span>
-                                        )}
-                                    </div>
-                                    <div className="transactions-row-account">{account?.name ?? t("transactions.unknownAccount")}</div>
-                                    <div className="transactions-row-date">{dayjs(transaction.created).format("YYYY-MM-DD")}</div>
-                                </div>
-                            );
-                        })}
-                    </section>
-                ))
-            )}
-
-            <div className="transactions-pagination">
-                <div>
-                    {t("transactions.paginationSummary", {
-                        visible: visibleTransactions.length,
-                        total,
-                        period: periodLabel,
-                    })}
-                </div>
-                <Pagination
-                    current={pagination.current}
-                    onChange={paginationChangedHandler}
-                    pageSize={pagination.size}
-                    pageSizeOptions={[20, 50, 100]}
-                    showSizeChanger
-                    total={pagination.total}
-                />
-            </div>
-
-            <InExDrawer
-                onClose={() => setEditRecord(null)}
-                open={editRecord !== null}
-                subtitle={t("transactions.editDrawerSubtitle")}
-                title={t("transactions.editDrawerTitle")}
-                width={460}
-            >
-                {editRecord ? (
-                    <>
-                        <TransactionEditForm
-                            accounts={accounts}
-                            categories={categories}
-                            record={editRecord}
-                        />
-                        {formError && (
-                            <Alert
-                                className="transactions-form-error"
-                                message={formError}
-                                showIcon
-                                type="error"
-                            />
-                        )}
-                    </>
-                ) : (
-                    <div className="transactions-empty-drawer">
-                        <Inbox size={20} />
-                    </div>
-                )}
-            </InExDrawer>
-        </>
-    );
+    return <>
+        {query.isFetching && hasRows && <div className="transactions-refreshing" role="status"><RotateCw aria-hidden="true" size={14} />{t("transactions.loading.refreshing")}</div>}
+        {query.isError && hasRows && <Alert action={<InExButton icon={<RotateCw size={14} />} kind="ghost" onClick={() => query.refetch()} size="sm">{t("transactions.error.retry")}</InExButton>} className="transactions-inline-error" message={t("transactions.error.partialFailure")} showIcon type="error" />}
+        <div className="transactions-ledger-head"><div>{t("transactions.description")}</div><div>{t("transactions.amount")}</div><div>{t("transactions.account")}</div><div>{t("transactions.date")}</div></div>
+        {groups.map(group => <section className="transactions-day-group" key={group.dateKey}>
+            <header className="transactions-day-header"><div className="transactions-day-header__date">{group.label}<span>&middot; {t("transactions.itemCount", { count: group.items.length })}</span></div></header>
+            {group.items.map(transaction => {
+                const account = accountsById.get(transaction.accountId);
+                const category = categoriesById.get(transaction.categoryId);
+                const kind = getTransactionKind(transaction, category);
+                const amountKind: MoneyKind = kind === "transfer" ? "transfer" : kind;
+                const cleanComment = transaction.comment?.replace(/#\S+/g, "").replace(/@\S+/g, "").trim();
+                const categoryPath = getCategoryPathLabel(category, categoriesById);
+                const title = cleanComment || (kind === "transfer" ? t("transactions.transfer") : category?.name) || t("transactions.uncategorized");
+                const currency = account?.currency ?? transaction.accountCurrency;
+                const baseEquivalent = getBaseCurrencyEquivalent(transaction.amount, currency, exchangeRates);
+                const openEdit = () => setEditRecord(transaction);
+                return <div className={`transactions-ledger-row transactions-ledger-row--${kind}`} key={transaction.id} onClick={openEdit} onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") { event.preventDefault(); openEdit(); }
+                }} role="button" tabIndex={0}>
+                    <div className="transactions-row-main"><div className="transactions-row-title">{title}</div><div className="transactions-row-meta">{categoryPath && kind !== "transfer" && <span className="transactions-category-path">{categoryPath}</span>}{kind === "transfer" && <span>{t("transactions.transfer")}</span>}{transaction.tags.map(tag => <span className="transactions-row-token" key={`tag-${tag}`}>#{tag}</span>)}{transaction.refs.map(ref => <span className="transactions-row-token" key={`ref-${ref}`}>@{ref}</span>)}</div></div>
+                    <div className="transactions-row-amount"><Num currency={currency} kind={amountKind} size={15} value={transaction.amount} />{baseEquivalent && <span className="transactions-row-amount-equivalent">≈ <Num currency={baseEquivalent.currency} kind={amountKind} signage="color-only" size={12} value={Math.abs(baseEquivalent.value)} /></span>}</div>
+                    <div className="transactions-row-account">{account?.name ?? t("transactions.unknownAccount")}</div><div className="transactions-row-date">{dayjs(transaction.created).format("YYYY-MM-DD")}</div>
+                </div>;
+            })}
+        </section>)}
+        <div className="transactions-pagination"><div>{t("transactions.paginationSummary", { visible: transactions.length, total, period: periodLabel })}</div>{navigationMode === "progressive" ? <div ref={loadMoreSentinel}><InExButton disabled={!hasNextPage || query.isFetching} kind="default" onClick={loadMore}>{query.isFetching ? t("transactions.loading.refreshing") : t("transactions.loadMore")}</InExButton></div> : <Pagination current={pagination.current} onChange={paginationChangedHandler} pageSize={pagination.size} pageSizeOptions={[20, 50, 100]} showSizeChanger total={total} />}</div>
+        <InExDrawer onClose={() => setEditRecord(null)} open={editRecord !== null} subtitle={t("transactions.editDrawerSubtitle")} title={t("transactions.editDrawerTitle")} width={460}>{editRecord ? <><TransactionEditForm accounts={accounts} categories={categories} record={editRecord} />{formError && <Alert className="transactions-form-error" message={formError} showIcon type="error" />}</> : <div className="transactions-empty-drawer"><Inbox size={20} /></div>}</InExDrawer>
+    </>;
 };
 
 export default TransactionList;

--- a/inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-filter-url.test.ts
@@ -11,6 +11,9 @@ const emptyFilter = {
   categoryIds: [],
   tags: [],
   refs: [],
+  range: [],
+  type: "all" as const,
+  search: "",
 };
 
 describe("transaction filter URL helpers", () => {
@@ -54,5 +57,17 @@ describe("transaction filter URL helpers", () => {
   it("rejects impossible calendar dates instead of normalizing them", () => {
     expect(parseTransactionFilterParam("start:2026-02-31;end:2026-03-31;")).toBeNull();
     expect(parseTransactionFilterParam("start:2026-02-01;end:2026-02-31;")).toBeNull();
+  });
+
+  it("retains valid criteria while independently dropping malformed URL values", () => {
+    expect(parseTransactionFilterParam("accountIds:7,nope;type:expense;search:%25E0%25A4%25A;start:no;end:2026-06-30;tags:food,;unknown:value;"))
+      .toEqual(expect.objectContaining({ accountIds: [7], tags: ["food"], type: "expense", search: "%E0%A4%A", range: [] }));
+  });
+
+  it("normalizes and round-trips Type and trimmed Search with the server filters", () => {
+    const search = buildTransactionFilterSearch({ ...emptyFilter, accountIds: [2, 1, 2], type: "income", search: "  salary  " });
+    expect(search).toContain("accountIds%3A1%2C2%3B");
+    expect(search).toContain("type%3Aincome%3B");
+    expect(search).toContain("search%3Asalary%3B");
   });
 });

--- a/inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-filter-url.ts
@@ -1,7 +1,10 @@
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 
-import type { TransactionFilter } from "../../store/transactions/transactions-slice";
+import {
+    normalizeTransactionFilter,
+    type TransactionFilter,
+} from "../../store/transactions/transactions-slice";
 
 const FILTER_PARAM = "filter";
 const DATE_FORMAT = "YYYY-MM-DD";
@@ -46,6 +49,8 @@ export const parseTransactionFilterParam = (filter: string | null): TransactionF
         tags: [],
         refs: [],
         range: [],
+        type: "all",
+        search: "",
     };
     let startDate = "";
     let endDate = "";
@@ -79,6 +84,16 @@ export const parseTransactionFilterParam = (filter: string | null): TransactionF
             case "refs":
                 parsedFilter.refs = parseTextValues(values);
                 break;
+            case "type": {
+                const type = decodeFilterValue(values[0] || "").trim().toLowerCase();
+                if (type === "income" || type === "expense" || type === "transfer") {
+                    parsedFilter.type = type;
+                }
+                break;
+            }
+            case "search":
+                parsedFilter.search = decodeFilterValue(values[0] || "").trim();
+                break;
         }
     });
 
@@ -91,37 +106,49 @@ export const parseTransactionFilterParam = (filter: string | null): TransactionF
         }
     }
 
+    const normalizedFilter = normalizeTransactionFilter(parsedFilter);
     const hasActiveFilter =
-        parsedFilter.accountIds.length > 0 ||
-        parsedFilter.categoryIds.length > 0 ||
-        parsedFilter.tags.length > 0 ||
-        parsedFilter.refs.length > 0 ||
-        parsedFilter.range.length === 2;
+        normalizedFilter.accountIds.length > 0 ||
+        normalizedFilter.categoryIds.length > 0 ||
+        normalizedFilter.tags.length > 0 ||
+        normalizedFilter.refs.length > 0 ||
+        normalizedFilter.range.length === 2 ||
+        normalizedFilter.type !== "all" ||
+        normalizedFilter.search !== "";
 
-    return hasActiveFilter ? parsedFilter : null;
+    return hasActiveFilter ? normalizedFilter : null;
 };
 
 export const buildTransactionFilterSearch = (filter: TransactionFilter): string => {
+    const normalizedFilter = normalizeTransactionFilter(filter);
     let filterValue = "";
 
-    if (filter.categoryIds.length > 0) {
-        filterValue += `categoryIds:${filter.categoryIds.join(",")};`;
+    if (normalizedFilter.categoryIds.length > 0) {
+        filterValue += `categoryIds:${normalizedFilter.categoryIds.join(",")};`;
     }
 
-    if (filter.accountIds.length > 0) {
-        filterValue += `accountIds:${filter.accountIds.join(",")};`;
+    if (normalizedFilter.accountIds.length > 0) {
+        filterValue += `accountIds:${normalizedFilter.accountIds.join(",")};`;
     }
 
-    if (filter.range.length === 2) {
-        filterValue += `start:${dayjs.unix(filter.range[0]).format("YYYY-MM-DD")};end:${dayjs.unix(filter.range[1]).format("YYYY-MM-DD")};`;
+    if (normalizedFilter.range.length === 2) {
+        filterValue += `start:${dayjs.unix(normalizedFilter.range[0]).format("YYYY-MM-DD")};end:${dayjs.unix(normalizedFilter.range[1]).format("YYYY-MM-DD")};`;
     }
 
-    if (filter.tags.length > 0) {
-        filterValue += `tags:${filter.tags.map(encodeFilterValue).join(",")};`;
+    if (normalizedFilter.tags.length > 0) {
+        filterValue += `tags:${normalizedFilter.tags.map(encodeFilterValue).join(",")};`;
     }
 
-    if (filter.refs.length > 0) {
-        filterValue += `refs:${filter.refs.map(encodeFilterValue).join(",")};`;
+    if (normalizedFilter.refs.length > 0) {
+        filterValue += `refs:${normalizedFilter.refs.map(encodeFilterValue).join(",")};`;
+    }
+
+    if (normalizedFilter.type !== "all") {
+        filterValue += `type:${normalizedFilter.type};`;
+    }
+
+    if (normalizedFilter.search !== "") {
+        filterValue += `search:${encodeFilterValue(normalizedFilter.search)};`;
     }
 
     if (filterValue === "") return "";

--- a/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.test.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.test.ts
@@ -4,18 +4,19 @@ import { describe, expect, it } from "vitest";
 import type { CategoryResponse } from "../../store/categories/categories-api";
 import type { TransactionResponse } from "../../model/Transaction/TransactionResponse";
 import {
-  getAccountFilterCurrency,
   getBaseCurrencyEquivalent,
   getCategoryPathLabel,
   getCurrentTransactionMonthRange,
   getFriendlyTransactionDayLabel,
   getLedgerMetricsFromSummary,
   getLedgerTypeCounts,
+  appendSequentialPage,
+  createProgressivePageAccumulator,
+  getTransactionNavigationMode,
   isCurrentOrFutureTransactionMonth,
   isWholeTransactionMonthRange,
   shiftTransactionMonthRange,
   toBaseCurrencyAmount,
-  toCurrencyAmount,
 } from "./transaction-ledger-utils";
 
 const categories: CategoryResponse[] = [
@@ -91,23 +92,6 @@ describe("transaction ledger helpers", () => {
     expect(toBaseCurrencyAmount(-80, "USD", rates)).toBe(-80);
     expect(toBaseCurrencyAmount(-80, "PLN", rates)).toBe(-20);
     expect(toBaseCurrencyAmount(-80, "EUR", rates)).toBe(-40);
-    expect(toCurrencyAmount(-80, "PLN", "EUR", rates)).toBe(-40);
-    expect(toCurrencyAmount(-80, "PLN", "PLN", rates)).toBe(-80);
-    expect(toCurrencyAmount(-80, "EUR", "USD", rates)).toBe(-40);
-    expect(toCurrencyAmount(-80, "UZS", "PLN", rates)).toBeNull();
-  });
-
-  it("derives filter currency only when selected accounts share one currency", () => {
-    const accounts = [
-      { id: 1, currency: "PLN" },
-      { id: 2, currency: "PLN" },
-      { id: 3, currency: "USD" },
-    ];
-
-    expect(getAccountFilterCurrency(accounts, [])).toBeNull();
-    expect(getAccountFilterCurrency(accounts, [1])).toBe("PLN");
-    expect(getAccountFilterCurrency(accounts, [1, 2])).toBe("PLN");
-    expect(getAccountFilterCurrency(accounts, [1, 3])).toBeNull();
   });
 
   it("counts ledger types from category semantics", () => {
@@ -176,6 +160,29 @@ describe("transaction ledger helpers", () => {
     expect(isWholeTransactionMonthRange([dayjs("2026-06-05").unix(), june[1]])).toBe(false);
     expect(isCurrentOrFutureTransactionMonth(june, "2026-06-22T10:00:00")).toBe(true);
     expect(isCurrentOrFutureTransactionMonth(may, "2026-06-22T10:00:00")).toBe(false);
+  });
+
+  it("uses progressive loading through one calendar month and pagination for longer ranges", () => {
+    expect(getTransactionNavigationMode([
+      dayjs("2026-06-01T00:00:00").unix(),
+      dayjs("2026-06-30T23:59:59").unix(),
+    ])).toBe("progressive");
+    expect(getTransactionNavigationMode([
+      dayjs("2026-06-01T00:00:00").unix(),
+      dayjs("2026-07-02T00:00:00").unix(),
+    ])).toBe("pagination");
+  });
+
+  it("rejects stale or out-of-sequence progressive pages and deduplicates sequential rows", () => {
+    const initial = createProgressivePageAccumulator<{ id: number }>("current");
+    const pageOne = appendSequentialPage(initial, "current", 1, 3, [{ id: 1 }, { id: 2 }]);
+    expect(appendSequentialPage(pageOne, "stale", 2, 3, [{ id: 3 }])).toBe(pageOne);
+    expect(appendSequentialPage(pageOne, "current", 3, 3, [{ id: 3 }])).toBe(pageOne);
+    expect(appendSequentialPage(pageOne, "current", 2, 3, [{ id: 2 }, { id: 3 }])).toMatchObject({
+      nextPage: 3,
+      total: 3,
+      items: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    });
   });
 
 });

--- a/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.ts
+++ b/inex/ClientApp/src/pages/Transactions/transaction-ledger-utils.ts
@@ -5,13 +5,7 @@ import type { TransactionResponse } from "../../model/Transaction/TransactionRes
 
 export type LedgerTypeFilter = "all" | "income" | "expense" | "transfer";
 export type LedgerTransactionKind = Exclude<LedgerTypeFilter, "all">;
-
-export interface LedgerUiFilter {
-  type: LedgerTypeFilter;
-  search: string;
-  minAmount: string;
-  maxAmount: string;
-}
+export type TransactionNavigationMode = "progressive" | "pagination";
 
 export interface LedgerSummary {
   income: number;
@@ -51,24 +45,12 @@ export interface ExchangeRateLike {
   rate: number;
 }
 
-export interface AccountCurrencyLike {
-  id: number;
-  currency: string;
-}
-
 export interface BaseCurrencyEquivalent {
   currency: string;
   value: number;
 }
 
 export type TransactionMonthRange = [number, number];
-
-export const emptyLedgerFilter: LedgerUiFilter = {
-  type: "all",
-  search: "",
-  minAmount: "",
-  maxAmount: "",
-};
 
 export const emptyLedgerMetrics: LedgerMetrics = {
   income: 0,
@@ -118,42 +100,6 @@ export const toBaseCurrencyAmount = (
   if (sameCurrency(accountCurrency, baseCurrency)) return amount;
 
   return getBaseCurrencyEquivalent(amount, accountCurrency, exchangeRates)?.value ?? null;
-};
-
-export const toCurrencyAmount = (
-  amount: number,
-  accountCurrency: string,
-  targetCurrency: string,
-  exchangeRates: ExchangeRateLike[],
-): number | null => {
-  if (sameCurrency(accountCurrency, targetCurrency)) return amount;
-
-  const baseAmount = toBaseCurrencyAmount(amount, accountCurrency, exchangeRates);
-  if (baseAmount === null) return null;
-
-  const baseCurrency = getBaseCurrencyCode(exchangeRates);
-  if (sameCurrency(targetCurrency, baseCurrency)) return baseAmount;
-
-  const targetRate = exchangeRates.find((item) => sameCurrency(item.currencyTo, targetCurrency));
-  if (!targetRate || targetRate.rate <= 0) return null;
-
-  return baseAmount * targetRate.rate;
-};
-
-export const getAccountFilterCurrency = (
-  accounts: AccountCurrencyLike[],
-  accountIds: number[],
-): string | null => {
-  const selectedCurrencies = accountIds
-    .map((id) => accounts.find((account) => account.id === id)?.currency)
-    .filter((currency): currency is string => Boolean(currency));
-
-  if (selectedCurrencies.length === 0) return null;
-
-  const [firstCurrency] = selectedCurrencies;
-  return selectedCurrencies.every((currency) => sameCurrency(currency, firstCurrency))
-    ? firstCurrency
-    : null;
 };
 
 export const getLedgerMetricsFromSummary = (
@@ -285,4 +231,44 @@ export const formatTransactionMonthLabel = (range: number[], fallback: string): 
   if (range.length !== 2 || range[0] <= 0) return fallback;
 
   return dayjs.unix(range[0]).format("MMMM YYYY");
+};
+
+export const getTransactionNavigationMode = (range: number[]): TransactionNavigationMode => {
+  if (range.length !== 2 || range[0] <= 0 || range[1] < range[0]) return "progressive";
+
+  return dayjs.unix(range[1]).isAfter(dayjs.unix(range[0]).add(1, "month"))
+    ? "pagination"
+    : "progressive";
+};
+
+export interface ProgressivePageAccumulator<T> {
+  key: string;
+  nextPage: number;
+  total: number;
+  items: T[];
+}
+
+export const createProgressivePageAccumulator = <T>(key: string): ProgressivePageAccumulator<T> => ({
+  key,
+  nextPage: 1,
+  total: 0,
+  items: [],
+});
+
+export const appendSequentialPage = <T extends { id: number }>(
+  accumulator: ProgressivePageAccumulator<T>,
+  key: string,
+  page: number,
+  total: number,
+  items: T[],
+): ProgressivePageAccumulator<T> => {
+  if (accumulator.key !== key || page !== accumulator.nextPage) return accumulator;
+
+  const existingIds = new Set(accumulator.items.map((item) => item.id));
+  return {
+    key,
+    nextPage: page + 1,
+    total,
+    items: [...accumulator.items, ...items.filter((item) => !existingIds.has(item.id))],
+  };
 };

--- a/inex/ClientApp/src/store/transactions/transactions-api.ts
+++ b/inex/ClientApp/src/store/transactions/transactions-api.ts
@@ -7,14 +7,9 @@ import axiosBaseQuery from "../axiosBaseQuery";
 import { accountsApi } from "../accounts/accounts-api";
 import { budgetReportApi } from "../budgetReport/budgetReport-api";
 import { reportApi } from "../report/report-api";
-import type { TransactionFilter } from "./transactions-slice";
+import { normalizeTransactionFilter, type NormalizedTransactionFilter, type TransactionFilter } from "./transactions-slice";
 
-export type TransactionFilterType = "all" | "income" | "expense" | "transfer";
-
-export type TransactionFilterParams = TransactionFilter & {
-  type?: TransactionFilterType;
-  search?: string;
-};
+export type TransactionFilterParams = TransactionFilter;
 
 export interface GetTransactionsArgs {
   pageSize: number;
@@ -47,19 +42,9 @@ export interface TransactionSummaryResult {
   currencySummaries: TransactionCurrencySummary[];
 }
 
-const normalizeTransactionFilterParams = (
+export const normalizeTransactionFilterParams = (
   filter: TransactionFilterParams,
-): TransactionFilterParams => {
-  const normalizedType = filter.type?.trim().toLowerCase();
-  const type: TransactionFilterType | undefined = normalizedType === "income" ||
-    normalizedType === "expense" ||
-    normalizedType === "transfer"
-    ? normalizedType
-    : undefined;
-  const search = filter.search?.trim() || undefined;
-
-  return { ...filter, type, search };
-};
+): NormalizedTransactionFilter => normalizeTransactionFilter(filter);
 
 export const formatTransactionFilterDateTime = (timestamp: number): string =>
   dayjs.unix(timestamp).format("YYYY-MM-DDTHH:mm:ss");
@@ -107,7 +92,7 @@ function appendTransactionFilters(
     params.set("endDate", formatTransactionFilterDateTime(normalizedFilter.range[1]));
   }
 
-  if (normalizedFilter.type) {
+  if (normalizedFilter.type !== "all") {
     params.set("type", normalizedFilter.type);
   }
 

--- a/inex/ClientApp/src/store/transactions/transactions-slice.ts
+++ b/inex/ClientApp/src/store/transactions/transactions-slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-import { TransactionFilterState } from "../../model/Transaction/TransactionFilterState";
+export type TransactionFilterType = "all" | "income" | "expense" | "transfer";
 
 export interface TransactionFilter {
     accountIds: number[];
@@ -8,20 +8,55 @@ export interface TransactionFilter {
     tags: string[];
     refs: string[];
     range: number[];
+    type?: TransactionFilterType;
+    search?: string;
+}
+
+export interface NormalizedTransactionFilter extends TransactionFilter {
+    type: TransactionFilterType;
+    search: string;
 }
 
 interface TransactionsState {
-    filter: TransactionFilterState;
+    filter: NormalizedTransactionFilter;
     error: string | null;
 }
 
-const defaultFilter: TransactionFilterState = {
+const defaultFilter: NormalizedTransactionFilter = {
     accountIds: [],
     categoryIds: [],
     tags: [],
     refs: [],
-    tagsAndRefs: "",
     range: [],
+    type: "all",
+    search: "",
+};
+
+const normalizedIds = (values: number[] | undefined): number[] => Array.from(
+    new Set((values ?? []).filter((value) => Number.isInteger(value) && value > 0)),
+).sort((left, right) => left - right);
+
+const normalizedText = (values: string[] | undefined): string[] => Array.from(
+    new Set((values ?? []).map((value) => value.trim()).filter(Boolean)),
+).sort((left, right) => left.localeCompare(right));
+
+export const normalizeTransactionFilter = (filter: Partial<TransactionFilter>): NormalizedTransactionFilter => {
+    const type = filter.type === "income" || filter.type === "expense" || filter.type === "transfer"
+        ? filter.type
+        : "all";
+    const range = filter.range?.length === 2 && filter.range[0] > 0 && filter.range[1] >= filter.range[0]
+        ? [filter.range[0], filter.range[1]]
+        : [];
+
+    return {
+        accountIds: normalizedIds(filter.accountIds),
+        categoryIds: normalizedIds(filter.categoryIds),
+        tags: normalizedText(filter.tags),
+        refs: normalizedText(filter.refs),
+        range,
+        type,
+        search: filter.search?.trim() ?? "",
+    };
 };
 
 const transactionsSlice = createSlice({
@@ -31,8 +66,8 @@ const transactionsSlice = createSlice({
         error: null as string | null,
     } as TransactionsState,
     reducers: {
-        setFilter(state, action: PayloadAction<{ filter: TransactionFilterState | TransactionFilter }>) {
-            state.filter = { ...defaultFilter, ...action.payload.filter };
+        setFilter(state, action: PayloadAction<{ filter: Partial<TransactionFilter> }>) {
+            state.filter = normalizeTransactionFilter({ ...defaultFilter, ...action.payload.filter });
         },
         resetFilter(state) {
             state.filter = defaultFilter;

--- a/inex/ClientApp/visual-qa/transactions.mjs
+++ b/inex/ClientApp/visual-qa/transactions.mjs
@@ -31,8 +31,8 @@ const authUser = {
 
 const defaultViewportHeight = 900;
 
-function createTransactionsSummary(fixture, scenario) {
-  const transactions = scenario === "empty" ? [] : fixture.transactionsVisualFixtureTransactions;
+function createTransactionsSummary(fixture, scenario, hasNoMatch) {
+  const transactions = scenario === "empty" || hasNoMatch ? [] : fixture.transactionsVisualFixtureTransactions;
   const categoriesById = new Map(fixture.transactionsVisualFixtureCategories.map((category) => [category.id, category]));
   const currencySummariesByCurrency = new Map();
   const typeCounts = {
@@ -168,6 +168,7 @@ function createApiHandler(fixture, requestLog, unhandledApiRequests, scenarioRef
     unhandledApiRequests,
     scenarioRef,
     handleRequest: ({ url, method, scenario }) => {
+      const hasNoMatch = url.searchParams.get("search") === "zzzz-no-match";
       if (url.pathname === "/api/auth/refresh" && method === "POST") {
         return jsonResponse({ accessToken: "visual-qa-token", expiresIn: 3600 });
       }
@@ -188,14 +189,14 @@ function createApiHandler(fixture, requestLog, unhandledApiRequests, scenarioRef
           return problemResponse("Transactions fixture failure", "Controlled Transactions summary failure.", 500);
         }
 
-        return jsonResponse(createTransactionsSummary(fixture, scenario));
+        return jsonResponse(createTransactionsSummary(fixture, scenario, hasNoMatch));
       }
       if (url.pathname === "/api/transactions" && method === "GET") {
         if (scenario === "transactions-error") {
           return problemResponse("Transactions fixture failure", "Controlled Transactions load failure.", 500);
         }
 
-        const data = scenario === "empty" ? [] : fixture.transactionsVisualFixtureTransactions;
+        const data = scenario === "empty" || hasNoMatch ? [] : fixture.transactionsVisualFixtureTransactions;
         return jsonResponse({
           data,
           metadata: { totalItems: data.length },
@@ -272,12 +273,6 @@ async function collectMetrics(client, state, apiRequestCount) {
     const drawerRect = drawer ? drawer.getBoundingClientRect() : null;
     const rows = Array.from(document.querySelectorAll(".transactions-ledger-row"));
     const groups = Array.from(document.querySelectorAll(".transactions-day-group"));
-    const amountFilterItem = Array.from(document.querySelectorAll(".ant-form-item"))
-      .find((item) => item.innerText.includes("Amount equivalent"));
-    const amountFilterAddons = amountFilterItem
-      ? Array.from(amountFilterItem.querySelectorAll(".ant-input-group-addon")).map((addon) => addon.textContent.trim()).filter(Boolean)
-      : [];
-
     return {
       title: document.title,
       scrollWidth: documentElement.scrollWidth,
@@ -296,8 +291,6 @@ async function collectMetrics(client, state, apiRequestCount) {
       maxRowHeight: rows.length ? Math.max(...rows.map((row) => row.getBoundingClientRect().height)) : null,
       addDrawerOpen: document.body.innerText.includes("New transaction"),
       advancedFilterDrawerOpen: document.body.innerText.includes("Advanced filters"),
-      amountFilterAddons,
-      amountFilterDefaultUsdAddonVisible: amountFilterAddons.includes("USD"),
       rowEditDrawerOpen: document.body.innerText.includes("Edit transaction"),
       loadErrorVisible: document.body.innerText.includes("Failed to load transactions"),
       filterEmptyVisible: document.body.innerText.includes("No transactions match these filters"),
@@ -359,9 +352,9 @@ function buildSummary({ stateResults, requestLog, unhandledApiRequests, failures
     states: stateResults,
     checks: {
       ...buildCommonChecks(stateResults, failures, unhandledApiRequests),
-      advancedFilterDefaultCurrencyClear: stateResults
+      amountFilterRemoved: stateResults
         .filter((state) => state.interaction === "open-filter-drawer")
-        .every((state) => !state.amountFilterDefaultUsdAddonVisible),
+        .every((state) => !state.textSample.includes("Amount equivalent")),
     },
   };
 }


### PR DESCRIPTION
## Summary
- normalize all Transactions URL filters into one shared server-filter state
- use the same state for list/summary RTK Query cache keys and requests
- remove Amount filtering and add adaptive progressive loading with accessible Load more fallback

Closes #291

## Verification
- npm test (134 passed)
- npm run lint
- npm run build
- Transactions visual QA harness attempted but blocked before the fixture route rendered; existing generated evidence was restored

## Review
- Blind Hunter, Edge Case Hunter, and Acceptance Auditor: no high/medium findings
- Remaining risk: fixture visual-QA route startup must be repaired before fresh visual parity evidence can be captured.