### PR TITLE
Show native balances in transaction drawers

### DIFF
--- a/inex/ClientApp/public/locales/en/translation.json
+++ b/inex/ClientApp/public/locales/en/translation.json
@@ -225,6 +225,7 @@
     "accountBalancesLoading": "Loading account balances",
     "accountBalancesEmpty": "No active accounts to display.",
     "accountBalancesError": "Could not load account balances.",
+    "nativeBalance": "Native balance",
     "filtersActive": "Filters active",
     "status": "Status",
     "amount": "Amount",

--- a/inex/ClientApp/public/locales/ru/translation.json
+++ b/inex/ClientApp/public/locales/ru/translation.json
@@ -225,6 +225,7 @@
     "accountBalancesLoading": "Загружаем балансы счетов",
     "accountBalancesEmpty": "Нет активных счетов для отображения.",
     "accountBalancesError": "Не удалось загрузить балансы счетов.",
+    "nativeBalance": "Исходный баланс",
     "filtersActive": "Фильтры применены",
     "status": "Статус",
     "amount": "Сумма",

--- a/inex/ClientApp/src/pages/Transactions.tsx
+++ b/inex/ClientApp/src/pages/Transactions.tsx
@@ -110,6 +110,7 @@ const Transactions = () => {
     const cachedRatesCompletedKey = useAppSelector(state => state.rates.cached?.completedKey ?? null);
 
     const [addDrawerOpen, setAddDrawerOpen] = useState(false);
+    const [editDrawerOpen, setEditDrawerOpen] = useState(false);
     const [accountBalancesOpen, setAccountBalancesOpen] = useState(false);
     const [filterDrawerOpen, setFilterDrawerOpen] = useState(filterParam !== null);
     const [createMode, setCreateMode] = useState<TransactionType>(TransactionType.EXPENSE);
@@ -126,7 +127,7 @@ const Transactions = () => {
     );
     const activeAccountIds = useMemo(() => activeAccounts.map(account => account.id), [activeAccounts]);
     const accountBalancesQuery = useGetAccountsSummaryQuery(activeAccountIds, {
-        skip: !accountBalancesOpen || activeAccountIds.length === 0,
+        skip: !(accountBalancesOpen || addDrawerOpen || editDrawerOpen) || activeAccountIds.length === 0,
     });
     const accountBalances = accountBalancesQuery.currentData ?? accountBalancesQuery.data ?? [];
     const accountBalancesLoading = accountBalancesOpen && (
@@ -440,15 +441,23 @@ const Transactions = () => {
         },
     ];
 
+    const openAddDrawer = () => {
+        dispatch(transactionsActions.setError({ error: null }));
+        setCreateMode(TransactionType.EXPENSE);
+        setAddDrawerOpen(true);
+    };
+
+    const closeAddDrawer = () => {
+        dispatch(transactionsActions.setError({ error: null }));
+        setAddDrawerOpen(false);
+    };
+
     const headerActions = (
         <div className="transactions-header-actions">
             <InExButton
                 icon={<Plus size={16} />}
                 kind="primary"
-                onClick={() => {
-                    setCreateMode(TransactionType.EXPENSE);
-                    setAddDrawerOpen(true);
-                }}
+                onClick={openAddDrawer}
                 size="md"
             >
                 {t("transactions.addTransaction")}
@@ -580,12 +589,14 @@ const Transactions = () => {
 
                         <TransactionList
                             accounts={allAccounts}
+                            accountSummaries={accountBalances}
                             categories={allCategories}
                             exchangeRates={exchangeRates}
                             filter={canonicalFilter}
-                            onAddTransaction={() => setAddDrawerOpen(true)}
+                            onAddTransaction={openAddDrawer}
                             onClearFilters={clearAllFilters}
                             onInitialLoadingChange={setLedgerInitialLoading}
+                            onEditDrawerOpenChange={setEditDrawerOpen}
                             onVisibleCountChange={setLedgerVisibleCount}
                             periodLabel={periodLabel}
                         />
@@ -603,7 +614,7 @@ const Transactions = () => {
             </BasicPage>
 
             <InExDrawer
-                onClose={() => setAddDrawerOpen(false)}
+                onClose={closeAddDrawer}
                 open={addDrawerOpen}
                 subtitle={addDrawerSubtitle}
                 title={t("transactions.addDrawerTitle")}
@@ -612,10 +623,19 @@ const Transactions = () => {
                 {addDrawerOpen && (
                     <TransactionCreate
                         accounts={activeAccounts}
+                        accountSummaries={accountBalances}
                         categories={activeCategories}
-                        onCancel={() => setAddDrawerOpen(false)}
+                        onCancel={closeAddDrawer}
                         onModeChange={setCreateMode}
-                        onSubmit={() => setAddDrawerOpen(false)}
+                        onSubmit={closeAddDrawer}
+                    />
+                )}
+                {formError && (
+                    <Alert
+                        className="transactions-form-error"
+                        message={formError}
+                        showIcon
+                        type="error"
                     />
                 )}
             </InExDrawer>

--- a/inex/ClientApp/src/pages/Transactions/SelectedAccountNativeBalance.tsx
+++ b/inex/ClientApp/src/pages/Transactions/SelectedAccountNativeBalance.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { Num } from "../../components/primitives";
+import type { AccountSummary } from "../../store/accounts/accounts-api";
+
+interface SelectedAccountNativeBalanceProps {
+    accountId: number;
+    summaries: AccountSummary[];
+}
+
+const SelectedAccountNativeBalance: React.FC<SelectedAccountNativeBalanceProps> = ({ accountId, summaries }) => {
+    const { t } = useTranslation();
+    const summary = summaries.find((candidate) => candidate.id === accountId);
+
+    if (!summary) return null;
+
+    return (
+        <div className="transactions-selected-account-balance" data-qa="selected-account-native-balance" data-testid="selected-account-native-balance">
+            <span>{t("transactions.nativeBalance")}</span>
+            <Num currency={summary.currency} kind="neutral" signage="signed" value={summary.value} />
+        </div>
+    );
+};
+
+export default SelectedAccountNativeBalance;

--- a/inex/ClientApp/src/pages/Transactions/TransactionCreate.test.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionCreate.test.tsx
@@ -112,6 +112,7 @@ const renderCreateForm = () =>
     render(
         <TransactionCreate
             accounts={accounts}
+            accountSummaries={[]}
             categories={categories}
             onCancel={() => undefined}
             onSubmit={() => undefined}

--- a/inex/ClientApp/src/pages/Transactions/TransactionCreate.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionCreate.tsx
@@ -9,11 +9,12 @@ import { AccountDetails } from "../../model/Account/AccountDetails";
 import { CategoryDetails, createCategoryDetails, getCategoriesTree } from "../../model/Category/CategoryDetails";
 import { TransactionSetState } from "../../model/Transaction/TransactionSetState";
 import { TransactionType } from "../../model/Transaction/TransactionType";
-import type { AccountResponse } from "../../store/accounts/accounts-api";
+import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
 import type { CategoryResponse } from "../../store/categories/categories-api";
 import { transactionsActions } from "../../store/transactions/transactions-slice";
 import { useCreateTransactionMutation, useCreateTransferMutation } from "../../store/transactions/transactions-api";
 import { useAppDispatch } from "../../store/hooks";
+import { parseAxiosError } from "../../utils/parseAxiosError";
 import TransactionCreateExpenseForm from "./TransactionCreateExpenseForm";
 import TransactionCreateIncomeForm from "./TransactionCreateIncomeForm";
 import TransactionCreateTransferForm from "./TransactionCreateTransferForm";
@@ -22,6 +23,7 @@ type DropdownSelectInfo = Parameters<NonNullable<MenuProps["onSelect"]>>[0];
 
 interface TransactionCreateProps {
     accounts: AccountResponse[];
+    accountSummaries: AccountSummary[];
     categories: CategoryResponse[];
     onCancel: () => void;
     onModeChange?: (mode: TransactionType) => void;
@@ -115,6 +117,7 @@ const isSelectedEntity = (id: number | undefined): boolean => typeof id === "num
 
 const TransactionCreate: React.FC<TransactionCreateProps> = ({
     accounts,
+    accountSummaries,
     categories,
     onCancel,
     onModeChange,
@@ -268,11 +271,15 @@ const TransactionCreate: React.FC<TransactionCreateProps> = ({
                     created,
                 }).unwrap();
             }
-        } catch {
+        } catch (error) {
             dispatch(transactionsActions.setError({
-                error: state.mode === TransactionType.TRANSFER
-                    ? t("transactions.formErrors.transferFailure")
-                    : t("transactions.formErrors.createFailure"),
+                error: parseAxiosError(
+                    error,
+                    state.mode === TransactionType.TRANSFER
+                        ? t("transactions.formErrors.transferFailure")
+                        : t("transactions.formErrors.createFailure"),
+                    t,
+                ),
             }));
             return;
         }
@@ -303,6 +310,7 @@ const TransactionCreate: React.FC<TransactionCreateProps> = ({
             {state.mode === TransactionType.EXPENSE && (
                 <TransactionCreateExpenseForm
                     accounts={accounts}
+                    accountSummaries={accountSummaries}
                     category={state.category}
                     categories={categoryTree}
                     comment={state.comment}
@@ -321,6 +329,7 @@ const TransactionCreate: React.FC<TransactionCreateProps> = ({
             {state.mode === TransactionType.INCOME && (
                 <TransactionCreateIncomeForm
                     accounts={accounts}
+                    accountSummaries={accountSummaries}
                     category={state.category}
                     categories={categoryTree}
                     comment={state.comment}

--- a/inex/ClientApp/src/pages/Transactions/TransactionCreateExpenseForm.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionCreateExpenseForm.tsx
@@ -8,13 +8,15 @@ import Dropdown from "../../components/Dropdown";
 import ExpressionInputNumber from "../../components/ExpressionInputNumber";
 import type { AccountDetails } from "../../model/Account/AccountDetails";
 import type { CategoryDetails } from "../../model/Category/CategoryDetails";
-import type { AccountResponse } from "../../store/accounts/accounts-api";
+import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
 import type { TransactionCreateValidationErrors } from "./TransactionCreate";
+import SelectedAccountNativeBalance from "./SelectedAccountNativeBalance";
 
 type DropdownSelectInfo = Parameters<NonNullable<MenuProps["onSelect"]>>[0];
 
 interface TransactionCreateExpenseFormProps {
     accounts: AccountResponse[];
+    accountSummaries: AccountSummary[];
     categories: CategoryDetails[];
     category: CategoryDetails;
     comment: string;
@@ -40,6 +42,7 @@ const getSelectedCategory = (category: CategoryDetails): CategoryDetails[] =>
 
 const TransactionCreateExpenseForm: React.FC<TransactionCreateExpenseFormProps> = ({
     accounts,
+    accountSummaries,
     categories,
     category,
     comment,
@@ -61,6 +64,7 @@ const TransactionCreateExpenseForm: React.FC<TransactionCreateExpenseFormProps> 
             <Form.Item
                 help={validationErrors.fromAccount}
                 label={t("transactions.account")}
+                extra={<SelectedAccountNativeBalance accountId={fromAccount.id} summaries={accountSummaries} />}
                 validateStatus={validationErrors.fromAccount ? "error" : undefined}
             >
                 <Dropdown
@@ -70,6 +74,20 @@ const TransactionCreateExpenseForm: React.FC<TransactionCreateExpenseFormProps> 
                     onChange={onSetFromAccount}
                     placeholder={t("transactions.selectAccount")}
                     selection={getSelectedAccount(fromAccount)}
+                />
+            </Form.Item>
+            <Form.Item
+                help={validationErrors.category}
+                label={t("transactions.category")}
+                validateStatus={validationErrors.category ? "error" : undefined}
+            >
+                <Dropdown
+                    id="expense_category"
+                    items={categories}
+                    multiple={false}
+                    onChange={onSetCategory}
+                    placeholder={t("transactions.selectCategory")}
+                    selection={getSelectedCategory(category)}
                 />
             </Form.Item>
             <Form.Item
@@ -85,20 +103,6 @@ const TransactionCreateExpenseForm: React.FC<TransactionCreateExpenseFormProps> 
                     precision={2}
                     size="large"
                     value={fromAmount}
-                />
-            </Form.Item>
-            <Form.Item
-                help={validationErrors.category}
-                label={t("transactions.category")}
-                validateStatus={validationErrors.category ? "error" : undefined}
-            >
-                <Dropdown
-                    id="expense_category"
-                    items={categories}
-                    multiple={false}
-                    onChange={onSetCategory}
-                    placeholder={t("transactions.selectCategory")}
-                    selection={getSelectedCategory(category)}
                 />
             </Form.Item>
             <Form.Item

--- a/inex/ClientApp/src/pages/Transactions/TransactionCreateForms.test.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionCreateForms.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AccountDetails } from "../../model/Account/AccountDetails";
 import type { CategoryDetails } from "../../model/Category/CategoryDetails";
-import type { AccountResponse } from "../../store/accounts/accounts-api";
+import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
 import TransactionCreateExpenseForm from "./TransactionCreateExpenseForm";
 import TransactionCreateIncomeForm from "./TransactionCreateIncomeForm";
 import TransactionCreateTransferForm from "./TransactionCreateTransferForm";
@@ -19,6 +19,7 @@ vi.mock("react-i18next", () => ({
             "transactions.comment": "Comment",
             "transactions.commentPlaceholder": "Comment with optional #tag or @reference",
             "transactions.date": "Date",
+            "transactions.nativeBalance": "Native balance",
             "transactions.selectAccount": "Select account",
             "transactions.selectCategory": "Select category",
             "transactions.transferFrom": "Transfer from",
@@ -37,6 +38,10 @@ const accounts: AccountResponse[] = [
         currencyId: 1,
         currency: "PLN",
     },
+];
+
+const accountSummaries: AccountSummary[] = [
+    { ...accounts[0], value: 253.2, thisMonthNet: 0 },
 ];
 
 const categories: CategoryDetails[] = [
@@ -90,10 +95,11 @@ describe("Transaction create mode forms", () => {
         });
     });
 
-    it("renders expense account before amount without a default currency or separate tags field", () => {
+    it("renders expense account before category and amount without a default currency or separate tags field", () => {
         const { container } = render(
             <TransactionCreateExpenseForm
                 accounts={accounts}
+                accountSummaries={accountSummaries}
                 categories={categories}
                 category={unselectedCategory}
                 comment=""
@@ -110,16 +116,18 @@ describe("Transaction create mode forms", () => {
         );
 
         const text = container.textContent ?? "";
-        expect(text.indexOf("Account")).toBeLessThan(text.indexOf("Amount"));
+        expect(text.indexOf("Account")).toBeLessThan(text.indexOf("Category"));
+        expect(text.indexOf("Category")).toBeLessThan(text.indexOf("Amount"));
         expect(screen.getByText("Select account")).toBeInTheDocument();
         expect(screen.queryByText("Tags")).not.toBeInTheDocument();
         expect(screen.queryByText("USD")).not.toBeInTheDocument();
     });
 
-    it("renders income account before amount without a default currency or separate tags field", () => {
+    it("renders income account before category and amount without a default currency or separate tags field", () => {
         const { container } = render(
             <TransactionCreateIncomeForm
                 accounts={accounts}
+                accountSummaries={accountSummaries}
                 categories={categories}
                 category={unselectedCategory}
                 comment=""
@@ -136,10 +144,38 @@ describe("Transaction create mode forms", () => {
         );
 
         const text = container.textContent ?? "";
-        expect(text.indexOf("Account")).toBeLessThan(text.indexOf("Amount"));
+        expect(text.indexOf("Account")).toBeLessThan(text.indexOf("Category"));
+        expect(text.indexOf("Category")).toBeLessThan(text.indexOf("Amount"));
         expect(screen.getByText("Select account")).toBeInTheDocument();
         expect(screen.queryByText("Tags")).not.toBeInTheDocument();
         expect(screen.queryByText("USD")).not.toBeInTheDocument();
+    });
+
+    it("shows the selected account's native balance without a live region", () => {
+        render(
+            <TransactionCreateExpenseForm
+                accounts={accounts}
+                accountSummaries={accountSummaries}
+                categories={categories}
+                category={unselectedCategory}
+                comment=""
+                date={null}
+                fromAccount={{ ...unselectedAccount, ...accounts[0], description: accounts[0].description ?? "" }}
+                fromAmount={0}
+                onSetCategory={noop}
+                onSetComment={noop}
+                onSetDate={noop}
+                onSetFromAccount={noop}
+                onSetFromAmount={noop}
+                validationErrors={{}}
+            />,
+        );
+
+        const balance = screen.getByTestId("selected-account-native-balance");
+        expect(balance).toHaveTextContent("Native balance");
+        expect(balance).toHaveTextContent("253.2");
+        expect(balance).not.toHaveAttribute("role", "status");
+        expect(balance).not.toHaveAttribute("aria-live");
     });
 
     it("renders each transfer account before its related amount without default currency suffixes", () => {

--- a/inex/ClientApp/src/pages/Transactions/TransactionCreateIncomeForm.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionCreateIncomeForm.tsx
@@ -8,13 +8,15 @@ import Dropdown from "../../components/Dropdown";
 import ExpressionInputNumber from "../../components/ExpressionInputNumber";
 import type { AccountDetails } from "../../model/Account/AccountDetails";
 import type { CategoryDetails } from "../../model/Category/CategoryDetails";
-import type { AccountResponse } from "../../store/accounts/accounts-api";
+import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
 import type { TransactionCreateValidationErrors } from "./TransactionCreate";
+import SelectedAccountNativeBalance from "./SelectedAccountNativeBalance";
 
 type DropdownSelectInfo = Parameters<NonNullable<MenuProps["onSelect"]>>[0];
 
 interface TransactionCreateIncomeFormProps {
     accounts: AccountResponse[];
+    accountSummaries: AccountSummary[];
     categories: CategoryDetails[];
     category: CategoryDetails;
     comment: string;
@@ -40,6 +42,7 @@ const getSelectedCategory = (category: CategoryDetails): CategoryDetails[] =>
 
 const TransactionCreateIncomeForm: React.FC<TransactionCreateIncomeFormProps> = ({
     accounts,
+    accountSummaries,
     categories,
     category,
     comment,
@@ -61,6 +64,7 @@ const TransactionCreateIncomeForm: React.FC<TransactionCreateIncomeFormProps> = 
             <Form.Item
                 help={validationErrors.toAccount}
                 label={t("transactions.account")}
+                extra={<SelectedAccountNativeBalance accountId={toAccount.id} summaries={accountSummaries} />}
                 validateStatus={validationErrors.toAccount ? "error" : undefined}
             >
                 <Dropdown
@@ -70,6 +74,20 @@ const TransactionCreateIncomeForm: React.FC<TransactionCreateIncomeFormProps> = 
                     onChange={onSetToAccount}
                     placeholder={t("transactions.selectAccount")}
                     selection={getSelectedAccount(toAccount)}
+                />
+            </Form.Item>
+            <Form.Item
+                help={validationErrors.category}
+                label={t("transactions.category")}
+                validateStatus={validationErrors.category ? "error" : undefined}
+            >
+                <Dropdown
+                    id="income_category"
+                    items={categories}
+                    multiple={false}
+                    onChange={onSetCategory}
+                    placeholder={t("transactions.selectCategory")}
+                    selection={getSelectedCategory(category)}
                 />
             </Form.Item>
             <Form.Item
@@ -85,20 +103,6 @@ const TransactionCreateIncomeForm: React.FC<TransactionCreateIncomeFormProps> = 
                     precision={2}
                     size="large"
                     value={toAmount}
-                />
-            </Form.Item>
-            <Form.Item
-                help={validationErrors.category}
-                label={t("transactions.category")}
-                validateStatus={validationErrors.category ? "error" : undefined}
-            >
-                <Dropdown
-                    id="income_category"
-                    items={categories}
-                    multiple={false}
-                    onChange={onSetCategory}
-                    placeholder={t("transactions.selectCategory")}
-                    selection={getSelectedCategory(category)}
                 />
             </Form.Item>
             <Form.Item

--- a/inex/ClientApp/src/pages/Transactions/TransactionEditForm.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionEditForm.tsx
@@ -17,6 +17,8 @@ import Dropdown from "../../components/Dropdown";
 import ExpressionInputNumber from "../../components/ExpressionInputNumber";
 import { transactionsActions } from "../../store/transactions/transactions-slice";
 import { useDeleteTransactionMutation, useUpdateTransactionMutation } from "../../store/transactions/transactions-api";
+import { parseAxiosError } from "../../utils/parseAxiosError";
+import SelectedAccountNativeBalance from "./SelectedAccountNativeBalance";
 
 
 const defaultState: TransactionEditState = new TransactionEditState();
@@ -117,8 +119,9 @@ const TransactionEditForm = (props: any) => {
           created: state.date.format("YYYY-MM-DD"),
         }).unwrap();
         dispatch(transactionsActions.setError({ error: null }));
-      } catch {
-        dispatch(transactionsActions.setError({ error: t("transactions.formErrors.updateFailure") }));
+        props.onSaved();
+      } catch (error) {
+        dispatch(transactionsActions.setError({ error: parseAxiosError(error, t("transactions.formErrors.updateFailure"), t) }));
       }
     };
 
@@ -135,7 +138,10 @@ const TransactionEditForm = (props: any) => {
         <Form layout="vertical" hideRequiredMark>
             <Row gutter={8}>
                 <Col xs={24} sm={12}>
-                    <Form.Item label={t("transactions.account")}>
+                    <Form.Item
+                        extra={<SelectedAccountNativeBalance accountId={state.account.id} summaries={props.accountSummaries} />}
+                        label={t("transactions.account")}
+                    >
                         <Dropdown id="account" selection={[state.account]} onChange={setAccountHandler} items={props.accounts} multiple={false} />
                     </Form.Item>
                 </Col>

--- a/inex/ClientApp/src/pages/Transactions/TransactionList.tsx
+++ b/inex/ClientApp/src/pages/Transactions/TransactionList.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Alert, Pagination } from "antd";
 import { Inbox, Plus, RotateCw } from "lucide-react";
 
-import type { AccountResponse } from "../../store/accounts/accounts-api";
+import type { AccountResponse, AccountSummary } from "../../store/accounts/accounts-api";
 import type { CategoryResponse } from "../../store/categories/categories-api";
 import { useAppSelector } from "../../store/hooks";
 import type { TransactionResponse } from "../../model/Transaction/TransactionResponse";
@@ -27,12 +27,14 @@ import {
 
 interface TransactionListProps {
     accounts: AccountResponse[];
+    accountSummaries: AccountSummary[];
     categories: CategoryResponse[];
     exchangeRates: ExchangeRateLike[];
     filter: NormalizedTransactionFilter;
     onAddTransaction: () => void;
     onClearFilters: () => void;
     onInitialLoadingChange: (loading: boolean) => void;
+    onEditDrawerOpenChange: (open: boolean) => void;
     onVisibleCountChange: (count: number) => void;
     periodLabel: string;
 }
@@ -60,7 +62,7 @@ const groupTransactions = (transactions: TransactionResponse[], dayLabels: { tod
     return Array.from(groups.values()).sort((left, right) => right.dateKey.localeCompare(left.dateKey));
 };
 
-const TransactionList = ({ accounts, categories, exchangeRates, filter, onAddTransaction, onClearFilters, onInitialLoadingChange, onVisibleCountChange, periodLabel }: TransactionListProps) => {
+const TransactionList = ({ accounts, accountSummaries, categories, exchangeRates, filter, onAddTransaction, onClearFilters, onInitialLoadingChange, onEditDrawerOpenChange, onVisibleCountChange, periodLabel }: TransactionListProps) => {
     const { t } = useTranslation();
     const formError = useAppSelector(state => state.transactions.error);
     const [pagination, setPagination] = useState({ current: 1, size: 20 });
@@ -179,7 +181,10 @@ const TransactionList = ({ accounts, categories, exchangeRates, filter, onAddTra
                 const title = cleanComment || (kind === "transfer" ? t("transactions.transfer") : category?.name) || t("transactions.uncategorized");
                 const currency = account?.currency ?? transaction.accountCurrency;
                 const baseEquivalent = getBaseCurrencyEquivalent(transaction.amount, currency, exchangeRates);
-                const openEdit = () => setEditRecord(transaction);
+                const openEdit = () => {
+                    onEditDrawerOpenChange(true);
+                    setEditRecord(transaction);
+                };
                 return <div className={`transactions-ledger-row transactions-ledger-row--${kind}`} key={transaction.id} onClick={openEdit} onKeyDown={(event) => {
                     if (event.key === "Enter" || event.key === " ") { event.preventDefault(); openEdit(); }
                 }} role="button" tabIndex={0}>
@@ -190,7 +195,7 @@ const TransactionList = ({ accounts, categories, exchangeRates, filter, onAddTra
             })}
         </section>)}
         <div className="transactions-pagination"><div>{t("transactions.paginationSummary", { visible: transactions.length, total, period: periodLabel })}</div>{navigationMode === "progressive" ? <div ref={loadMoreSentinel}><InExButton disabled={!hasNextPage || query.isFetching} kind="default" onClick={loadMore}>{query.isFetching ? t("transactions.loading.refreshing") : t("transactions.loadMore")}</InExButton></div> : <Pagination current={pagination.current} onChange={paginationChangedHandler} pageSize={pagination.size} pageSizeOptions={[20, 50, 100]} showSizeChanger total={total} />}</div>
-        <InExDrawer onClose={() => setEditRecord(null)} open={editRecord !== null} subtitle={t("transactions.editDrawerSubtitle")} title={t("transactions.editDrawerTitle")} width={460}>{editRecord ? <><TransactionEditForm accounts={accounts} categories={categories} record={editRecord} />{formError && <Alert className="transactions-form-error" message={formError} showIcon type="error" />}</> : <div className="transactions-empty-drawer"><Inbox size={20} /></div>}</InExDrawer>
+        <InExDrawer onClose={() => { onEditDrawerOpenChange(false); setEditRecord(null); }} open={editRecord !== null} subtitle={t("transactions.editDrawerSubtitle")} title={t("transactions.editDrawerTitle")} width={460}>{editRecord ? <><TransactionEditForm accountSummaries={accountSummaries} accounts={accounts} categories={categories} onSaved={() => { onEditDrawerOpenChange(false); setEditRecord(null); }} record={editRecord} />{formError && <Alert className="transactions-form-error" message={formError} showIcon type="error" />}</> : <div className="transactions-empty-drawer"><Inbox size={20} /></div>}</InExDrawer>
     </>;
 };
 

--- a/inex/ClientApp/src/pages/Transactions/transactions-ledger.css
+++ b/inex/ClientApp/src/pages/Transactions/transactions-ledger.css
@@ -613,6 +613,37 @@
     padding-top: 4px;
 }
 
+.transactions-selected-account-balance {
+    align-items: baseline;
+    color: var(--fg-3);
+    display: flex;
+    font-size: 13px;
+    gap: 8px;
+    justify-content: space-between;
+    min-width: 0;
+    padding-top: 2px;
+}
+
+.transactions-selected-account-balance > span {
+    min-width: 0;
+}
+
+.transactions-selected-account-balance .inex-num {
+    color: var(--fg-2);
+    flex: 0 0 auto;
+}
+
+.transactions-create-form .ant-menu-submenu-title {
+    min-width: 0;
+    white-space: normal;
+}
+
+.transactions-create-form .ant-menu-title-content {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
 .transactions-empty-drawer {
     align-items: center;
     color: var(--fg-4);

--- a/inex/ClientApp/src/utils/parseAxiosError.test.ts
+++ b/inex/ClientApp/src/utils/parseAxiosError.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAxiosError } from "./parseAxiosError";
+
+const t = (key: string): string => ({
+    "errors.amount.not_zero": "Amount cannot be zero",
+}[key] ?? key);
+
+describe("parseAxiosError", () => {
+    it("translates ProblemDetails validation errors returned by RTK Query", () => {
+        expect(parseAxiosError(
+            { status: 422, data: { errors: { amount: ["amount.not_zero"] } } },
+            "Could not save transaction",
+            t,
+        )).toBe("Amount cannot be zero");
+    });
+
+    it("uses the fallback when an RTK Query error has no ProblemDetails payload", () => {
+        expect(parseAxiosError({ status: 500, data: "unexpected" }, "Could not save transaction", t))
+            .toBe("Could not save transaction");
+    });
+});

--- a/inex/ClientApp/src/utils/parseAxiosError.ts
+++ b/inex/ClientApp/src/utils/parseAxiosError.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
 
+const isProblemDetails = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
 /**
  * Extracts a human-readable message from an AxiosError response.
  * Handles RFC 7807 ProblemDetails format (the same shape as parseApiError,
@@ -13,8 +16,13 @@ export function parseAxiosError(
   defaultMessage: string,
   t?: (key: string) => string
 ): string {
-  if (axios.isAxiosError(error) && error.response?.data) {
-    const problem = error.response.data as Record<string, unknown>;
+  const problem = axios.isAxiosError(error)
+    ? error.response?.data
+    : isProblemDetails(error)
+      ? error.data
+      : undefined;
+
+  if (isProblemDetails(problem)) {
     // 422 ValidationProblemDetails — flatten and optionally translate field errors
     if (problem.errors && typeof problem.errors === "object") {
       const translate = (code: string) => {

--- a/inex/ClientApp/visual-qa/transactions.mjs
+++ b/inex/ClientApp/visual-qa/transactions.mjs
@@ -160,6 +160,14 @@ const states = [
     scenario: "populated",
     interaction: "open-add-drawer",
   },
+  ...visualQaViewports.map(({ suffix, viewport }) => ({
+    name: `selected-account-balance-create-${suffix}`,
+    screenshot: `selected-account-balance-create-${suffix}.png`,
+    viewport,
+    scenario: "populated",
+    interaction: "open-add-drawer-and-select-account",
+    screenshotMode: "viewport",
+  })),
   {
     name: "filter-drawer-open-390",
     screenshot: "filter-drawer-open-390.png",
@@ -224,6 +232,13 @@ const states = [
     scenario: "populated",
     interaction: "open-row-edit",
   },
+  ...visualQaViewports.filter(({ suffix }) => suffix === "1024" || suffix === "360").map(({ suffix, viewport }) => ({
+    name: `expanded-row-${suffix}`,
+    screenshot: `expanded-row-${suffix}.png`,
+    viewport,
+    scenario: "populated",
+    interaction: "open-row-edit",
+  })),
   {
     name: "load-error-390",
     screenshot: "load-error-390.png",
@@ -390,6 +405,24 @@ async function applyInteraction(client, state) {
       await evaluate(client, clickButtonByTextExpression("Add transaction"));
       await waitFor(client, "Boolean(document.querySelector('.ant-drawer-open')) && document.body.innerText.includes('New transaction')");
       return;
+    case "open-add-drawer-and-select-account":
+      await evaluate(client, clickButtonByTextExpression("Add transaction"));
+      await waitFor(client, "Boolean(document.querySelector('.ant-drawer-open')) && document.body.innerText.includes('New transaction')");
+      await evaluate(client, `(() => {
+        const trigger = Array.from(document.querySelectorAll(".ant-menu-submenu-title")).find((item) => item.textContent?.includes("Select account"));
+        if (!trigger) return false;
+        trigger.click();
+        return true;
+      })()`);
+      await waitFor(client, "Array.from(document.querySelectorAll('.ant-menu-item')).some((item) => item.textContent?.includes('Emergency reserve for long-term household commitments'))");
+      await evaluate(client, `(() => {
+        const account = Array.from(document.querySelectorAll(".ant-menu-item")).find((item) => item.textContent?.includes("Emergency reserve for long-term household commitments"));
+        if (!account) return false;
+        account.click();
+        return true;
+      })()`);
+      await waitFor(client, "document.body.innerText.includes('Native balance') && Boolean(document.querySelector('[data-qa=selected-account-native-balance]'))");
+      return;
     case "open-filter-drawer":
       await evaluate(client, clickButtonByTextExpression("Filters"));
       await waitFor(client, "Boolean(document.querySelector('.ant-drawer-open')) && document.body.innerText.includes('Advanced filters')");
@@ -419,7 +452,7 @@ async function applyInteraction(client, state) {
         row.click();
         return true;
       })()`);
-      await waitFor(client, "Boolean(document.querySelector('.ant-drawer-open')) && document.body.innerText.includes('Edit transaction')");
+      await waitFor(client, "Boolean(document.querySelector('.ant-drawer-open')) && document.body.innerText.includes('Edit transaction') && Boolean(document.querySelector('[data-qa=selected-account-native-balance]'))");
       return;
     case "load-more-pending":
       await evaluate(client, clickButtonByTextExpression("Load more"));
@@ -618,6 +651,14 @@ function buildSummary({ stateResults, requestLog, unhandledApiRequests, failures
 }
 
 const fixtureExports = loadFixture(fixturePath, `Transactions fixture is missing: ${fixturePath}`);
+const stateFilter = process.env.INEX_VISUAL_QA_STATE_FILTER;
+const configuredStates = stateFilter
+  ? states.filter((state) => state.name.startsWith(stateFilter))
+  : states;
+
+if (configuredStates.length === 0) {
+  throw new Error(`No Transactions visual-QA states match "${stateFilter}".`);
+}
 
 export const visualQaConfig = {
   clientRoot,
@@ -625,7 +666,7 @@ export const visualQaConfig = {
   outputDir,
   defaultPort: 5199,
   fixture: fixtureExports,
-  states,
+  states: configuredStates,
   createApiHandler,
   runState,
   buildSummary,


### PR DESCRIPTION
## Summary
- show the selected active account’s native-currency balance in create and edit transaction drawers
- order Expense and Income forms as Account, Category, Amount, Date, Comment
- keep long account labels within mobile drawers and add focused visual-QA states
- preserve inputs on failed submissions and surface localized RFC 7807 validation details

Closes #296

## Verification
- `npm test -- --run src/utils/parseAxiosError.test.ts src/pages/Transactions/TransactionCreateForms.test.tsx src/pages/Transactions/TransactionCreate.test.tsx`
- `npm run lint`
- `npm run build`
- focused fixture visual QA at 1440px, 1024px, 390px, and 360px (no overflow or bottom-nav occlusion; no real backend or external provider calls)
- full frontend suite: 144/145 passed; the one unrelated Register timeout passed on isolated rerun

## Review
- Acceptance and edge-case review found the RTK Query ProblemDetails handling and create-drawer feedback gaps; both are fixed and covered by parser tests.

## Risks
- The existing full visual-QA suite is broad; this PR ran the focused selected-account drawer states.