### PR TITLE
Protect account summary balances with user-scoped aggregation

### DIFF
--- a/inex.Services/Services/AccountService.cs
+++ b/inex.Services/Services/AccountService.cs
@@ -58,11 +58,11 @@ public class AccountService : InExService, IAccountService
         var monthEnd = monthStart.AddMonths(1);
 
         IQueryable<Account> items = DbInEx.AccountRepository.Get(true, null, i => i.Currency)
-            .Where(i => i.UserId == userId && ids.Contains(i.Id))
+            .Where(i => i.UserId == userId && i.IsEnabled && ids.Contains(i.Id))
             .OrderBy(i => i.Name);
 
         var accountDetails = DbInEx.TransactionRepository.Get(true)
-            .Where(i => ids.Contains(i.AccountId))
+            .Where(i => i.UserId == userId && ids.Contains(i.AccountId))
             .GroupBy(i => i.AccountId)
             .Select(i => new
             {

--- a/inex.Tests/Accounts/AccountsControllerTests.cs
+++ b/inex.Tests/Accounts/AccountsControllerTests.cs
@@ -1,5 +1,9 @@
 using System.Net.Http.Json;
+using inex.Data;
+using inex.Data.Models;
 using inex.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace inex.Tests.Accounts;
 
@@ -35,6 +39,46 @@ public class AccountsControllerTests : IClassFixture<InExWebApplicationFactory>
         var response = await client.GetAsync("/api/accounts?mode=ALL");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DetailsForList_ForeignTransactionOnOwnedAccount_DoesNotAffectBalance()
+    {
+        var userA = await CreateAuthenticatedClientAsync();
+        var userB = await CreateAuthenticatedClientAsync();
+        int accountId = await CreateAccountAsync(userA, "balance-owner-account");
+        int inactiveAccountId = await CreateAccountAsync(userA, "balance-inactive-account", isEnabled: false);
+        int foreignCategoryId = await CreateCategoryAsync(userB, "balance-foreign-category");
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<InExDbContext>();
+            var ownedAccount = await db.Accounts.SingleAsync(account => account.Id == accountId);
+            var foreignCategory = await db.Categories.SingleAsync(category => category.Id == foreignCategoryId);
+            var now = DateTime.UtcNow;
+
+            db.Transactions.Add(new Transaction
+            {
+                AccountId = ownedAccount.Id,
+                CategoryId = foreignCategory.Id,
+                UserId = foreignCategory.UserId,
+                Value = 125m,
+                Created = now,
+                Updated = now,
+                CreatedBy = foreignCategory.UserId,
+                UpdatedBy = foreignCategory.UserId,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var response = await userA.GetAsync($"/api/accounts/details?mode=active&ids[0]={accountId}&ids[1]={inactiveAccountId}");
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var summary = Assert.Single(body.GetProperty("data").EnumerateArray());
+        Assert.Equal(accountId, summary.GetProperty("id").GetInt32());
+        Assert.Equal(0m, summary.GetProperty("value").GetDecimal());
+        Assert.Equal(0m, summary.GetProperty("thisMonthNet").GetDecimal());
     }
 
     // ── POST /api/accounts ────────────────────────────────────────────────────
@@ -197,18 +241,33 @@ public class AccountsControllerTests : IClassFixture<InExWebApplicationFactory>
             email: $"{Guid.NewGuid()}@example.com",
             username: $"user-{Guid.NewGuid():N}");
 
-    private static async Task<int> CreateAccountAsync(HttpClient client, string key)
+    private static async Task<int> CreateAccountAsync(HttpClient client, string key, bool isEnabled = true)
     {
         var createResponse = await client.PostAsJsonAsync("/api/accounts", new
         {
             key,
             name       = key,
             currencyId = 1,
-            isEnabled  = true,
+            isEnabled,
         });
         createResponse.EnsureSuccessStatusCode();
 
         var body = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("id").GetInt32();
+    }
+
+    private static async Task<int> CreateCategoryAsync(HttpClient client, string key)
+    {
+        var response = await client.PostAsJsonAsync("/api/categories", new
+        {
+            key,
+            name = key,
+            isEnabled = true,
+            isSystem = false,
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         return body.GetProperty("id").GetInt32();
     }
 }


### PR DESCRIPTION
## Summary
- Scope account-summary accounts and transaction aggregates to the authenticated user.
- Exclude inactive accounts from the active summary endpoint.
- Add a regression test proving a foreign-user transaction cannot influence an owned account balance.

Closes #294

## Verification
- `dotnet test inex.Services.Tests/` — 91 passed
- `dotnet test` — 212 passed
- MySQL read-only schema check confirmed the transaction aggregate columns: `account_fk`, `user_fk`.

## Review
- High-risk Blind Hunter, Edge Case Hunter, and Acceptance Auditor passes completed with no remaining findings.

## Risk
- No API route or response-contract changes. Transaction mutation cache invalidation remains unchanged.